### PR TITLE
点の移動操作の追加

### DIFF
--- a/insert_seed_data.sh
+++ b/insert_seed_data.sh
@@ -1,4 +1,4 @@
 DOCKER_BUILDKIT=1 \
 COMPOSE_DOCKER_CLI_BUILD=1 \
 BUILDKIT_PROGRESS=plain \
-docker-compose run api /app/bin/release/seed
+docker-compose run api /app/target/release/seed

--- a/openapi/paths/routes_move.yml
+++ b/openapi/paths/routes_move.yml
@@ -1,0 +1,33 @@
+patch:
+  operationId: routesMove
+  summary: 指定した点の座標の変更
+  tags: [route]
+  parameters:
+    - $ref: ../components/parameters/route_id.yml
+    - $ref: ../components/parameters/pos.yml
+  requestBody:
+    description: ルートの情報
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          description: 変更したい点の新しい座標
+          required: [coord]
+          properties:
+            coord:
+              $ref: ../components/schemas/coordinate.yml#/Coordinate
+  responses:
+    200:
+      description: 更新成功
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/route_edit.yml#/RouteEditResponse
+    400:
+      description: |
+        更新失敗、posの値がRouteの長さ以上の場合など
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/error.yml#/Error

--- a/openapi/paths/routes_move.yml
+++ b/openapi/paths/routes_move.yml
@@ -1,6 +1,7 @@
 patch:
   operationId: routesMove
-  summary: 指定した点の座標の変更
+  summary: 点の座標の変更
+  description: route_idに対応するRouteのpos番目の点の座標を変更する
   tags: [route]
   parameters:
     - $ref: ../components/parameters/route_id.yml

--- a/openapi/root.yml
+++ b/openapi/root.yml
@@ -21,6 +21,8 @@ paths:
     $ref: ./paths/routes_add.yml
   /routes/{id}/remove/{pos}:
     $ref: ./paths/routes_remove.yml
+  /routes/{id}/move/{pos}:
+    $ref: ./paths/routes_move.yml
   /routes/{id}/clear/:
     $ref: ./paths/routes_clear.yml
   /routes/{id}/redo/:

--- a/src/infrastructure/dto/operation.rs
+++ b/src/infrastructure/dto/operation.rs
@@ -35,6 +35,10 @@ impl OperationDto {
                 pos_op = Some(*pos);
                 polyline = Polyline::from_vec(vec![coord.clone()]);
             }
+            Operation::Move { pos, from, to } => {
+                pos_op = Some(*pos);
+                polyline = Polyline::from_vec(vec![from.clone(), to.clone()]);
+            }
             Operation::Clear { org_list: list } | Operation::InitWithList { list } => {
                 pos_op = None;
                 polyline = list.clone();

--- a/src/usecase/route.rs
+++ b/src/usecase/route.rs
@@ -43,17 +43,16 @@ impl<R: RouteRepository> RouteUseCase<R> {
         coord: Option<Coordinate>,
     ) -> ApplicationResult<RouteOperationResponse> {
         let mut route = self.repository.find(route_id)?;
+
+        let coord_vec = coord.map_or(vec![], |coord| vec![coord]);
+        let pos_vec = pos.map_or(Ok(vec![]), |pos| {
+            Ok(vec![route.polyline().get(pos)?.clone()])
+        })?;
+
         let op_polyline = match op_code {
-            "add" => {
-                let vec = coord.map_or(vec![], |coord| vec![coord]);
-                Polyline::from_vec(vec)
-            }
-            "rm" => {
-                let vec = pos.map_or(Ok(vec![]), |pos| {
-                    Ok(vec![route.polyline().get(pos)?.clone()])
-                })?;
-                Polyline::from_vec(vec)
-            }
+            "add" => Polyline::from_vec(coord_vec),
+            "rm" => Polyline::from_vec(pos_vec),
+            "mv" => Polyline::from_vec([pos_vec, coord_vec].concat()),
             "clear" => route.polyline().clone(),
             _ => {
                 return Err(ApplicationError::UseCaseError(format!(
@@ -108,7 +107,7 @@ pub struct RouteCreateResponse {
 
 #[derive(Getters, Deserialize)]
 #[get = "pub"]
-pub struct AddPointRequest {
+pub struct NewPointRequest {
     coord: Coordinate,
 }
 

--- a/src/usecase/route.rs
+++ b/src/usecase/route.rs
@@ -49,7 +49,9 @@ impl<R: RouteRepository> RouteUseCase<R> {
                 Polyline::from_vec(vec)
             }
             "rm" => {
-                let vec = pos.map_or(vec![], |pos| vec![route.polyline()[pos].clone()]);
+                let vec = pos.map_or(Ok(vec![]), |pos| {
+                    Ok(vec![route.polyline().get(pos)?.clone()])
+                })?;
                 Polyline::from_vec(vec)
             }
             "clear" => route.polyline().clone(),


### PR DESCRIPTION
Closes #27 
* `PATCH routes/{id}/move/{pos}`を追加した
* これに伴い、`Operation::Move`を追加した
* ついでに`Polyline`でVecの関数を使えなくし（外から勝手にいじれないように）、代わりに`get`や`replace`を追加した
* insert_seed_data.shがバグってたので直した