### PR TITLE
ルート一覧画面周辺のエンドポイントたち

### DIFF
--- a/openapi/components/schemas/polyline.yml
+++ b/openapi/components/schemas/polyline.yml
@@ -1,0 +1,6 @@
+Polyline:
+  type: string
+  description: |
+    Polyline形式で表現された座標のリスト
+    参考：https://developers.google.com/maps/documentation/utilities/polylinealgorithm
+  example: _p~iF~ps|U_ulLnnqC_mqNvxq`@

--- a/openapi/components/schemas/route.yml
+++ b/openapi/components/schemas/route.yml
@@ -11,9 +11,7 @@ Route:
       maxLength: 50
       description: ルートの名前
     polyline:
-      type: array
-      items:
-        $ref: ./coordinate.yml#/Coordinate
+      $ref: ./polyline.yml#/Polyline
       description: ルート上の座標のリスト
     operation_history:
       $ref: ./operation_history.yml#/OperationHistory

--- a/openapi/components/schemas/route_edit.yml
+++ b/openapi/components/schemas/route_edit.yml
@@ -3,8 +3,5 @@ RouteEditResponse:
   description: Route編集レスポンス
   required: [points]
   properties:
-    points:
-      type: array
-      items:
-        $ref: ./coordinate.yml#/Coordinate
-      description: 編集後のルート上の座標のリスト
+    polyline:
+      $ref: ./polyline.yml#/Polyline

--- a/openapi/components/schemas/route_rename.yml
+++ b/openapi/components/schemas/route_rename.yml
@@ -1,0 +1,8 @@
+RouteRenameRequest:
+  type: object
+  description: Route改名リクエスト
+  required: [name]
+  properties:
+    name:
+      type: string
+      description: 変更したい名前

--- a/openapi/paths/routes.yml
+++ b/openapi/paths/routes.yml
@@ -1,3 +1,21 @@
+get:
+  operationId: routesGetAll
+  summary: 全Route一覧の表示
+  tags: [route]
+  responses:
+    200:
+      description: ok
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [routes]
+            properties:
+              routes:
+                type: array
+                items:
+                  $ref: ../components/schemas/route.yml#/Route
+
 post:
   operationId: routesPost
   summary: Routeの作成

--- a/openapi/paths/routes_by_id.yml
+++ b/openapi/paths/routes_by_id.yml
@@ -11,3 +11,13 @@ get:
         application/json:
           schema:
             $ref: ../components/schemas/route.yml#/Route
+
+delete:
+  operationId: routesDelete
+  summary: Routeの削除
+  tags: [route]
+  parameters:
+    - $ref: ../components/parameters/route_id.yml
+  responses:
+    200:
+      description: ok

--- a/openapi/paths/routes_rename.yml
+++ b/openapi/paths/routes_rename.yml
@@ -1,0 +1,28 @@
+patch:
+  operationId: routesRename
+  summary: Routeの名前変更
+  description: |
+    指定したRouteの名前を変更する
+  tags: [route]
+  parameters:
+    - $ref: ../components/parameters/route_id.yml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/route_rename.yml#/RouteRenameRequest
+  responses:
+    200:
+      description: 更新成功
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/route.yml#/Route
+    404:
+      description: |
+        対応するRouteが存在しない場合
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/error.yml#/Error

--- a/openapi/root.yml
+++ b/openapi/root.yml
@@ -17,6 +17,8 @@ paths:
     $ref: ./paths/routes.yml
   /routes/{id}:
     $ref: ./paths/routes_by_id.yml
+  /routes/{id}/rename/:
+    $ref: ./paths/routes_rename.yml
   /routes/{id}/add/{pos}:
     $ref: ./paths/routes_add.yml
   /routes/{id}/remove/{pos}:

--- a/src/controller/route.rs
+++ b/src/controller/route.rs
@@ -20,6 +20,10 @@ impl<R: RouteRepository> RouteController<R> {
         Ok(HttpResponse::Ok().json(self.usecase.find(id.as_ref())?))
     }
 
+    async fn get_all(&self) -> Result<HttpResponse> {
+        Ok(HttpResponse::Ok().json(self.usecase.find_all()?))
+    }
+
     async fn post(&self, req: web::Json<RouteCreateRequest>) -> Result<HttpResponse> {
         Ok(HttpResponse::Created().json(self.usecase.create(&req)?))
     }
@@ -74,7 +78,11 @@ impl<R: RouteRepository> BuildService<Scope> for &'static Lazy<RouteController<R
         // TODO: /の過不足は許容する ex) "/{id}/"
         web::scope("/routes")
             .service(web::resource("/{id}").route(web::get().to(move |id| self.get(id))))
-            .service(web::resource("/").route(web::post().to(move |req| self.post(req))))
+            .service(
+                web::resource("/")
+                    .route(web::get().to(move || self.get_all()))
+                    .route(web::post().to(move |req| self.post(req))),
+            )
             .service(
                 web::resource("/{id}/rename/")
                     .route(web::patch().to(move |id, req| self.patch_rename(id, req))),

--- a/src/controller/route.rs
+++ b/src/controller/route.rs
@@ -3,7 +3,9 @@ use once_cell::sync::Lazy;
 
 use crate::domain::route::RouteRepository;
 use crate::domain::types::RouteId;
-use crate::usecase::route::{NewPointRequest, RouteCreateRequest, RouteUseCase};
+use crate::usecase::route::{
+    NewPointRequest, RouteCreateRequest, RouteRenameRequest, RouteUseCase,
+};
 
 pub struct RouteController<R: RouteRepository> {
     usecase: RouteUseCase<R>,
@@ -20,6 +22,14 @@ impl<R: RouteRepository> RouteController<R> {
 
     async fn post(&self, req: web::Json<RouteCreateRequest>) -> Result<HttpResponse> {
         Ok(HttpResponse::Created().json(self.usecase.create(&req)?))
+    }
+
+    async fn patch_rename(
+        &self,
+        id: web::Path<RouteId>,
+        req: web::Json<RouteRenameRequest>,
+    ) -> Result<HttpResponse> {
+        Ok(HttpResponse::Ok().json(self.usecase.rename(&id, &req)?))
     }
 
     async fn patch_new_point(
@@ -65,6 +75,10 @@ impl<R: RouteRepository> BuildService<Scope> for &'static Lazy<RouteController<R
         web::scope("/routes")
             .service(web::resource("/{id}").route(web::get().to(move |id| self.get(id))))
             .service(web::resource("/").route(web::post().to(move |req| self.post(req))))
+            .service(
+                web::resource("/{id}/rename/")
+                    .route(web::patch().to(move |id, req| self.patch_rename(id, req))),
+            )
             .service(
                 web::resource("/{id}/add/{pos}").route(
                     web::patch().to(move |path, req| self.patch_new_point(path, req, "add")),

--- a/src/domain/polyline.rs
+++ b/src/domain/polyline.rs
@@ -8,6 +8,7 @@ use std::convert::TryFrom;
 use std::iter::FromIterator;
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(into = "String")]
 pub struct Polyline(Vec<Coordinate>);
 
 impl Polyline {
@@ -93,6 +94,14 @@ impl Polyline {
             self.0 = points.0;
             Ok(())
         }
+    }
+}
+
+impl Into<String> for Polyline {
+    fn into(self) -> String {
+        // Coordinateで範囲チェックしてるので
+        // encode_coordinatesのerrには引っかからないはず
+        self.encode().unwrap()
     }
 }
 

--- a/src/domain/route.rs
+++ b/src/domain/route.rs
@@ -53,4 +53,6 @@ pub trait RouteRepository {
     fn register(&self, route: &Route) -> ApplicationResult<()>;
 
     fn update(&self, route: &Route) -> ApplicationResult<()>;
+
+    fn delete(&self, id: &RouteId) -> ApplicationResult<()>;
 }

--- a/src/domain/route.rs
+++ b/src/domain/route.rs
@@ -30,6 +30,10 @@ impl Route {
         }
     }
 
+    pub fn rename(&mut self, name: &String) {
+        self.name = name.clone();
+    }
+
     pub fn push_operation(&mut self, op: Operation) -> ApplicationResult<()> {
         self.operation_history.push(op, &mut self.polyline)
     }

--- a/src/domain/route.rs
+++ b/src/domain/route.rs
@@ -48,6 +48,8 @@ impl Route {
 pub trait RouteRepository {
     fn find(&self, id: &RouteId) -> ApplicationResult<Route>;
 
+    fn find_all(&self) -> ApplicationResult<Vec<Route>>;
+
     fn register(&self, route: &Route) -> ApplicationResult<()>;
 
     fn update(&self, route: &Route) -> ApplicationResult<()>;

--- a/src/infrastructure/repository/route.rs
+++ b/src/infrastructure/repository/route.rs
@@ -58,6 +58,7 @@ impl RouteRepository for RouteRepositoryMysql {
                 })
             })?;
 
+        // TODO: OperationRepositoryとして分離する
         let op_dtos = OperationDto::belonging_to(&route_dto)
             .order(schema::operations::index.asc())
             .load(&conn)
@@ -68,6 +69,23 @@ impl RouteRepository for RouteRepositoryMysql {
             })?;
 
         Ok(route_dto.to_model(op_dtos)?)
+    }
+
+    fn find_all(&self) -> ApplicationResult<Vec<Route>> {
+        let conn = self.get_connection()?;
+
+        let route_dtos = RouteDto::table().load::<RouteDto>(&conn).or_else(|_| {
+            Err(ApplicationError::DataBaseError(
+                "Failed to load from Routes!".into(),
+            ))
+        })?;
+
+        // TODO: Routeじゃなく、RouteProfile的なOperationHistoryを抜いたstructを返す
+        //     : ここではOperationを空のままRouteにしてしまっている
+        Ok(route_dtos
+            .iter()
+            .map(|dto| dto.to_model(Vec::new()))
+            .collect::<ApplicationResult<Vec<Route>>>()?)
     }
 
     fn register(&self, route: &Route) -> ApplicationResult<()> {

--- a/src/infrastructure/repository/route.rs
+++ b/src/infrastructure/repository/route.rs
@@ -102,6 +102,7 @@ impl RouteRepository for RouteRepositoryMysql {
                 ))
             })?;
 
+        // TODO: OperationRepositoryとして分離する
         diesel::insert_into(OperationDto::table())
             .values(op_dtos)
             .execute(&conn)
@@ -145,6 +146,31 @@ impl RouteRepository for RouteRepositoryMysql {
             .or_else(|_| {
                 Err(ApplicationError::DataBaseError(
                     "Failed to insert into Operations!".into(),
+                ))
+            })?;
+
+        Ok(())
+    }
+
+    fn delete(&self, route_id: &RouteId) -> ApplicationResult<()> {
+        let conn = self.get_connection()?;
+
+        let id_str = route_id.to_string();
+
+        diesel::delete(RouteDto::table().find(&id_str))
+            .execute(&conn)
+            .or_else(|_| {
+                Err(ApplicationError::DataBaseError(
+                    "Failed to delete Route!".into(),
+                ))
+            })?;
+
+        // TODO: OperationRepositoryとして分離する
+        diesel::delete(OperationDto::table().filter(schema::operations::route_id.eq(&id_str)))
+            .execute(&conn)
+            .or_else(|_| {
+                Err(ApplicationError::DataBaseError(
+                    "Failed to delete Operations!".into(),
                 ))
             })?;
 

--- a/src/usecase/route.rs
+++ b/src/usecase/route.rs
@@ -84,7 +84,7 @@ impl<R: RouteRepository> RouteUseCase<R> {
         self.repository.update(&route)?;
 
         Ok(RouteOperationResponse {
-            points: route.polyline().clone(),
+            polyline: route.polyline().clone(),
         })
     }
 
@@ -102,7 +102,7 @@ impl<R: RouteRepository> RouteUseCase<R> {
         self.repository.update(&route)?;
 
         Ok(RouteOperationResponse {
-            points: route.polyline().clone(),
+            polyline: route.polyline().clone(),
         })
     }
 
@@ -135,7 +135,7 @@ pub struct NewPointRequest {
 
 #[derive(Serialize)]
 pub struct RouteOperationResponse {
-    pub points: Polyline,
+    pub polyline: Polyline,
 }
 
 #[derive(Getters, Deserialize)]

--- a/src/usecase/route.rs
+++ b/src/usecase/route.rs
@@ -20,6 +20,12 @@ impl<R: RouteRepository> RouteUseCase<R> {
         self.repository.find(route_id)
     }
 
+    pub fn find_all(&self) -> ApplicationResult<RouteGetAllRequest> {
+        Ok(RouteGetAllRequest {
+            routes: self.repository.find_all()?,
+        })
+    }
+
     pub fn create(&self, req: &RouteCreateRequest) -> ApplicationResult<RouteCreateResponse> {
         let route = Route::new(
             RouteId::new(),
@@ -99,6 +105,11 @@ impl<R: RouteRepository> RouteUseCase<R> {
             points: route.polyline().clone(),
         })
     }
+}
+
+#[derive(Serialize)]
+pub struct RouteGetAllRequest {
+    pub routes: Vec<Route>,
 }
 
 #[derive(Getters, Deserialize)]

--- a/src/usecase/route.rs
+++ b/src/usecase/route.rs
@@ -105,6 +105,10 @@ impl<R: RouteRepository> RouteUseCase<R> {
             points: route.polyline().clone(),
         })
     }
+
+    pub fn delete(&self, route_id: &RouteId) -> ApplicationResult<()> {
+        self.repository.delete(route_id)
+    }
 }
 
 #[derive(Serialize)]

--- a/src/usecase/route.rs
+++ b/src/usecase/route.rs
@@ -35,6 +35,13 @@ impl<R: RouteRepository> RouteUseCase<R> {
         })
     }
 
+    pub fn rename(&self, route_id: &RouteId, req: &RouteRenameRequest) -> ApplicationResult<Route> {
+        let mut route = self.repository.find(route_id)?;
+        route.rename(req.name());
+        self.repository.update(&route)?;
+        Ok(route)
+    }
+
     pub fn edit(
         &self,
         op_code: &str,
@@ -114,4 +121,10 @@ pub struct NewPointRequest {
 #[derive(Serialize)]
 pub struct RouteOperationResponse {
     pub points: Polyline,
+}
+
+#[derive(Getters, Deserialize)]
+#[get = "pub"]
+pub struct RouteRenameRequest {
+    name: String,
 }


### PR DESCRIPTION
Closes #31 

* エンドポイントたちの追加
  * `PATCH routes/{id}/rename`
    * ルートの名前変更
  *  `GET routes/`
    * ルート一覧取得
  *  `DELETE routes/{id}`
    * ルート削除
* ルート操作時やルート取得時に座標の配列を返していたところを、polyline形式のstringに変更
  * **フロントの対応必要そう**
  * ちなみにレスポンスのOperationの部分はまだいじってないけど、今後ほぼ確実にいじる

エンドポイントごとにきれいにcommit分けられたので、commitごとに見ると良さそう