### PR TITLE
APIドキュメントの追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-cors"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36b133d8026a9f209a9aeeeacd028e7451bcca975f592881b305d37983f303d7"
+dependencies = [
+ "actix-web",
+ "derive_more",
+ "futures-util",
+ "log",
+ "once_cell",
+ "tinyvec",
+]
+
+[[package]]
 name = "actix-http"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,6 +1722,7 @@ checksum = "e5864e7ef1a6b7bcf1d6ca3f655e65e724ed3b52546a0d0a663c991522f552ea"
 name = "route-bucket-backend"
 version = "0.1.0"
 dependencies = [
+ "actix-cors",
  "actix-rt",
  "actix-web",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ default-run = "route-bucket-backend"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+actix-cors = "0.5.4"
 actix-rt = "1.1.0"
 actix-web = "3.3.2"
 bigdecimal = "0.1.2"

--- a/README.md
+++ b/README.md
@@ -30,3 +30,10 @@ docker-compose up db
 cargo run
 ```
 The root of the app will be at http://localhost:8080/
+
+## Documentation
+To see the documentation(SwaggerUI), run ↓
+```bash
+docker-compose up -d swagger
+```
+and then go to http://localhost:8000/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,13 @@ services:
     # 今回はdieselにやってもらう
     #  volumes:
     #    - ./mysql:/docker-entrypoint-initdb.d
+
+  swagger:
+    image: swaggerapi/swagger-ui:v3.45.1
+    ports:
+      - "8000:8080"
+    volumes:
+      - ./openapi/:/openapi/
+    environment:
+      # yamlなのにjsonに指定するのなぜ
+      SWAGGER_JSON: /openapi/root.yml

--- a/openapi/components/parameters/pos.yml
+++ b/openapi/components/parameters/pos.yml
@@ -1,0 +1,7 @@
+in: path
+name: pos
+description: 点の位置
+required: true
+schema:
+  type: number
+  format: integer

--- a/openapi/components/parameters/route_id.yml
+++ b/openapi/components/parameters/route_id.yml
@@ -1,0 +1,6 @@
+in: path
+name: id
+description: RouteのID
+required: true
+schema:
+  type: string

--- a/openapi/components/schemas/coordinate.yml
+++ b/openapi/components/schemas/coordinate.yml
@@ -1,0 +1,17 @@
+Coordinate:
+  type: object
+  description: 座標
+  required: [latitude, longitude]
+  properties:
+    latitude:
+      type: number
+      format: double
+      minimum: -90
+      maximum: 90
+      description: 緯度
+    longitude:
+      type: number
+      format: double
+      minimum: -180
+      maximum: 180
+      description: 経度

--- a/openapi/components/schemas/error.yml
+++ b/openapi/components/schemas/error.yml
@@ -1,0 +1,8 @@
+Error:
+  type: object
+  description: Error
+  required: [message]
+  properties:
+    message:
+      type: string
+      description: エラー内容

--- a/openapi/components/schemas/operation_history.yml
+++ b/openapi/components/schemas/operation_history.yml
@@ -1,0 +1,18 @@
+OperationHistory:
+  type: object
+  description: Routeへの操作履歴
+  required: [op_list, pos]
+  properties:
+    op_list:
+      type: array
+      items:
+        $ref: '#/Operation'
+      description: 操作のリスト
+    pos:
+      type: number
+      description: 現在op_listのどこにいるか(redo/undo)
+
+Operation:
+  type: string
+  description: Routeへの操作
+  example: まだschema検討中

--- a/openapi/components/schemas/route.yml
+++ b/openapi/components/schemas/route.yml
@@ -1,0 +1,19 @@
+Route:
+  type: object
+  description: Route
+  required: [id, name]
+  properties:
+    id:
+      type: string
+      description: RouteId
+    name:
+      type: string
+      maxLength: 50
+      description: ルートの名前
+    polyline:
+      type: array
+      items:
+        $ref: ./coordinate.yml#/Coordinate
+      description: ルート上の座標のリスト
+    operation_history:
+      $ref: ./operation_history.yml#/OperationHistory

--- a/openapi/components/schemas/route_create.yml
+++ b/openapi/components/schemas/route_create.yml
@@ -1,0 +1,18 @@
+RouteCreateRequest:
+  type: object
+  description: Route作成リクエスト
+  required: [name]
+  properties:
+    name:
+      type: string
+      maxLength: 50
+      description: Routeの名前
+
+RouteCreateResponse:
+  type: object
+  description: Route作成レスポンス
+  required: [id]
+  properties:
+    id:
+      type: string
+      description: 作成したRouteのID

--- a/openapi/components/schemas/route_edit.yml
+++ b/openapi/components/schemas/route_edit.yml
@@ -1,0 +1,10 @@
+RouteEditResponse:
+  type: object
+  description: Route編集レスポンス
+  required: [points]
+  properties:
+    points:
+      type: array
+      items:
+        $ref: ./coordinate.yml#/Coordinate
+      description: 編集後のルート上の座標のリスト

--- a/openapi/paths/routes.yml
+++ b/openapi/paths/routes.yml
@@ -1,0 +1,18 @@
+post:
+  operationId: routesPost
+  summary: Routeの作成
+  tags: [route]
+  requestBody:
+    description: Routeの情報
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/route_create.yml#/RouteCreateRequest
+  responses:
+    201:
+      description: created
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/route_create.yml#/RouteCreateResponse

--- a/openapi/paths/routes_add.yml
+++ b/openapi/paths/routes_add.yml
@@ -1,0 +1,33 @@
+patch:
+  operationId: routesAdd
+  summary: 新たな点の追加
+  tags: [route]
+  parameters:
+    - $ref: ../components/parameters/route_id.yml
+    - $ref: ../components/parameters/pos.yml
+  requestBody:
+    description: ルートの情報
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          description: 追加したい点の情報
+          required: [coord]
+          properties:
+            coord:
+              $ref: ../components/schemas/coordinate.yml#/Coordinate
+  responses:
+    200:
+      description: 更新成功
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/route_edit.yml#/RouteEditResponse
+    400:
+      description: |
+        更新失敗、posの値がRouteの長さより長い場合など
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/error.yml#/Error

--- a/openapi/paths/routes_by_id.yml
+++ b/openapi/paths/routes_by_id.yml
@@ -1,0 +1,13 @@
+get:
+  operationId: routesGet
+  summary: Routeの取得
+  tags: [route]
+  parameters:
+    - $ref: ../components/parameters/route_id.yml
+  responses:
+    200:
+      description: ok
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/route.yml#/Route

--- a/openapi/paths/routes_clear.yml
+++ b/openapi/paths/routes_clear.yml
@@ -1,0 +1,13 @@
+patch:
+  operationId: routesClear
+  summary: 点のクリア
+  tags: [route]
+  parameters:
+    - $ref: ../components/parameters/route_id.yml
+  responses:
+    200:
+      description: 更新成功
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/route_edit.yml#/RouteEditResponse

--- a/openapi/paths/routes_redo.yml
+++ b/openapi/paths/routes_redo.yml
@@ -1,0 +1,20 @@
+patch:
+  operationId: routesRedo
+  summary: 操作を進む
+  tags: [route]
+  parameters:
+    - $ref: ../components/parameters/route_id.yml
+  responses:
+    200:
+      description: 更新成功
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/route_edit.yml#/RouteEditResponse
+    400:
+      description: |
+        更新失敗、これ以上redoできない場合など
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/error.yml#/Error

--- a/openapi/paths/routes_remove.yml
+++ b/openapi/paths/routes_remove.yml
@@ -1,0 +1,21 @@
+patch:
+  operationId: routesRemove
+  summary: 点の削除
+  tags: [route]
+  parameters:
+    - $ref: ../components/parameters/route_id.yml
+    - $ref: ../components/parameters/pos.yml
+  responses:
+    200:
+      description: 更新成功
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/route_edit.yml#/RouteEditResponse
+    400:
+      description: |
+        更新失敗、posの値がRouteの長さより長い場合など
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/error.yml#/Error

--- a/openapi/paths/routes_undo.yml
+++ b/openapi/paths/routes_undo.yml
@@ -1,0 +1,20 @@
+patch:
+  operationId: routesUndo
+  summary: 操作を戻る
+  tags: [route]
+  parameters:
+    - $ref: ../components/parameters/route_id.yml
+  responses:
+    200:
+      description: 更新成功
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/route_edit.yml#/RouteEditResponse
+    400:
+      description: |
+        更新失敗、これ以上undoできない場合など
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/error.yml#/Error

--- a/openapi/root.yml
+++ b/openapi/root.yml
@@ -1,0 +1,29 @@
+openapi: 3.0.3
+info:
+  title: RouteBucketBackend
+  description: RouteBucketBackend
+  version: 1.0.0
+
+servers:
+  - url: 'http://localhost:8080/'
+    description: development
+
+tags:
+  - name: route
+    description: ルートに関するエンドポイントたち
+
+paths:
+  /routes/:
+    $ref: ./paths/routes.yml
+  /routes/{id}:
+    $ref: ./paths/routes_by_id.yml
+  /routes/{id}/add/{pos}:
+    $ref: ./paths/routes_add.yml
+  /routes/{id}/remove/{pos}:
+    $ref: ./paths/routes_remove.yml
+  /routes/{id}/clear/:
+    $ref: ./paths/routes_clear.yml
+  /routes/{id}/redo/:
+    $ref: ./paths/routes_redo.yml
+  /routes/{id}/undo/:
+    $ref: ./paths/routes_undo.yml

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use diesel::r2d2::{ConnectionManager, Pool};
 use dotenv::dotenv;
 use once_cell::sync::Lazy;
 
+use actix_cors::Cors;
 use route_bucket_backend::controller::route::{BuildService, RouteController};
 use route_bucket_backend::infrastructure::repository::route::RouteRepositoryMysql;
 use route_bucket_backend::usecase::route::RouteUseCase;
@@ -45,6 +46,8 @@ async fn main() -> Result<(), Error> {
 
     HttpServer::new(move || {
         App::new()
+            // TODO: swagger以外からのアクセス(or development以外の環境)ではcorsを避けたい
+            .wrap(Cors::permissive())
             .wrap(Logger::new("%a \"%r\" %s (%T s)"))
             .service(ROUTE_CONTROLLER.build_service())
     })


### PR DESCRIPTION
* [OpenAPI spec](https://swagger.io/specification/)を用いてドキュメントを作った(`openapi/*.yml`)
* SwaggerUIで↑を表示できるようにした（使い方は[README.md](https://github.com/team-azb/route-bucket-backend/blob/feature/documentation/README.md#documentation)参照）
  * UI上にある`Try it out`からリクエストたたけて、curlする必要なくなる
    * これをローカルでできるか試して欲しい
* ↑の`Try it out`機能のために、一旦APIのCORSの制限を外した
  * リリースまでにどうにかする