### PR TITLE
Controllerの追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,6 +537,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "r2d2",
  "url 1.7.2",
 ]
 
@@ -1151,9 +1152,9 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "once_cell"
-version = "1.7.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10acf907b94fc1b1a152d08ef97e7759650268cf986bf127f387e602b02c7e5a"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "opaque-debug"
@@ -1326,6 +1327,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r2d2"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
 ]
 
 [[package]]
@@ -1534,6 +1546,9 @@ dependencies = [
  "env_logger",
  "getset",
  "nanoid",
+ "once_cell",
+ "r2d2",
+ "serde",
  "thiserror",
 ]
 
@@ -1559,6 +1574,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "scheduled-thread-pool"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1581,18 +1605,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,12 @@ actix-rt = "1.1.0"
 actix-web = "3.3.2"
 bigdecimal = "0.1.2"
 derive_more = "0.99.11"
-diesel = { version = "1.4.6", features = ["mysql", "numeric"] }
+diesel = { version = "1.4.6", features = ["mysql", "numeric", "r2d2"] }
 dotenv = "0.15.0"
 env_logger = "0.8.3"
 getset = "0.1.1"
 nanoid = "0.3.0"
+once_cell = "1.7.2"
+r2d2 = "0.8.9"
+serde = { version = "1.0.124", features = ["derive"] }
 thiserror = "1.0.24"

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -1,0 +1,1 @@
+pub mod route;

--- a/src/controller/route.rs
+++ b/src/controller/route.rs
@@ -3,7 +3,7 @@ use getset::Getters;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 
-use crate::domain::route::{Route, RouteRepository};
+use crate::domain::route::RouteRepository;
 use crate::domain::types::RouteId;
 
 #[derive(Clone)]
@@ -16,13 +16,13 @@ impl<Repository: RouteRepository> RouteController<Repository> {
         RouteController { repository }
     }
 
-    pub async fn get(&self, id: web::Path<RouteId>) -> Result<HttpResponse> {
+    async fn get(&self, id: web::Path<RouteId>) -> Result<HttpResponse> {
         let route = self.repository.find(id.as_ref())?;
 
         Ok(HttpResponse::Ok().json(route))
     }
 
-    pub async fn post(&self, req: web::Json<RouteCreateRequest>) -> Result<HttpResponse> {
+    async fn post(&self, req: web::Json<RouteCreateRequest>) -> Result<HttpResponse> {
         let route_id = self.repository.create(&req.name())?;
 
         Ok(HttpResponse::Created().json(RouteCreateResponse::new(&route_id)))
@@ -42,7 +42,7 @@ impl<R: RouteRepository> BuildService<Scope> for &'static Lazy<RouteController<R
 }
 
 // TODO: UseCaseを作ったらそっちに移動する
-/// response body for POST /routes/
+/// request body for POST /routes/
 #[derive(Getters, Deserialize)]
 #[get = "pub"]
 struct RouteCreateRequest {

--- a/src/controller/route.rs
+++ b/src/controller/route.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Serialize};
 use crate::domain::route::RouteRepository;
 use crate::domain::types::RouteId;
 
-#[derive(Clone)]
 pub struct RouteController<Repository: RouteRepository> {
     repository: Repository,
 }

--- a/src/controller/route.rs
+++ b/src/controller/route.rs
@@ -1,0 +1,41 @@
+use actix_web::{get, web, HttpResponse, Result, Scope};
+
+use crate::domain::route::{Route, RouteRepository};
+use crate::domain::types::RouteId;
+use actix_web::dev::HttpServiceFactory;
+use actix_web::web::Json;
+use once_cell::sync::Lazy;
+
+#[derive(Clone)]
+pub struct RouteController<Repository: RouteRepository> {
+    repository: Repository,
+}
+
+impl<Repository: RouteRepository> RouteController<Repository> {
+    pub fn new(repository: Repository) -> RouteController<Repository> {
+        RouteController { repository }
+    }
+
+    pub async fn get(&self, id: web::Path<RouteId>) -> Result<HttpResponse> {
+        let route = self.repository.find(id.as_ref())?;
+
+        Ok(HttpResponse::Ok().json(route))
+    }
+
+    pub async fn post(&self, route: Json<Route>) -> Result<HttpResponse> {
+        self.repository.register(&route)?;
+
+        Ok(HttpResponse::Created().finish())
+    }
+}
+
+pub trait BuildService<S: HttpServiceFactory + 'static> {
+    fn build_service(self) -> S;
+}
+
+impl<R: RouteRepository> BuildService<Scope> for &'static Lazy<RouteController<R>> {
+    fn build_service(self) -> Scope {
+        web::scope("/routes")
+            .service(web::resource("/{id}").route(web::get().to(move |id| self.get(id))))
+    }
+}

--- a/src/domain/coordinate.rs
+++ b/src/domain/coordinate.rs
@@ -3,9 +3,10 @@ use crate::lib::error::ApplicationResult;
 use crate::domain::types::{Latitude, Longitude};
 use bigdecimal::BigDecimal;
 use getset::Getters;
+use serde::Serialize;
 
 /// Value Object for Coordinates
-#[derive(Clone, Debug, PartialEq, Getters)]
+#[derive(Clone, Debug, PartialEq, Getters, Serialize)]
 #[get = "pub"]
 pub struct Coordinate {
     latitude: Latitude,

--- a/src/domain/coordinate.rs
+++ b/src/domain/coordinate.rs
@@ -3,10 +3,10 @@ use crate::lib::error::ApplicationResult;
 use crate::domain::types::{Latitude, Longitude};
 use bigdecimal::BigDecimal;
 use getset::Getters;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// Value Object for Coordinates
-#[derive(Clone, Debug, PartialEq, Getters, Serialize)]
+#[derive(Clone, Debug, PartialEq, Getters, Deserialize, Serialize)]
 #[get = "pub"]
 pub struct Coordinate {
     latitude: Latitude,

--- a/src/domain/route.rs
+++ b/src/domain/route.rs
@@ -3,9 +3,9 @@ use crate::domain::types::RouteId;
 use crate::lib::error::ApplicationResult;
 
 use getset::Getters;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Getters, Serialize)]
+#[derive(Debug, Getters, Deserialize, Serialize)]
 #[get = "pub"]
 pub struct Route {
     id: RouteId,

--- a/src/domain/route.rs
+++ b/src/domain/route.rs
@@ -3,8 +3,9 @@ use crate::domain::types::RouteId;
 use crate::lib::error::ApplicationResult;
 
 use getset::Getters;
+use serde::Serialize;
 
-#[derive(Debug, Getters)]
+#[derive(Debug, Getters, Serialize)]
 #[get = "pub"]
 pub struct Route {
     id: RouteId,

--- a/src/domain/types.rs
+++ b/src/domain/types.rs
@@ -1,13 +1,14 @@
 use crate::lib::error::{ApplicationError, ApplicationResult};
 use bigdecimal::BigDecimal;
 use nanoid::nanoid;
+use serde::{Deserialize, Serialize, Serializer};
 
 // TODO: Value Object用のderive macroを作る
 // ↓みたいな一要素のタプル構造体たちにfrom, valueをデフォルトで実装したい
 // ただのgenericsでSelf(val)やself.0.clone()をしようとすると怒られるので、
 // derive macro + traitでやるしかなさそう
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RouteId(String);
 
 impl RouteId {
@@ -46,6 +47,15 @@ impl Latitude {
     }
 }
 
+impl Serialize for Latitude {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0.to_string())
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct Longitude(BigDecimal);
 
@@ -62,5 +72,14 @@ impl Longitude {
 
     pub fn value(&self) -> BigDecimal {
         self.0.clone()
+    }
+}
+
+impl Serialize for Longitude {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0.to_string())
     }
 }

--- a/src/domain/types.rs
+++ b/src/domain/types.rs
@@ -1,7 +1,8 @@
 use crate::lib::error::{ApplicationError, ApplicationResult};
 use bigdecimal::BigDecimal;
 use nanoid::nanoid;
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::str::FromStr;
 
 // TODO: Value Object用のderive macroを作る
 // ↓みたいな一要素のタプル構造体たちにfrom, valueをデフォルトで実装したい
@@ -28,8 +29,14 @@ impl RouteId {
 // (今MAX以外はimplの中身完全一致してる)
 // ↑のderive ValueObjectをベースにしたtraitなイメージ (RangedValueObjectか、ValueObjectのオプションか)
 // オプションならconst genericsいらなそう
-#[derive(Clone, Debug, PartialEq)]
-pub struct Latitude(BigDecimal);
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Latitude(
+    #[serde(
+        serialize_with = "serialize_big_decimal",
+        deserialize_with = "deserialize_big_decimal"
+    )]
+    BigDecimal,
+);
 
 impl Latitude {
     pub fn from(val: BigDecimal) -> ApplicationResult<Self> {
@@ -47,17 +54,14 @@ impl Latitude {
     }
 }
 
-impl Serialize for Latitude {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(&self.0.to_string())
-    }
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct Longitude(BigDecimal);
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Longitude(
+    #[serde(
+        serialize_with = "serialize_big_decimal",
+        deserialize_with = "deserialize_big_decimal"
+    )]
+    BigDecimal,
+);
 
 impl Longitude {
     pub fn from(val: BigDecimal) -> ApplicationResult<Self> {
@@ -75,11 +79,18 @@ impl Longitude {
     }
 }
 
-impl Serialize for Longitude {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(&self.0.to_string())
-    }
+fn serialize_big_decimal<S>(target: &BigDecimal, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&target.to_string())
+}
+
+fn deserialize_big_decimal<'de, D>(deserializer: D) -> Result<BigDecimal, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let bd_string = String::deserialize(deserializer)?;
+    // TODO: ここのunwrapどうにかする
+    Ok(BigDecimal::from_str(&bd_string).unwrap())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,20 @@
 #[macro_use]
 extern crate diesel;
 
+mod controller;
 mod domain;
 mod infrastructure;
 mod lib;
 
 use actix_web::middleware::Logger;
-use actix_web::{get, App, Error, HttpResponse, HttpServer};
+use actix_web::{get, web, App, Error, HttpResponse, HttpServer, Result};
 use bigdecimal::BigDecimal;
 use diesel::mysql::MysqlConnection;
 use diesel::prelude::*;
 use dotenv::dotenv;
+use once_cell::sync::Lazy;
 
+use crate::controller::route::{BuildService, RouteController};
 use crate::domain::coordinate::Coordinate;
 use crate::domain::route::{Route, RouteRepository};
 use crate::domain::types::RouteId;
@@ -30,15 +33,33 @@ fn create_pool() -> Pool<ConnectionManager<MysqlConnection>> {
         .expect("Failed to create pool")
 }
 
+// TODO: ControllerとRepositoryMysql系のstructに共通trait実装してcontrollerの初期化を↓みたいに共通化したい
+// fn create_static_controller<Controller, Repository>() -> Lazy<Controller> {
+//     Lazy::new(|| {
+//         let pool = create_pool();
+//         let route_repository = Repository::new(pool);
+//         Controller::new(route_repository)
+//     })
+// }
+
+type StaticRouteController = Lazy<RouteController<RouteRepositoryMysql>>;
+
 #[actix_rt::main]
 async fn main() -> Result<(), Error> {
     std::env::set_var("RUST_LOG", "actix_web=info");
     env_logger::init();
 
+    // staticじゃないと↓で怒られる
+    static ROUTE_CONTROLLER: StaticRouteController = StaticRouteController::new(|| {
+        let pool = create_pool();
+        let route_repository = RouteRepositoryMysql::new(pool);
+        RouteController::new(route_repository)
+    });
+
     HttpServer::new(move || {
         App::new()
             .wrap(Logger::new("%a \"%r\" %s (%T s)"))
-            .service(index)
+            .service(ROUTE_CONTROLLER.build_service())
     })
     .bind("0.0.0.0:8080")?
     .run()

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,19 +7,14 @@ mod infrastructure;
 mod lib;
 
 use actix_web::middleware::Logger;
-use actix_web::{get, web, App, Error, HttpResponse, HttpServer, Result};
-use bigdecimal::BigDecimal;
+use actix_web::{App, Error, HttpServer, Result};
 use diesel::mysql::MysqlConnection;
-use diesel::prelude::*;
+use diesel::r2d2::{ConnectionManager, Pool};
 use dotenv::dotenv;
 use once_cell::sync::Lazy;
 
 use crate::controller::route::{BuildService, RouteController};
-use crate::domain::coordinate::Coordinate;
-use crate::domain::route::{Route, RouteRepository};
-use crate::domain::types::RouteId;
 use crate::infrastructure::repository::route::RouteRepositoryMysql;
-use diesel::r2d2::{ConnectionManager, Pool};
 
 fn create_pool() -> Pool<ConnectionManager<MysqlConnection>> {
     dotenv().ok();


### PR DESCRIPTION
Closes #5 

# 概要
* `controller/route.rs`にてエンドポイントを追加
  * `GET /routes/{id}`: idに対応する`Route`の取得
  * `POST /routes` : 指定した`name`を持つ空の`Route`の作成
* ↑に伴い、実験用に使っていた`GET /`を消した
* `RouteController`のメソッドをエンドポイント用に使うには、staticな変数である必要が出てきた
  * → staticをいい感じに使いやすくするライブラリ`once_cell::Lazy`を追加
  * → `RouteRepository`が`MysqlConnection`ではなく`Pool`を持ち、その都度Connectionを発行する形に変更
    * `MysqlConnection`をstaticにするにはMutexに入れる必要があって、性能悪そう & 使いづらい & そのためのPool
* 勝手にRequestやResponseのjsonとの相互変換をしてくれるように、各modelに`Serialize`や`Deserialize`を付与した
  * `BigDecimal`はそのままでは付与できなかったので、専用の関数(`(de)serialize_big_decimal`)を用意した

# 動作確認
1. 適当な名前のRouteを作成
    ```Bash
    > curl -X POST http://localhost:8080/routes/ \
        -H "Content-Type: application/json" \
        -d '{"name": "my awsome route"}'

    {"id":"IFskwsFgwJW"}
    ```
1. 帰ってきたidでGETしてみる
    ```Bash
    > curl http://localhost:8080/routes/IFskwsFgwJW

    {"id":"IFskwsFgwJW","name":"my awsome route","points":[]}
    ```
    → 空のRouteできてる！

ちなみにmasterにチェックアウトして`GET / `すればpointsを二つ持ってるレコードが生成できるので、それGETすれば、Coordinatesの動作確認もできる（あとで初期データちゃんと作ります）
