### PR TITLE
Repositoryの追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "autocfg"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +368,17 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "bigdecimal"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1374191e2dd25f9ae02e3aa95041ed5d747fc77b3c102b49fe2dd9a8117a6244"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "bitflags"
@@ -508,9 +530,13 @@ version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "047bfc4d5c3bd2ef6ca6f981941046113524b9a9f9a7cbdfdd7ff40f58e6f542"
 dependencies = [
+ "bigdecimal",
  "byteorder",
  "diesel_derives",
  "mysqlclient-sys",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
  "url 1.7.2",
 ]
 
@@ -571,6 +597,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -812,6 +851,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "615caabe2c3160b313d52ccc905335f4ed5f10881dd63dc5699d47e90be85691"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,6 +1089,36 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -1416,9 +1491,11 @@ version = "0.1.0"
 dependencies = [
  "actix-rt",
  "actix-web",
+ "bigdecimal",
  "derive_more",
  "diesel",
  "dotenv",
+ "env_logger",
  "nanoid",
  "thiserror",
 ]
@@ -1626,6 +1703,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1988,6 +2074,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,6 +773,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b328c01a4d71d2d8173daa93562a73ab0fe85616876f02500f53d82948c504"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "gimli"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,6 +1269,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1496,6 +1532,7 @@ dependencies = [
  "diesel",
  "dotenv",
  "env_logger",
+ "getset",
  "nanoid",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,6 @@ derive_more = "0.99.11"
 diesel = { version = "1.4.6", features = ["mysql", "numeric"] }
 dotenv = "0.15.0"
 env_logger = "0.8.3"
+getset = "0.1.1"
 nanoid = "0.3.0"
 thiserror = "1.0.24"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,10 @@ edition = "2018"
 [dependencies]
 actix-rt = "1.1.0"
 actix-web = "3.3.2"
+bigdecimal = "0.1.2"
 derive_more = "0.99.11"
-diesel = { version = "1.4.6", features = ["mysql"] }
+diesel = { version = "1.4.6", features = ["mysql", "numeric"] }
 dotenv = "0.15.0"
+env_logger = "0.8.3"
 nanoid = "0.3.0"
 thiserror = "1.0.24"

--- a/diesel.toml
+++ b/diesel.toml
@@ -2,4 +2,4 @@
 # see diesel.rs/guides/configuring-diesel-cli
 
 [print_schema]
-file = "src/infrastructure/dto/schema.rs"
+file = "src/infrastructure/schema.rs"

--- a/migrations/2021-03-07-045223_create_routes/up.sql
+++ b/migrations/2021-03-07-045223_create_routes/up.sql
@@ -8,7 +8,7 @@ CREATE TABLE routes (
 CREATE TABLE coordinates (
     PRIMARY KEY (`route_id`, `index`),
     `route_id` VARCHAR(11) NOT NULL,
-    `index` INTEGER NOT NULL,
+    `index` INTEGER UNSIGNED NOT NULL,
     `latitude` DECIMAL NOT NULL,
     `longitude` DECIMAL NOT NULL
 );

--- a/src/domain/coordinate.rs
+++ b/src/domain/coordinate.rs
@@ -1,7 +1,8 @@
 use crate::lib::error::{ApplicationError, ApplicationResult};
 
 /// Value Object for Coordinates
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Getters)]
+#[get = "pub"]
 pub struct Coordinate {
     latitude: Latitude,
     longitude: Longitude,

--- a/src/domain/coordinate.rs
+++ b/src/domain/coordinate.rs
@@ -1,4 +1,4 @@
-use crate::lib::error::{ApplicationError, ApplicationResult};
+use crate::lib::error::ApplicationResult;
 
 use crate::domain::types::{Latitude, Longitude};
 use bigdecimal::BigDecimal;

--- a/src/domain/coordinate.rs
+++ b/src/domain/coordinate.rs
@@ -1,5 +1,9 @@
 use crate::lib::error::{ApplicationError, ApplicationResult};
 
+use crate::domain::types::{Latitude, Longitude};
+use bigdecimal::BigDecimal;
+use getset::Getters;
+
 /// Value Object for Coordinates
 #[derive(Clone, Debug, PartialEq, Getters)]
 #[get = "pub"]
@@ -9,46 +13,11 @@ pub struct Coordinate {
 }
 
 impl Coordinate {
-    pub fn create(lat :f64, lon: f64) -> ApplicationResult<Coordinate> {
-        let coord = Coordinate{
-            latitude: Latitude::from_f64(lat)?,
-            longitude: Longitude::from_f64(lon)?,
+    pub fn new(lat: BigDecimal, lon: BigDecimal) -> ApplicationResult<Coordinate> {
+        let coord = Coordinate {
+            latitude: Latitude::from(lat)?,
+            longitude: Longitude::from(lon)?,
         };
         Ok(coord)
-    }
-}
-
-// TODO: rustc 1.51.0でconst genericsが実装される
-// これを使うと、Latitude, Longitudeそれぞれのfrom_f64はいらなくなる
-// pub trait FromF64<T, const MAX: f64>
-// これやるついでにF64じゃなくてBigDecimalに変えてもいいかも
-pub trait FromF64<T> {
-    fn from_f64(val :f64) -> ApplicationResult<T>;
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct Latitude(f64);
-
-impl FromF64<Latitude> for Latitude {
-    fn from_f64(val :f64) -> ApplicationResult<Self> {
-        if val.abs() <= 90.0 {
-            Ok(Latitude(val))
-        } else {
-            Err(ApplicationError::ValueObjectError("Absolute value of Latitude must be <= 90"))
-        }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct Longitude(f64);
-
-
-impl FromF64<Longitude> for Longitude {
-    fn from_f64(val :f64) -> ApplicationResult<Self> {
-        if val.abs() <= 180.0 {
-            Ok(Longitude(val))
-        } else {
-            Err(ApplicationError::ValueObjectError("Absolute value of Longitude must be <= 180"))
-        }
     }
 }

--- a/src/domain/coordinate.rs
+++ b/src/domain/coordinate.rs
@@ -29,7 +29,7 @@ impl FromF64<Latitude> for Latitude {
         if val.abs() <= 90.0 {
             Ok(Latitude(val))
         } else {
-            Err(ApplicationError::BadRequest("Absolute value of Latitude must be <= 90"))
+            Err(ApplicationError::ValueObjectError("Absolute value of Latitude must be <= 90"))
         }
     }
 }
@@ -43,7 +43,7 @@ impl FromF64<Longitude> for Longitude {
         if val.abs() <= 180.0 {
             Ok(Longitude(val))
         } else {
-            Err(ApplicationError::BadRequest("Absolute value of Longitude must be <= 180"))
+            Err(ApplicationError::ValueObjectError("Absolute value of Longitude must be <= 180"))
         }
     }
 }

--- a/src/domain/coordinate.rs
+++ b/src/domain/coordinate.rs
@@ -1,6 +1,6 @@
 use crate::lib::error::{ApplicationError, ApplicationResult};
 
-/// A Value Class for Coordinates
+/// Value Object for Coordinates
 #[derive(Clone, Debug, PartialEq)]
 pub struct Coordinate {
     latitude: Latitude,
@@ -17,6 +17,10 @@ impl Coordinate {
     }
 }
 
+// TODO: rustc 1.51.0でconst genericsが実装される
+// これを使うと、Latitude, Longitudeそれぞれのfrom_f64はいらなくなる
+// pub trait FromF64<T, const MAX: f64>
+// これやるついでにF64じゃなくてBigDecimalに変えてもいいかも
 pub trait FromF64<T> {
     fn from_f64(val :f64) -> ApplicationResult<T>;
 }

--- a/src/domain/coordinate.rs
+++ b/src/domain/coordinate.rs
@@ -1,4 +1,4 @@
-use crate::lib::error::ApplicationError;
+use crate::lib::error::{ApplicationError, ApplicationResult};
 
 /// A Value Class for Coordinates
 #[derive(Clone, Debug, PartialEq)]
@@ -8,7 +8,7 @@ pub struct Coordinate {
 }
 
 impl Coordinate {
-    pub fn create(lat :f64, lon: f64) -> Result<Coordinate, ApplicationError> {
+    pub fn create(lat :f64, lon: f64) -> ApplicationResult<Coordinate> {
         let coord = Coordinate{
             latitude: Latitude::from_f64(lat)?,
             longitude: Longitude::from_f64(lon)?,
@@ -18,14 +18,14 @@ impl Coordinate {
 }
 
 pub trait FromF64<T> {
-    fn from_f64(val :f64) -> Result<T, ApplicationError>;
+    fn from_f64(val :f64) -> ApplicationResult<T>;
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Latitude(f64);
 
 impl FromF64<Latitude> for Latitude {
-    fn from_f64(val :f64) -> Result<Self, ApplicationError> {
+    fn from_f64(val :f64) -> ApplicationResult<Self> {
         if val.abs() <= 90.0 {
             Ok(Latitude(val))
         } else {
@@ -39,8 +39,7 @@ pub struct Longitude(f64);
 
 
 impl FromF64<Longitude> for Longitude {
-    fn from_f64(val :f64) -> Result<Self, ApplicationError> {
-        // TODO: エラー処理を書く
+    fn from_f64(val :f64) -> ApplicationResult<Self> {
         if val.abs() <= 180.0 {
             Ok(Longitude(val))
         } else {

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,2 +1,3 @@
 pub mod coordinate;
 pub mod route;
+pub mod types;

--- a/src/domain/route.rs
+++ b/src/domain/route.rs
@@ -1,16 +1,20 @@
 use crate::domain::coordinate::Coordinate;
+use crate::domain::types::RouteId;
+use crate::lib::error::ApplicationResult;
 
 #[derive(Debug)]
 pub struct Route {
+    id: RouteId,
     name: String,
     points: Vec<Coordinate>,
 }
 
 impl Route {
-    pub fn new(name: &str) -> Route {
+    pub fn new(id: RouteId, name: String, points: Vec<Coordinate>) -> Route {
         Route {
+            id,
             name: name.to_string(),
-            points: Vec::new()
+            points
         }
     }
 

--- a/src/domain/route.rs
+++ b/src/domain/route.rs
@@ -2,7 +2,10 @@ use crate::domain::coordinate::Coordinate;
 use crate::domain::types::RouteId;
 use crate::lib::error::ApplicationResult;
 
-#[derive(Debug)]
+use getset::Getters;
+
+#[derive(Debug, Getters)]
+#[get = "pub"]
 pub struct Route {
     id: RouteId,
     name: String,

--- a/src/domain/route.rs
+++ b/src/domain/route.rs
@@ -26,3 +26,7 @@ impl Route {
         println!("{:?}", self.points);
     }
 }
+
+pub trait RouteRepository {
+    fn find(&self, id: RouteId) -> ApplicationResult<Route>;
+}

--- a/src/domain/route.rs
+++ b/src/domain/route.rs
@@ -17,19 +17,27 @@ impl Route {
         Route {
             id,
             name: name.to_string(),
-            points
+            points,
         }
     }
 
     pub fn add_point(&mut self, point: Coordinate) {
         self.points.push(point);
     }
-
-    pub fn show_points(&self) {
-        println!("{:?}", self.points);
-    }
 }
 
 pub trait RouteRepository {
-    fn find(&self, id: RouteId) -> ApplicationResult<Route>;
+    fn find(&self, id: &RouteId) -> ApplicationResult<Route>;
+
+    fn register(&self, route: &Route) -> ApplicationResult<()>;
+
+    fn create(&self, name: &String) -> ApplicationResult<RouteId> {
+        let route = Route {
+            id: RouteId::new(),
+            name: name.clone(),
+            points: Vec::new(),
+        };
+        self.register(&route)?;
+        Ok(route.id)
+    }
 }

--- a/src/domain/types.rs
+++ b/src/domain/types.rs
@@ -1,0 +1,12 @@
+#[derive(Debug)]
+pub struct RouteId(pub String);
+
+impl RouteId {
+    // TODO: ここもconst generics実装されたらtraitとしてひとまとめにしていいかも
+    pub fn from_string(id: String) -> Self {
+        Self(id)
+    }
+    pub fn to_string(&self) -> String {
+        self.0.clone()
+    }
+}

--- a/src/domain/types.rs
+++ b/src/domain/types.rs
@@ -1,12 +1,66 @@
-#[derive(Debug)]
-pub struct RouteId(pub String);
+use crate::lib::error::{ApplicationError, ApplicationResult};
+use bigdecimal::BigDecimal;
+use nanoid::nanoid;
+
+// TODO: Value Object用のderive macroを作る
+// ↓みたいな一要素のタプル構造体たちにfrom, valueをデフォルトで実装したい
+// ただのgenericsでSelf(val)やself.0.clone()をしようとすると怒られるので、
+// derive macro + traitでやるしかなさそう
+
+#[derive(Debug, Clone)]
+pub struct RouteId(String);
 
 impl RouteId {
-    // TODO: ここもconst generics実装されたらtraitとしてひとまとめにしていいかも
+    pub fn new() -> RouteId {
+        RouteId(nanoid!(11))
+    }
     pub fn from_string(id: String) -> Self {
         Self(id)
     }
     pub fn to_string(&self) -> String {
+        self.0.clone()
+    }
+}
+
+// TODO: rustc 1.51.0でconst genericsが実装される
+// これを使うと、Latitude, Longitudeそれぞれのfromやvalueはいらなくなる
+// (今MAX以外はimplの中身完全一致してる)
+// ↑のderive ValueObjectをベースにしたtraitなイメージ (RangedValueObjectか、ValueObjectのオプションか)
+// オプションならconst genericsいらなそう
+#[derive(Clone, Debug, PartialEq)]
+pub struct Latitude(BigDecimal);
+
+impl Latitude {
+    pub fn from(val: BigDecimal) -> ApplicationResult<Self> {
+        if val.abs() <= BigDecimal::from(90.0) {
+            Ok(Self(val))
+        } else {
+            Err(ApplicationError::ValueObjectError(
+                "Absolute value of Latitude must be <= 90.0",
+            ))
+        }
+    }
+
+    pub fn value(&self) -> BigDecimal {
+        self.0.clone()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Longitude(BigDecimal);
+
+impl Longitude {
+    pub fn from(val: BigDecimal) -> ApplicationResult<Self> {
+        if val.abs() <= BigDecimal::from(180.0) {
+            Ok(Self(val))
+        } else {
+            Err(ApplicationError::ValueObjectError(
+                "Absolute value of Latitude must be <= 180.0",
+            ))
+        }
+    }
+
+    pub fn value(&self) -> BigDecimal {
         self.0.clone()
     }
 }

--- a/src/infrastructure/dto/coordinate.rs
+++ b/src/infrastructure/dto/coordinate.rs
@@ -1,7 +1,16 @@
-#[derive(Queryable)]
+use crate::infrastructure::schema::coordinates;
+use crate::infrastructure::dto::route::RouteDto;
+use bigdecimal::BigDecimal;
+
+
+/// 座標のdto構造体
+#[derive(Identifiable, Queryable, Insertable, Associations, Debug)]
+#[table_name = "coordinates"]
+#[primary_key(route_id, index)]
+#[belongs_to(RouteDto, foreign_key = "route_id")]
 pub struct CoordinateDto {
     pub route_id: String,
-    pub index: i32,
-    pub latitude: f64,
-    pub longitude: f64,
+    pub index: u32,
+    pub latitude: BigDecimal,
+    pub longitude: BigDecimal,
 }

--- a/src/infrastructure/dto/coordinate.rs
+++ b/src/infrastructure/dto/coordinate.rs
@@ -4,7 +4,7 @@ use crate::infrastructure::dto::route::RouteDto;
 use crate::infrastructure::schema::coordinates;
 use crate::lib::error::ApplicationResult;
 
-use bigdecimal::{BigDecimal, FromPrimitive, ToPrimitive};
+use bigdecimal::BigDecimal;
 
 /// 座標のdto構造体
 #[derive(Identifiable, Queryable, Insertable, Associations, Debug)]

--- a/src/infrastructure/dto/coordinate.rs
+++ b/src/infrastructure/dto/coordinate.rs
@@ -1,7 +1,10 @@
-use crate::infrastructure::schema::coordinates;
+use crate::domain::coordinate::Coordinate;
+use crate::domain::types::RouteId;
 use crate::infrastructure::dto::route::RouteDto;
-use bigdecimal::BigDecimal;
+use crate::infrastructure::schema::coordinates;
+use crate::lib::error::ApplicationResult;
 
+use bigdecimal::{BigDecimal, FromPrimitive, ToPrimitive};
 
 /// 座標のdto構造体
 #[derive(Identifiable, Queryable, Insertable, Associations, Debug)]
@@ -9,8 +12,26 @@ use bigdecimal::BigDecimal;
 #[primary_key(route_id, index)]
 #[belongs_to(RouteDto, foreign_key = "route_id")]
 pub struct CoordinateDto {
-    pub route_id: String,
-    pub index: u32,
-    pub latitude: BigDecimal,
-    pub longitude: BigDecimal,
+    route_id: String,
+    index: u32,
+    latitude: BigDecimal,
+    longitude: BigDecimal,
+}
+
+impl CoordinateDto {
+    pub fn to_model(&self) -> ApplicationResult<Coordinate> {
+        Ok(Coordinate::new(
+            self.latitude.clone(),
+            self.longitude.clone(),
+        )?)
+    }
+
+    pub fn from_model(coord: &Coordinate, route_id: &RouteId, index: u32) -> CoordinateDto {
+        CoordinateDto {
+            route_id: route_id.to_string(),
+            index,
+            latitude: coord.latitude().value(),
+            longitude: coord.longitude().value(),
+        }
+    }
 }

--- a/src/infrastructure/dto/route.rs
+++ b/src/infrastructure/dto/route.rs
@@ -1,9 +1,35 @@
+use crate::domain::route::Route;
+use crate::domain::types::RouteId;
+use crate::infrastructure::dto::coordinate::CoordinateDto;
 use crate::infrastructure::schema::routes;
+use crate::lib::error::ApplicationResult;
 
 /// ルートのdto構造体
 #[derive(Identifiable, Queryable, Insertable, Debug)]
 #[table_name = "routes"]
 pub struct RouteDto {
-    pub id: String,
-    pub name: String
+    id: String,
+    name: String,
+}
+
+impl RouteDto {
+    pub fn to_model(&self, point_dtos: Vec<CoordinateDto>) -> ApplicationResult<Route> {
+        let points = point_dtos
+            .iter()
+            .map(CoordinateDto::to_model)
+            .collect::<ApplicationResult<Vec<_>>>()?;
+
+        Ok(Route::new(
+            RouteId::from_string(self.id.clone()),
+            self.name.clone(),
+            points,
+        ))
+    }
+
+    pub fn from_model(route: &Route) -> RouteDto {
+        RouteDto {
+            id: route.id().to_string(),
+            name: route.name().clone(),
+        }
+    }
 }

--- a/src/infrastructure/dto/route.rs
+++ b/src/infrastructure/dto/route.rs
@@ -1,6 +1,7 @@
 use crate::infrastructure::schema::routes;
 
-#[derive(Queryable, Insertable, Debug)]
+/// ルートのdto構造体
+#[derive(Identifiable, Queryable, Insertable, Debug)]
 #[table_name = "routes"]
 pub struct RouteDto {
     pub id: String,

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -1,2 +1,3 @@
 pub mod dto;
 pub mod schema;
+pub mod repository;

--- a/src/infrastructure/repository/mod.rs
+++ b/src/infrastructure/repository/mod.rs
@@ -1,0 +1,1 @@
+pub mod route;

--- a/src/infrastructure/repository/route.rs
+++ b/src/infrastructure/repository/route.rs
@@ -1,11 +1,9 @@
-use bigdecimal::ToPrimitive;
 use diesel::{
     associations::HasTable, BelongingToDsl, ExpressionMethods, MysqlConnection, QueryDsl,
     RunQueryDsl,
 };
 use std::convert::TryInto;
 
-use crate::domain::coordinate::Coordinate;
 use crate::domain::route::{Route, RouteRepository};
 use crate::domain::types::RouteId;
 use crate::infrastructure::dto::coordinate::CoordinateDto;

--- a/src/infrastructure/repository/route.rs
+++ b/src/infrastructure/repository/route.rs
@@ -50,7 +50,11 @@ impl RouteRepository for RouteRepositoryMysql {
 
         let coord_dtos = CoordinateDto::belonging_to(&route_dto)
             .load(&self.conn)
-            .expect("Couldn't load coords");
+            .or_else(|_| {
+                Err(ApplicationError::DataBaseError(
+                    "Failed to load from Coordinates!",
+                ))
+            })?;
 
         Ok(route_dto.to_model(coord_dtos)?)
     }
@@ -61,12 +65,20 @@ impl RouteRepository for RouteRepositoryMysql {
         diesel::insert_into(RouteDto::table())
             .values(route_dto)
             .execute(&self.conn)
-            .expect("failed inserting route");
+            .or_else(|_| {
+                Err(ApplicationError::DataBaseError(
+                    "Failed to insert into Routes!",
+                ))
+            })?;
 
         diesel::insert_into(CoordinateDto::table())
             .values(coord_dtos)
             .execute(&self.conn)
-            .expect("failed inserting coord");
+            .or_else(|_| {
+                Err(ApplicationError::DataBaseError(
+                    "Failed to insert into Coordinates!",
+                ))
+            })?;
 
         Ok(())
     }

--- a/src/infrastructure/repository/route.rs
+++ b/src/infrastructure/repository/route.rs
@@ -1,0 +1,62 @@
+use diesel::{MysqlConnection, QueryDsl, RunQueryDsl, BelongingToDsl, ExpressionMethods, associations::HasTable};
+
+use crate::domain::route::{RouteRepository, Route};
+use crate::domain::types::RouteId;
+use crate::infrastructure::dto::route::RouteDto;
+use crate::infrastructure::schema;
+use crate::lib::error::{ApplicationError, ApplicationResult};
+use crate::infrastructure::dto::coordinate::CoordinateDto;
+use crate::domain::coordinate::Coordinate;
+use bigdecimal::ToPrimitive;
+
+
+pub struct RouteRepositoryMysql {
+    conn: MysqlConnection
+}
+
+impl RouteRepositoryMysql {
+    pub fn new(conn: MysqlConnection) -> RouteRepositoryMysql {
+        RouteRepositoryMysql { conn }
+    }
+
+    fn dto_to_coord(coord_dto: &CoordinateDto) -> ApplicationResult<Coordinate> {
+        Ok(Coordinate::create(
+            coord_dto.latitude.to_f64().unwrap(),
+            coord_dto.longitude.to_f64().unwrap())?)
+    }
+
+    fn dtos_to_route(route_dto: &RouteDto, coord_dtos: Vec<CoordinateDto>) -> ApplicationResult<Route> {
+        Ok(
+            Route::new(
+                RouteId(route_dto.id.clone()),
+                route_dto.name.clone(),
+                coord_dtos.iter()
+                    .map(|dto| Self::dto_to_coord(dto))
+                    // Resultにcollectからのquestion
+                    // https://users.rust-lang.org/t/use-operator-inside-map-function/16230/7
+                    .collect::<ApplicationResult<Vec<_>>>()?
+            )
+        )
+    }
+}
+
+
+impl RouteRepository for RouteRepositoryMysql {
+    fn find(&self, route_id: RouteId) -> ApplicationResult<Route> {
+        let route_dto = RouteDto::table()
+            .filter(schema::routes::id.eq(&route_id.to_string()))
+            .first::<RouteDto>(&self.conn)
+            .or_else(|_| {
+                Err(ApplicationError::ResourceNotFound {
+                    resource_name: "Route",
+                    id: route_id.to_string()
+                })
+            })?;
+
+        let coord_dtos = CoordinateDto::belonging_to(&route_dto)
+            .load(&self.conn)
+            .expect("Couldn't load coords");
+
+        Ok(Self::dtos_to_route(&route_dto, coord_dtos)?)
+    }
+}

--- a/src/infrastructure/schema.rs
+++ b/src/infrastructure/schema.rs
@@ -1,7 +1,7 @@
 table! {
     coordinates (route_id, index) {
         route_id -> Varchar,
-        index -> Integer,
+        index -> Unsigned<Integer>,
         latitude -> Decimal,
         longitude -> Decimal,
     }

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -8,18 +8,18 @@ pub type ApplicationResult<T> = Result<T, ApplicationError>;
 /// actix-webを用いて直接リクエストに変換できる自作エラークラス
 #[derive(Debug, Display, Error)]
 pub enum ApplicationError {
-    #[display(fmt = "Bad Request: {}", _0)]
-    BadRequest(&'static str),
+    #[display(fmt = "ValueObjectError: {}", _0)]
+    ValueObjectError(&'static str),
 
-    #[display(fmt = "Internal Server Error: {}", _0)]
-    InternalServerError(&'static str),
+    #[display(fmt = "ResourceNotFound: {} {} not found", resource_name, id)]
+    ResourceNotFound{ resource_name: &'static str, id: String },
 }
 
 impl ResponseError for ApplicationError {
     fn status_code(&self) -> StatusCode {
         match *self {
-            ApplicationError::BadRequest(..) => StatusCode::BAD_REQUEST,
-            ApplicationError::InternalServerError(..) => StatusCode::INTERNAL_SERVER_ERROR,
+            ApplicationError::ValueObjectError(..) => StatusCode::INTERNAL_SERVER_ERROR,
+            ApplicationError::ResourceNotFound{..} => StatusCode::NOT_FOUND,
         }
     }
     fn error_response(&self) -> HttpResponse {

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -2,6 +2,10 @@ use actix_web::{ResponseError, http::StatusCode, dev::HttpResponseBuilder, http:
 use derive_more::Display;
 use thiserror::Error;
 
+/// ApplicationErrorを持つResult用のエイリアス
+pub type ApplicationResult<T> = Result<T, ApplicationError>;
+
+/// actix-webを用いて直接リクエストに変換できる自作エラークラス
 #[derive(Debug, Display, Error)]
 pub enum ApplicationError {
     #[display(fmt = "Bad Request: {}", _0)]

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -1,4 +1,6 @@
-use actix_web::{ResponseError, http::StatusCode, dev::HttpResponseBuilder, http::header, HttpResponse};
+use actix_web::{
+    dev::HttpResponseBuilder, http::header, http::StatusCode, HttpResponse, ResponseError,
+};
 use derive_more::Display;
 use thiserror::Error;
 
@@ -8,18 +10,25 @@ pub type ApplicationResult<T> = Result<T, ApplicationError>;
 /// actix-webを用いて直接リクエストに変換できる自作エラークラス
 #[derive(Debug, Display, Error)]
 pub enum ApplicationError {
+    #[display(fmt = "DataBaseError: {}", _0)]
+    DataBaseError(&'static str),
+
     #[display(fmt = "ValueObjectError: {}", _0)]
     ValueObjectError(&'static str),
 
     #[display(fmt = "ResourceNotFound: {} {} not found", resource_name, id)]
-    ResourceNotFound{ resource_name: &'static str, id: String },
+    ResourceNotFound {
+        resource_name: &'static str,
+        id: String,
+    },
 }
 
 impl ResponseError for ApplicationError {
     fn status_code(&self) -> StatusCode {
         match *self {
+            ApplicationError::DataBaseError(..) => StatusCode::INTERNAL_SERVER_ERROR,
             ApplicationError::ValueObjectError(..) => StatusCode::INTERNAL_SERVER_ERROR,
-            ApplicationError::ResourceNotFound{..} => StatusCode::NOT_FOUND,
+            ApplicationError::ResourceNotFound { .. } => StatusCode::NOT_FOUND,
         }
     }
     fn error_response(&self) -> HttpResponse {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,19 +11,14 @@ use bigdecimal::BigDecimal;
 use diesel::mysql::MysqlConnection;
 use diesel::prelude::*;
 use dotenv::dotenv;
-use nanoid::nanoid;
 
 use crate::domain::coordinate::Coordinate;
 use crate::domain::route::{Route, RouteRepository};
 use crate::domain::types::RouteId;
-use crate::infrastructure::dto::route::RouteDto;
 use crate::infrastructure::repository::route::RouteRepositoryMysql;
-use crate::infrastructure::schema;
 
 #[get("/")]
 async fn index() -> Result<HttpResponse, Error> {
-    use schema::routes::dsl::*;
-
     let conn = establish_connection();
     let repository = RouteRepositoryMysql::new(conn);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,48 +2,50 @@
 extern crate diesel;
 
 mod domain;
-mod lib;
 mod infrastructure;
+mod lib;
 
-use actix_web::{HttpResponse, get, HttpServer, App, Error};
 use actix_web::middleware::Logger;
-use dotenv::dotenv;
-use diesel::prelude::*;
+use actix_web::{get, App, Error, HttpResponse, HttpServer};
+use bigdecimal::BigDecimal;
 use diesel::mysql::MysqlConnection;
+use diesel::prelude::*;
+use dotenv::dotenv;
 use nanoid::nanoid;
 
+use crate::domain::coordinate::Coordinate;
 use crate::domain::route::{Route, RouteRepository};
+use crate::domain::types::RouteId;
 use crate::infrastructure::dto::route::RouteDto;
 use crate::infrastructure::repository::route::RouteRepositoryMysql;
 use crate::infrastructure::schema;
-use crate::domain::types::RouteId;
 
 #[get("/")]
 async fn index() -> Result<HttpResponse, Error> {
     use schema::routes::dsl::*;
 
     let conn = establish_connection();
-    let route_id = nanoid!(11);
-    let new_route = RouteDto {
-        id: route_id.clone(),
-        name: "sample route".to_string()
-    };
-
-    diesel::insert_into(routes)
-        .values(new_route)
-        .execute(&conn)
-        .expect("failed inserting");
-
     let repository = RouteRepositoryMysql::new(conn);
-    let route = repository.find(RouteId(route_id))?;
+
+    let route = Route::new(
+        RouteId::new(),
+        "sample route".to_string(),
+        vec![
+            Coordinate::new(BigDecimal::from(35.0), BigDecimal::from(130.0))?,
+            Coordinate::new(BigDecimal::from(45.0), BigDecimal::from(140.0))?,
+        ],
+    );
+
+    repository.register(&route)?;
+
+    let route = repository.find(&route.id())?;
     Ok(HttpResponse::Ok().body(format!("{:#?}", route)))
 }
 
 fn establish_connection() -> MysqlConnection {
     dotenv().ok();
 
-    let database_url = std::env::var("DATABASE_URL")
-        .expect("DATABASE_URL NOT FOUND");
+    let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL NOT FOUND");
 
     MysqlConnection::establish(&database_url).expect("Error on db connection!")
 }
@@ -53,9 +55,13 @@ async fn main() -> Result<(), Error> {
     std::env::set_var("RUST_LOG", "actix_web=info");
     env_logger::init();
 
-    HttpServer::new(move || App::new().wrap(Logger::new("%a \"%r\" %s (%T s)")).service(index))
-        .bind("0.0.0.0:8080")?
-        .run()
-        .await?;
+    HttpServer::new(move || {
+        App::new()
+            .wrap(Logger::new("%a \"%r\" %s (%T s)"))
+            .service(index)
+    })
+    .bind("0.0.0.0:8080")?
+    .run()
+    .await?;
     Ok(())
 }


### PR DESCRIPTION
Closes #10 
# 概要
* dieselを用いたDBへの操作を`RouteRepositoryMysql`クラスに集約した
  * `infrastructure/repository/route.rs`と`domain/route.rs`の`RouteRepository`
  * idで見つける`find`、ドメインモデル`Route`のインスタンスをinsertする`register`、一点も持たない空の`Route`を作成してinsertする`create`を実装した
* actix-webのloggerを使って、来たリクエストとそれに対するステータスコードや処理秒数を表示するようにした
  * `main.rs`の`main()`の最初2行
* `ApplicationError::DataBaseError`を追加した
  * `lib/error.rs`

# 注目ポイント
* main.rsで直接dieselを呼んでいたのが、`RouteRepositoryMysql`経由でのDB操作をするようになった
  * その結果、`RouteDto`ではなく`Route`モデルを直接DBに保存できている
    * `Route.points`に含まれる各`Coordinate`はちゃんと順番通りにDBの`Coordinates`に保存されている 
    * `infrastructure/repository/route.rs`の`route_to_dtos`で`RouteDto`と`Vec<CoordinateDto>`に変換し、`register`でそれぞれをinsertしている
* `infrastructure/repository/route.rs`だけでrepositoryを実装すればいいものを、`domain/route.rs`で`RouteRepository`にtraitとして宣言してから、それをinfraで実装する形にしている
  * これは、application側でもrepositoryを使いたいから
    * applicationはHTTP捌くレイヤー
  * 依存関係をapplication -> domain <- infrastructureにしたい
    * applicationはinfra(DB)に依存しないし、infraはapplication(APIの設計)に依存しない
  * applicationで使う分には、repositoryがどんな関数持つのか(=trait)だけわかればいいので、traitだけdomainに書いている
  * これにより、例えばMySQLをやめてPostgresにしたい！となっても、`RouteRepositoryPostgres`を実装して`RouteReposityryMysql`と入れ替えるだけでapplication, domainは一切いじらずに切り替えられる