### PR TITLE
ドメインモデルの追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,17 +871,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lombok"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7579c52d658ba83087fc527fe53b70cefe11ad8c0ce3ef4fc86e1c6ad1f3df28"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,7 +1209,8 @@ version = "0.1.0"
 dependencies = [
  "actix-rt",
  "actix-web",
- "lombok",
+ "derive_more",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,6 +871,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "lombok"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7579c52d658ba83087fc527fe53b70cefe11ad8c0ce3ef4fc86e1c6ad1f3df28"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1209,6 +1220,7 @@ version = "0.1.0"
 dependencies = [
  "actix-rt",
  "actix-web",
+ "lombok",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2018"
 [dependencies]
 actix-rt = "1.1.0"
 actix-web = "3.3.2"
+lombok = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,5 @@ edition = "2018"
 [dependencies]
 actix-rt = "1.1.0"
 actix-web = "3.3.2"
-lombok = "0.1.0"
+derive_more = "0.99.11"
+thiserror = "1.0.24"

--- a/src/domain/coordinate.rs
+++ b/src/domain/coordinate.rs
@@ -1,0 +1,38 @@
+use lombok::Getters;
+use std::os::raw::c_uint;
+
+/// A Value Class for Coordinates
+#[derive(Clone, Debug, Getters, AllArgsConstructor, PartialEq, Eq)]
+pub struct Coordinate {
+    latitude: Latitude,
+    longitude: Longitude,
+}
+
+#[derive(Clone, Debug, Getters, PartialEq, Eq)]
+pub struct Latitude(f64);
+
+impl FromF64 for Latitude {
+    fn from_f64(val :f64) -> Result<Self, todo!()> {
+        // TODO: エラー処理を書く
+        if val.abs() <= 90.0 {
+            Ok(Latitude(val))
+        } else {
+            todo!()
+        }
+    }
+}
+
+#[derive(Clone, Debug, Getters, PartialEq, Eq)]
+pub struct Longitude(f64);
+
+
+impl FromF64 for Longitude {
+    fn from_f64(val :f64) -> Result<Self, todo!()> {
+        // TODO: エラー処理を書く
+        if val.abs() <= 180.0 {
+            Ok(Longitude(val))
+        } else {
+            todo!()
+        }
+    }
+}

--- a/src/domain/coordinate.rs
+++ b/src/domain/coordinate.rs
@@ -1,38 +1,50 @@
-use lombok::Getters;
-use std::os::raw::c_uint;
+use crate::lib::error::ApplicationError;
 
 /// A Value Class for Coordinates
-#[derive(Clone, Debug, Getters, AllArgsConstructor, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Coordinate {
     latitude: Latitude,
     longitude: Longitude,
 }
 
-#[derive(Clone, Debug, Getters, PartialEq, Eq)]
+impl Coordinate {
+    pub fn create(lat :f64, lon: f64) -> Result<Coordinate, ApplicationError> {
+        let coord = Coordinate{
+            latitude: Latitude::from_f64(lat)?,
+            longitude: Longitude::from_f64(lon)?,
+        };
+        Ok(coord)
+    }
+}
+
+pub trait FromF64<T> {
+    fn from_f64(val :f64) -> Result<T, ApplicationError>;
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct Latitude(f64);
 
-impl FromF64 for Latitude {
-    fn from_f64(val :f64) -> Result<Self, todo!()> {
-        // TODO: エラー処理を書く
+impl FromF64<Latitude> for Latitude {
+    fn from_f64(val :f64) -> Result<Self, ApplicationError> {
         if val.abs() <= 90.0 {
             Ok(Latitude(val))
         } else {
-            todo!()
+            Err(ApplicationError::BadRequest("Absolute value of Latitude must be <= 90"))
         }
     }
 }
 
-#[derive(Clone, Debug, Getters, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Longitude(f64);
 
 
-impl FromF64 for Longitude {
-    fn from_f64(val :f64) -> Result<Self, todo!()> {
+impl FromF64<Longitude> for Longitude {
+    fn from_f64(val :f64) -> Result<Self, ApplicationError> {
         // TODO: エラー処理を書く
         if val.abs() <= 180.0 {
             Ok(Longitude(val))
         } else {
-            todo!()
+            Err(ApplicationError::BadRequest("Absolute value of Longitude must be <= 180"))
         }
     }
 }

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,1 +1,2 @@
-mod coordinate;
+pub mod coordinate;
+pub mod route;

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,0 +1,1 @@
+mod coordinate;

--- a/src/domain/route.rs
+++ b/src/domain/route.rs
@@ -1,0 +1,25 @@
+use std::vec;
+use crate::domain::coordinate::Coordinate;
+
+#[derive(Debug)]
+pub struct Route {
+    name: String,
+    points: Vec<Coordinate>,
+}
+
+impl Route {
+    pub fn new(name: &str) -> Route {
+        Route {
+            name: name.to_string(),
+            points: Vec::new()
+        }
+    }
+
+    pub fn add_point(&mut self, point: Coordinate) {
+        self.points.push(point);
+    }
+
+    pub fn show_points(&self) {
+        println!("{:?}", self.points);
+    }
+}

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -1,0 +1,26 @@
+use actix_web::{ResponseError, http::StatusCode, dev::HttpResponseBuilder, http::header, HttpResponse};
+use derive_more::{Display};
+use thiserror::Error;
+
+#[derive(Debug, Display, Error)]
+pub enum ApplicationError {
+    #[display("Bad Request: {0}")]
+    BadRequest(&'static str),
+
+    #[display("Internal Server Error: {0}")]
+    InternalServerError(&'static str),
+}
+
+impl ResponseError for ApplicationError {
+    fn status_code(&self) -> StatusCode {
+        match *self {
+            ApplicationError::BadRequest(..) => StatusCode::BAD_REQUEST,
+            ApplicationError::InternalServerError(..) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+    fn error_response(&self) -> HttpResponse {
+        HttpResponseBuilder::new(self.status_code())
+            .set_header(header::CONTENT_TYPE, "text/html; charset=utf-8")
+            .body(self.to_string())
+    }
+}

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -1,0 +1,1 @@
+pub mod error;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,26 @@
 mod domain;
+mod lib;
 
-use actix_web::{HttpResponse, get, HttpServer, App};
+use actix_web::{HttpResponse, get, HttpServer, App, Error};
+use crate::domain::coordinate::{Latitude, FromF64, Coordinate};
+use crate::domain::route::Route;
 
 #[get("/")]
-async fn index() -> Result<HttpResponse, actix_web::Error> {
-    let response_body = "Hello World";
+async fn index() -> Result<HttpResponse, Error> {
+    let tokyo_station_coord = Coordinate::create(35.680, 139.767)?;
+    let disney_land_coord = Coordinate::create(35.632, 139.880)?;
+
+    let mut route = Route::new("From Tokyo Station to Disney Land");
+
+    route.add_point(tokyo_station_coord);
+    route.add_point(disney_land_coord);
+
+    let response_body = format!("{:?}", route);
     Ok(HttpResponse::Ok().body(response_body))
 }
 
 #[actix_rt::main]
-async fn main() -> Result<(), actix_web::Error> {
+async fn main() -> Result<(), Error> {
     HttpServer::new(move || App::new().service(index))
         .bind("0.0.0.0:8080")?
         .run()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+mod domain;
+
 use actix_web::{HttpResponse, get, HttpServer, App};
 
 #[get("/")]


### PR DESCRIPTION
## 概要
* `ApplicationError`クラスを追加し、actix-webの機能を使いつつエラーを直接HttpResponseに投げられるようになった(a0e3c8f9a0f267e45d331e4eca554adece0ec5da)
* 緯度と経度を表し、その値の範囲のvalidationを行う構造体`Latitude`と`Longitude`の追加(195928651efdc94cd1c348a9895b68d080295378)
* 緯度と経度を持ち、座標を表す構造体`Coordinate`の追加(66b9ddfaff075c23de67e803182ab67fc4d91cdf)
* 名前と座標のリストとを持つ構造体`Route`の追加(0184c8e0caa5695440d088127897f45298181850)
  * テストとして、`GET http://localhost:8080/`で東京駅からディズニーランドまでの経路を表す`Route`を表示させている

## 参考
* caddiの神記事
  * https://caddi.tech/archives/1373
  * https://caddi.tech/archives/2021
* RustでのDDDのサンプル
  * https://github.com/kuwana-kb/ddd-in-rust
  * https://github.com/jdomenechb/rust-ddd-example
* [Rust版lombok](https://github.com/sokomishalov/lombok-rs)
* [actix-webのエラー処理](https://actix.rs/docs/errors/)