### PR TITLE
UseCase層の追加

### DIFF
--- a/src/domain/route.rs
+++ b/src/domain/route.rs
@@ -14,10 +14,10 @@ pub struct Route {
 }
 
 impl Route {
-    pub fn new(id: RouteId, name: String, points: Vec<Coordinate>) -> Route {
+    pub fn new(id: RouteId, name: &String, points: Vec<Coordinate>) -> Route {
         Route {
             id,
-            name: name.to_string(),
+            name: name.clone(),
             points,
         }
     }
@@ -31,15 +31,4 @@ pub trait RouteRepository {
     fn find(&self, id: &RouteId) -> ApplicationResult<Route>;
 
     fn register(&self, route: &Route) -> ApplicationResult<()>;
-
-    // TODO: こいつrepositoryではなくてusecase説ある
-    fn create(&self, name: &String) -> ApplicationResult<RouteId> {
-        let route = Route {
-            id: RouteId::new(),
-            name: name.clone(),
-            points: Vec::new(),
-        };
-        self.register(&route)?;
-        Ok(route.id)
-    }
 }

--- a/src/infrastructure/dto/route.rs
+++ b/src/infrastructure/dto/route.rs
@@ -21,7 +21,7 @@ impl RouteDto {
 
         Ok(Route::new(
             RouteId::from_string(self.id.clone()),
-            self.name.clone(),
+            &self.name,
             points,
         ))
     }

--- a/src/infrastructure/repository/route.rs
+++ b/src/infrastructure/repository/route.rs
@@ -50,7 +50,7 @@ impl RouteRepository for RouteRepositoryMysql {
     fn find(&self, route_id: &RouteId) -> ApplicationResult<Route> {
         let conn = self.get_connection()?;
         let route_dto = RouteDto::table()
-            .filter(schema::routes::id.eq(&route_id.to_string()))
+            .find(&route_id.to_string())
             .first::<RouteDto>(&conn)
             .or_else(|_| {
                 Err(ApplicationError::ResourceNotFound {

--- a/src/infrastructure/repository/route.rs
+++ b/src/infrastructure/repository/route.rs
@@ -23,7 +23,7 @@ impl RouteRepositoryMysql {
         RouteRepositoryMysql { pool }
     }
 
-    pub fn get_connection(&self) -> ApplicationResult<PooledConnection<MysqlConnectionManager>> {
+    fn get_connection(&self) -> ApplicationResult<PooledConnection<MysqlConnectionManager>> {
         let conn = self.pool.get().or_else(|_| {
             Err(ApplicationError::DataBaseError(
                 "Failed to get DB connection.",
@@ -32,7 +32,7 @@ impl RouteRepositoryMysql {
         Ok(conn)
     }
 
-    pub fn route_to_dtos(route: &Route) -> (RouteDto, Vec<CoordinateDto>) {
+    fn route_to_dtos(route: &Route) -> (RouteDto, Vec<CoordinateDto>) {
         let route_dto = RouteDto::from_model(route);
         let coord_dtos = route
             .points()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,5 @@ extern crate diesel;
 pub mod controller;
 pub mod domain;
 pub mod infrastructure;
+pub mod usecase;
 pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use once_cell::sync::Lazy;
 
 use route_bucket_backend::controller::route::{BuildService, RouteController};
 use route_bucket_backend::infrastructure::repository::route::RouteRepositoryMysql;
+use route_bucket_backend::usecase::route::RouteUseCase;
 
 fn create_pool() -> Pool<ConnectionManager<MysqlConnection>> {
     let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL NOT FOUND");
@@ -37,8 +38,9 @@ async fn main() -> Result<(), Error> {
     // staticじゃないと↓で怒られる
     static ROUTE_CONTROLLER: StaticRouteController = StaticRouteController::new(|| {
         let pool = create_pool();
-        let route_repository = RouteRepositoryMysql::new(pool);
-        RouteController::new(route_repository)
+        let repository = RouteRepositoryMysql::new(pool);
+        let usecase = RouteUseCase::new(repository);
+        RouteController::new(usecase)
     });
 
     HttpServer::new(move || {

--- a/src/usecase/mod.rs
+++ b/src/usecase/mod.rs
@@ -1,0 +1,1 @@
+pub mod route;

--- a/src/usecase/route.rs
+++ b/src/usecase/route.rs
@@ -1,0 +1,43 @@
+use getset::Getters;
+use serde::{Deserialize, Serialize};
+
+use crate::domain::route::{Route, RouteRepository};
+use crate::domain::types::RouteId;
+use crate::utils::error::ApplicationResult;
+
+pub struct RouteUseCase<R: RouteRepository> {
+    repository: R,
+}
+
+impl<R: RouteRepository> RouteUseCase<R> {
+    pub fn new(repository: R) -> Self {
+        Self { repository }
+    }
+
+    pub fn find(&self, route_id: &RouteId) -> ApplicationResult<Route> {
+        self.repository.find(route_id)
+    }
+
+    pub fn create(&self, req: &RouteCreateRequest) -> ApplicationResult<RouteCreateResponse> {
+        let route = Route::new(RouteId::new(), req.name(), Vec::new());
+
+        self.repository.register(&route)?;
+        Ok(RouteCreateResponse::new(route.id()))
+    }
+}
+
+#[derive(Getters, Deserialize)]
+#[get = "pub"]
+pub struct RouteCreateRequest {
+    name: String,
+}
+
+#[derive(Serialize)]
+pub struct RouteCreateResponse {
+    id: RouteId,
+}
+impl RouteCreateResponse {
+    pub fn new(id: &RouteId) -> Self {
+        Self { id: id.clone() }
+    }
+}


### PR DESCRIPTION
* controllerとdomainの間にusecase層を追加した
* 役割の棲み分け
  * Controller: ルーティングのパスに応じて HTTP request/responseとrequest/response構造体(ex: `RouteCreateRequest`)に置き換える
  * UseCase: Repositoryを操作して、満たすべき動作や仕様を体現する(Routeの作成、操作などは全てここ)
  * Domain: アプリケーションに出てくる要素たちをstructとして表現
  * infra: DBへの操作を集約
 
機能的には何一つ変わらない
依存関係↓

**before**: controller -> domain <- infra
**after**: controller -> usecase -> domain <- infra
