### PR TITLE
緯度経度構造体の共通化

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 # route-bucket-backend
 
 ## supported environment
-```
-rustc 1.48.0 (7eac88abb 2020-11-16)
-cargo 1.48.0 (65cbdd2dc 2020-10-14)
-```
+`rustc` & `cargo` must be `>=1.51.0` since this project uses [const generics](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html)
 
 ## Run the Project
 ### Start MySQL

--- a/src/domain/coordinate.rs
+++ b/src/domain/coordinate.rs
@@ -17,8 +17,8 @@ pub struct Coordinate {
 impl Coordinate {
     pub fn new(lat: BigDecimal, lon: BigDecimal) -> ApplicationResult<Coordinate> {
         let coord = Coordinate {
-            latitude: Latitude::from(lat)?,
-            longitude: Longitude::from(lon)?,
+            latitude: Latitude::try_from(lat)?,
+            longitude: Longitude::try_from(lon)?,
         };
         Ok(coord)
     }

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -14,7 +14,7 @@ pub enum ApplicationError {
     DataBaseError(&'static str),
 
     #[display(fmt = "ValueObjectError: {}", _0)]
-    ValueObjectError(&'static str),
+    ValueObjectError(String),
 
     #[display(fmt = "ResourceNotFound: {} {} not found", resource_name, id)]
     ResourceNotFound {


### PR DESCRIPTION
* `Latitude`と`Longitude`は値の上限以外に違いはなく、全く同じコードとなっていた
* 先月Rust 1.51.0で新たに追加されたConst Generics（ジェネリクスに定数を指定できる`BigDecimalValueObject<90>`みたいなやつ）を使って↑の値の違いを表現し、他の処理を共通化した（`struct BigDecimalValueObject`）
* `Latitude`や`Longitude`は`BigDecimalValueObject`でMAX_ABSを指定しただけのエイリアス
* ついでに、BigDecimalからの変換に使っていたfromメソッドを、標準の`std::convert::TryFrom`のtrait実装に変更した（ちゃんとした方法に変えた）

ただのリファクタで、機能的には何も変わらぬ