### PR TITLE
OSRMとの繋ぎ込み & Polylineのリファクタ

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,8 +12,8 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project 0.4.27",
- "tokio",
- "tokio-util",
+ "tokio 0.2.25",
+ "tokio-util 0.3.1",
 ]
 
 [[package]]
@@ -75,7 +75,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "fxhash",
- "h2",
+ "h2 0.2.7",
  "http",
  "httparse",
  "indexmap",
@@ -131,7 +131,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "smallvec",
- "tokio",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -147,11 +147,11 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "log",
- "mio",
+ "mio 0.6.23",
  "mio-uds",
  "num_cpus",
  "slab",
- "socket2",
+ "socket2 0.3.19",
 ]
 
 [[package]]
@@ -175,7 +175,7 @@ dependencies = [
  "actix-server",
  "actix-service",
  "log",
- "socket2",
+ "socket2 0.3.19",
 ]
 
 [[package]]
@@ -258,7 +258,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "socket2",
+ "socket2 0.3.19",
  "time",
  "tinyvec",
  "url 2.2.1",
@@ -502,12 +502,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chunked_transfer"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
-
-[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +532,22 @@ name = "copyless"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2df960f5d869b2dd8532793fde43eb5427cceb126c929747a26823ab0eeb536"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpuid-bool"
@@ -665,6 +675,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -856,7 +881,18 @@ checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -891,10 +927,29 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio",
- "tokio-util",
+ "tokio 0.2.25",
+ "tokio-util 0.3.1",
  "tracing",
  "tracing-futures",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
+dependencies = [
+ "bytes 1.0.1",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio 1.5.0",
+ "tokio-util 0.6.6",
+ "tracing",
 ]
 
 [[package]]
@@ -965,16 +1020,70 @@ dependencies = [
 ]
 
 [[package]]
-name = "httparse"
-version = "1.3.5"
+name = "http-body"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615caabe2c3160b313d52ccc905335f4ed5f10881dd63dc5699d47e90be85691"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
+dependencies = [
+ "bytes 1.0.1",
+ "http",
+ "pin-project-lite 0.2.4",
+]
+
+[[package]]
+name = "httparse"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
+
+[[package]]
+name = "httpdate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05842d0d43232b23ccb7060ecb0f0626922c21f30012e97b767b30afd4a5d4b9"
 
 [[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e5f105c494081baa3bf9e200b279e27ec1623895cd504c7dbef8d0b080fcf54"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.3",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project 1.0.5",
+ "socket2 0.4.0",
+ "tokio 1.5.0",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes 1.0.1",
+ "hyper",
+ "native-tls",
+ "tokio 1.5.0",
+ "tokio-native-tls",
+]
 
 [[package]]
 name = "idna"
@@ -1032,11 +1141,17 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7"
 dependencies = [
- "socket2",
+ "socket2 0.3.19",
  "widestring",
  "winapi 0.3.9",
- "winreg",
+ "winreg 0.6.2",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "itoa"
@@ -1046,9 +1161,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.49"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc15e39392125075f60c95ba416f5381ff6c3a948ff02ab12464715adf56c821"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1161,10 +1276,23 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow",
+ "miow 0.2.2",
  "net2",
  "slab",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
+dependencies = [
+ "libc",
+ "log",
+ "miow 0.3.7",
+ "ntapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1175,7 +1303,7 @@ checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
  "libc",
- "mio",
+ "mio 0.6.23",
 ]
 
 [[package]]
@@ -1188,6 +1316,15 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1210,6 +1347,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "net2"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,6 +1372,15 @@ checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
  "winapi 0.3.9",
 ]
 
@@ -1334,6 +1498,39 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b0d6fb7d80f877617dfcb014e605e2b5ab2fb0afdf27935219bb6bd984cb98"
+dependencies = [
+ "autocfg 1.0.1",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1495,9 +1692,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 dependencies = [
  "unicode-xid",
 ]
@@ -1553,11 +1750,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.2",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -1581,6 +1790,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.2",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1601,7 +1820,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+dependencies = [
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -1620,6 +1848,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1712,6 +1949,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2296f2fac53979e8ccbc4a1136b25dcefd37be9ed7e4a1f6b05a6029c84ff124"
+dependencies = [
+ "base64",
+ "bytes 1.0.1",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding 2.1.0",
+ "pin-project-lite 0.2.4",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio 1.5.0",
+ "tokio-native-tls",
+ "url 2.2.1",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.7.0",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,21 +2000,6 @@ checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
 dependencies = [
  "hostname",
  "quick-error",
-]
-
-[[package]]
-name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted",
- "web-sys",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1760,10 +2026,10 @@ dependencies = [
  "once_cell",
  "polyline",
  "r2d2",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror",
- "ureq",
 ]
 
 [[package]]
@@ -1794,23 +2060,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
-dependencies = [
- "base64",
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "scheduled-thread-pool"
@@ -1828,13 +2091,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "sct"
-version = "0.6.1"
+name = "security-framework"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+checksum = "3670b1d2fdf6084d192bc71ead7aabe6c06aa2ea3fbd9cc3ac111fa5c2b1bd84"
 dependencies = [
- "ring",
- "untrusted",
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1947,10 +2223,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.5.2"
+name = "socket2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -2018,13 +2298,27 @@ checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "rand 0.8.3",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2139,12 +2433,37 @@ dependencies = [
  "lazy_static",
  "libc",
  "memchr",
- "mio",
+ "mio 0.6.23",
  "mio-uds",
  "pin-project-lite 0.1.11",
  "signal-hook-registry",
  "slab",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
+dependencies = [
+ "autocfg 1.0.1",
+ "bytes 1.0.1",
+ "libc",
+ "memchr",
+ "mio 0.7.11",
+ "num_cpus",
+ "pin-project-lite 0.2.4",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio 1.5.0",
 ]
 
 [[package]]
@@ -2158,8 +2477,28 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.1.11",
- "tokio",
+ "tokio 0.2.25",
 ]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940a12c99365c31ea8dd9ba04ec1be183ffe4920102bb7122c2f515437601e8e"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite 0.2.4",
+ "tokio 1.5.0",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
@@ -2208,7 +2547,7 @@ dependencies = [
  "rand 0.7.3",
  "smallvec",
  "thiserror",
- "tokio",
+ "tokio 0.2.25",
  "url 2.2.1",
 ]
 
@@ -2228,9 +2567,15 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "thiserror",
- "tokio",
+ "tokio 0.2.25",
  "trust-dns-proto",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "typenum"
@@ -2269,30 +2614,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "ureq"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2475a6781e9bc546e7b64f4013d2f4032c8c6a40fcffd7c6f4ee734a890972ab"
-dependencies = [
- "base64",
- "chunked_transfer",
- "log",
- "once_cell",
- "rustls",
- "serde",
- "serde_json",
- "url 2.2.1",
- "webpki",
- "webpki-roots",
-]
-
-[[package]]
 name = "url"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2328,26 +2649,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.72"
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe8f61dba8e5d645a4d8132dc7a0a66861ed5e1045d2c0ed940fab33bac0fbe"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
  "cfg-if 1.0.0",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.72"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ceba58ff062da072c7cb4ba5b22a37f00a302483f7e2a6cdc18fedbdc1fd3"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2359,10 +2698,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.72"
+name = "wasm-bindgen-futures"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9aa01d36cda046f797c57959ff5f3c615c9cc63997a8d545831ec7976819b"
+checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2370,9 +2721,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.72"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96eb45c1b2ee33545a813a92dbb53856418bf7eb54ab34f7f7ff1448a5b3735d"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2383,37 +2734,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.72"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7148f4696fb4960a346eaa60bbfb42a1ac4ebba21f750f75fc1375b098d5ffa"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.49"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fe19d70f5dacc03f6e46777213facae5ac3801575d56ca6cbd4c93dcd12310"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
-dependencies = [
- "webpki",
 ]
 
 [[package]]
@@ -2470,6 +2802,15 @@ name = "winreg"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi 0.3.9",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,6 +502,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chunked_transfer"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
+
+[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,6 +1043,15 @@ name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
+name = "js-sys"
+version = "0.3.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc15e39392125075f60c95ba416f5381ff6c3a948ff02ab12464715adf56c821"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "kernel32-sys"
@@ -1707,6 +1722,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "robust"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,6 +1762,7 @@ dependencies = [
  "r2d2",
  "serde",
  "thiserror",
+ "ureq",
 ]
 
 [[package]]
@@ -1762,6 +1793,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1781,6 +1825,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "semver"
@@ -1890,6 +1944,12 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "stable_deref_trait"
@@ -2208,6 +2268,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "ureq"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2475a6781e9bc546e7b64f4013d2f4032c8c6a40fcffd7c6f4ee734a890972ab"
+dependencies = [
+ "base64",
+ "chunked_transfer",
+ "log",
+ "once_cell",
+ "rustls",
+ "serde",
+ "serde_json",
+ "url 2.2.1",
+ "webpki",
+ "webpki-roots",
+]
+
+[[package]]
 name = "url"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,9 +2334,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
+checksum = "8fe8f61dba8e5d645a4d8132dc7a0a66861ed5e1045d2c0ed940fab33bac0fbe"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -2260,9 +2344,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
+checksum = "046ceba58ff062da072c7cb4ba5b22a37f00a302483f7e2a6cdc18fedbdc1fd3"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2275,9 +2359,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
+checksum = "0ef9aa01d36cda046f797c57959ff5f3c615c9cc63997a8d545831ec7976819b"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2285,9 +2369,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
+checksum = "96eb45c1b2ee33545a813a92dbb53856418bf7eb54ab34f7f7ff1448a5b3735d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2298,9 +2382,38 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
+checksum = "b7148f4696fb4960a346eaa60bbfb42a1ac4ebba21f750f75fc1375b098d5ffa"
+
+[[package]]
+name = "web-sys"
+version = "0.3.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fe19d70f5dacc03f6e46777213facae5ac3801575d56ca6cbd4c93dcd12310"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+dependencies = [
+ "webpki",
+]
 
 [[package]]
 name = "widestring"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,6 +1761,7 @@ dependencies = [
  "polyline",
  "r2d2",
  "serde",
+ "serde_json",
  "thiserror",
  "ureq",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ num = "0.4.0"
 once_cell = "1.7.2"
 polyline = "0.9.0"
 r2d2 = "0.8.9"
+reqwest = { version = "0.11.3", features = ["blocking", "json"] }
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 thiserror = "1.0.24"
-ureq = { version = "2.1.0", features = ["json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ polyline = "0.9.0"
 r2d2 = "0.8.9"
 serde = { version = "1.0.124", features = ["derive"] }
 thiserror = "1.0.24"
+ureq = { version = "2.1.0", features = ["json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,6 @@ once_cell = "1.7.2"
 polyline = "0.9.0"
 r2d2 = "0.8.9"
 serde = { version = "1.0.124", features = ["derive"] }
+serde_json = "1.0.64"
 thiserror = "1.0.24"
 ureq = { version = "2.1.0", features = ["json"] }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     environment:
       DATABASE_URL: mysql://root:password@db:3306/route_bucket_db
       RUST_LOG: info
+      OSRM_ROOT: osrm
     command: >
       bash -c "
         ./wait_for_db.sh &&

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     environment:
       DATABASE_URL: mysql://root:password@db:3306/route_bucket_db
       RUST_LOG: info
-      OSRM_ROOT: osrm
+      OSRM_ROOT: http://osrm:5000
     command: >
       bash -c "
         ./wait_for_db.sh &&
@@ -35,8 +35,7 @@ services:
         /app/target/release/route-bucket-backend"
     depends_on:
       - db
-      # not yet
-      # - osrm
+      - osrm
 
   swagger:
     image: swaggerapi/swagger-ui:v3.45.1

--- a/docker/osrm.Dockerfile
+++ b/docker/osrm.Dockerfile
@@ -10,5 +10,5 @@ RUN mkdir /data && \
 
 # 地図データの前処理
 RUN osrm-extract -p /opt/bicycle.lua /data/map.osm.pbf && \
-    osrm-partition /data/map.osm.pbf && \
-    osrm-customize /data/map.osm.pbf
+    osrm-partition /data/map.osrm && \
+    osrm-customize /data/map.osrm

--- a/openapi/components/schemas/linestring.yml
+++ b/openapi/components/schemas/linestring.yml
@@ -1,0 +1,13 @@
+Waypoints:
+  type: array
+  items:
+    $ref: ./coordinate.yml#/Coordinate
+  description: |
+    ユーザーの入力した点の配列
+
+LineString:
+  type: array
+  items:
+    $ref: ./coordinate.yml#/Coordinate
+  description: |
+    waypointの間を補間した配列

--- a/openapi/components/schemas/route.yml
+++ b/openapi/components/schemas/route.yml
@@ -10,8 +10,25 @@ Route:
       type: string
       maxLength: 50
       description: ルートの名前
+    waypoints:
+      $ref: ./polyline.yml#/Polyline
+      description: ユーザーが打った点のリスト
+
+RouteWithPolyline:
+  type: object
+  description: Polyline付きのRoute
+  required: [ id, name ]
+  properties:
+    id:
+      type: string
+      description: RouteId
+    name:
+      type: string
+      maxLength: 50
+      description: ルートの名前
+    waypoints:
+      $ref: ./polyline.yml#/Polyline
+      description: ユーザーが打った点のリスト
     polyline:
       $ref: ./polyline.yml#/Polyline
       description: ルート上の座標のリスト
-    operation_history:
-      $ref: ./operation_history.yml#/OperationHistory

--- a/openapi/components/schemas/route.yml
+++ b/openapi/components/schemas/route.yml
@@ -1,7 +1,7 @@
 Route:
   type: object
   description: Route
-  required: [id, name]
+  required: [id, name, waypoints]
   properties:
     id:
       type: string
@@ -11,13 +11,12 @@ Route:
       maxLength: 50
       description: ルートの名前
     waypoints:
-      $ref: ./polyline.yml#/Polyline
-      description: ユーザーが打った点のリスト
+      $ref: ./linestring.yml#/Waypoints
 
 RouteWithPolyline:
   type: object
   description: Polyline付きのRoute
-  required: [ id, name ]
+  required: [ id, name, waypoints, linestring ]
   properties:
     id:
       type: string
@@ -27,8 +26,6 @@ RouteWithPolyline:
       maxLength: 50
       description: ルートの名前
     waypoints:
-      $ref: ./polyline.yml#/Polyline
-      description: ユーザーが打った点のリスト
-    polyline:
-      $ref: ./polyline.yml#/Polyline
-      description: ルート上の座標のリスト
+      $ref: ./linestring.yml#/Waypoints
+    linestring:
+      $ref: ./linestring.yml#/LineString

--- a/openapi/components/schemas/route_edit.yml
+++ b/openapi/components/schemas/route_edit.yml
@@ -1,9 +1,9 @@
 RouteEditResponse:
   type: object
   description: Route編集レスポンス
-  required: [waypoint, polyline]
+  required: [waypoints, linestring]
   properties:
-    waypoint:
-      $ref: ./polyline.yml#/Polyline
-    polyline:
-      $ref: ./polyline.yml#/Polyline
+    waypoints:
+      $ref: ./linestring.yml#/Waypoints
+    linestring:
+      $ref: ./linestring.yml#/LineString

--- a/openapi/components/schemas/route_edit.yml
+++ b/openapi/components/schemas/route_edit.yml
@@ -1,7 +1,9 @@
 RouteEditResponse:
   type: object
   description: Route編集レスポンス
-  required: [points]
+  required: [waypoint, polyline]
   properties:
+    waypoint:
+      $ref: ./polyline.yml#/Polyline
     polyline:
       $ref: ./polyline.yml#/Polyline

--- a/openapi/paths/routes_by_id.yml
+++ b/openapi/paths/routes_by_id.yml
@@ -12,7 +12,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/route.yml#/Route
+            $ref: ../components/schemas/route.yml#/RouteWithPolyline
 
 delete:
   operationId: routesDelete

--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -1,5 +1,5 @@
+use route_bucket_backend::domain::model::linestring::{Coordinate, LineString};
 use route_bucket_backend::domain::model::operation::Operation;
-use route_bucket_backend::domain::model::polyline::{Coordinate, Polyline};
 use route_bucket_backend::domain::model::route::{Route, RouteEditor};
 use route_bucket_backend::domain::model::types::RouteId;
 use route_bucket_backend::domain::service::route::RouteService;

--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -3,6 +3,7 @@ use route_bucket_backend::domain::model::operation::Operation;
 use route_bucket_backend::domain::model::route::{Route, RouteEditor};
 use route_bucket_backend::domain::model::types::RouteId;
 use route_bucket_backend::domain::service::route::RouteService;
+use route_bucket_backend::infrastructure::external::osrm::OsrmApi;
 use route_bucket_backend::infrastructure::repository::operation::OperationRepositoryMysql;
 use route_bucket_backend::infrastructure::repository::route::RouteRepositoryMysql;
 
@@ -12,12 +13,12 @@ macro_rules! coord {
     };
 }
 
-macro_rules! polyline {
+macro_rules! linestring {
     [] => {
-        Polyline::from_vec(vec![])
+        LineString::from(vec![])
     };
     [ $(($lat: expr, $lon: expr)),+ $(,)?] => {
-        Polyline::from_vec(vec![
+        LineString::from(vec![
             $(
                 coord!($lat, $lon),
             )+
@@ -30,37 +31,68 @@ fn main() {
 
     let route_repository = RouteRepositoryMysql::new();
     let op_repository = OperationRepositoryMysql::new();
-    let route_service = RouteService::new(route_repository, op_repository);
+    let osrm_api = OsrmApi::new();
+    let route_service = RouteService::new(route_repository, op_repository, osrm_api);
 
-    let sample1 = Route::new(RouteId::new(), &String::from("sample1"), polyline![], 0);
-    let sample2 = RouteEditor::new(
+    let sample1 = Route::new(RouteId::new(), &String::from("sample1"), linestring![], 0);
+    let sample2 = &mut RouteEditor::new(
         Route::new(
             RouteId::new(),
-            &"sample2".into(),
-            polyline![(0.0, 100.0), (10.0, 110.0), (20.0, 120.0)],
-            4,
+            &"sample2: 皇居ラン".into(),
+            linestring![],
+            0,
         ),
-        vec![
-            Operation::InitWithList {
-                list: polyline![(10.0, 110.0), (50.0, 150.0)],
-            },
-            Operation::Add {
-                pos: 0,
-                coord: coord!(0.0, 100.0),
-            },
-            Operation::Add {
-                pos: 2,
-                coord: coord!(20.0, 120.0),
-            },
-            Operation::Remove {
-                pos: 3,
-                coord: coord!(50.0, 150.0),
-            },
-            Operation::Clear {
-                org_list: polyline![(0.0, 100.0), (10.0, 110.0), (20.0, 120.0)],
-            },
-        ],
+        vec![],
     );
+    sample2
+        .push_operation(Operation::Add {
+            pos: 0,
+            coord: coord!(35.68136, 139.75875),
+        })
+        .unwrap();
+    sample2
+        .push_operation(Operation::Add {
+            pos: 1,
+            coord: coord!(35.69053, 139.75681),
+        })
+        .unwrap();
+    sample2
+        .push_operation(Operation::Add {
+            pos: 2,
+            coord: coord!(35.69510, 139.75139),
+        })
+        .unwrap();
+    sample2
+        .push_operation(Operation::Add {
+            pos: 3,
+            coord: coord!(35.68942, 139.74547),
+        })
+        .unwrap();
+    sample2
+        .push_operation(Operation::Add {
+            pos: 4,
+            coord: coord!(35.68418, 139.74424),
+        })
+        .unwrap();
+    sample2
+        .push_operation(Operation::Add {
+            pos: 5,
+            coord: coord!(35.68136, 139.75875),
+        })
+        .unwrap();
+    sample2
+        .push_operation(Operation::Clear {
+            org_list: linestring![
+                (35.68136, 139.75875),
+                (35.69053, 139.75681),
+                (35.69510, 139.75139),
+                (35.68942, 139.74547),
+                (35.68418, 139.74424),
+                (35.68136, 139.75875)
+            ],
+        })
+        .unwrap();
+    sample2.undo_operation().unwrap();
 
     route_service.register_route(&sample1).unwrap();
     log::info!("Route {} added!", sample1.id());

--- a/src/controller/route.rs
+++ b/src/controller/route.rs
@@ -2,18 +2,23 @@ use actix_web::{dev, web, HttpResponse, Result, Scope};
 use once_cell::sync::Lazy;
 
 use crate::domain::model::operation::OperationRepository;
-use crate::domain::model::route::RouteRepository;
+use crate::domain::model::route::{RouteInterpolationApi, RouteRepository};
 use crate::domain::model::types::RouteId;
 use crate::usecase::route::{
     NewPointRequest, RouteCreateRequest, RouteRenameRequest, RouteUseCase,
 };
 
-pub struct RouteController<R: RouteRepository, O: OperationRepository> {
-    usecase: RouteUseCase<R, O>,
+pub struct RouteController<R, O, I> {
+    usecase: RouteUseCase<R, O, I>,
 }
 
-impl<R: RouteRepository, O: OperationRepository> RouteController<R, O> {
-    pub fn new(usecase: RouteUseCase<R, O>) -> Self {
+impl<R, I, O> RouteController<R, O, I>
+where
+    R: RouteRepository,
+    O: OperationRepository,
+    I: RouteInterpolationApi,
+{
+    pub fn new(usecase: RouteUseCase<R, O, I>) -> Self {
         Self { usecase }
     }
 
@@ -79,8 +84,8 @@ pub trait BuildService<S: dev::HttpServiceFactory + 'static> {
     fn build_service(self) -> S;
 }
 
-impl<R: RouteRepository, O: OperationRepository> BuildService<Scope>
-    for &'static Lazy<RouteController<R, O>>
+impl<R: RouteRepository, O: OperationRepository, I: RouteInterpolationApi> BuildService<Scope>
+    for &'static Lazy<RouteController<R, O, I>>
 {
     fn build_service(self) -> Scope {
         // TODO: /の過不足は許容する ex) "/{id}/"

--- a/src/domain/model/linestring.rs
+++ b/src/domain/model/linestring.rs
@@ -87,6 +87,7 @@ impl TryFrom<geo::LineString<f64>> for LineString {
             .into_iter()
             .map(|coord| Coordinate::new(coord.y, coord.x))
             .collect::<ApplicationResult<Vec<_>>>()
+            .map(LineString::from)
     }
 }
 
@@ -108,7 +109,7 @@ impl TryFrom<Polyline> for LineString {
     type Error = ApplicationError;
 
     fn try_from(value: Polyline) -> Result<Self, Self::Error> {
-        let line_str = decode_polyline(value.into(), 5).map_err(|err| {
+        let line_str = decode_polyline(&String::from(value), 5).map_err(|err| {
             ApplicationError::DomainError(format!("failed to encode polyline: {}", err))
         })?;
         LineString::try_from(line_str)

--- a/src/domain/model/linestring.rs
+++ b/src/domain/model/linestring.rs
@@ -7,7 +7,6 @@ use std::convert::TryFrom;
 use std::iter::FromIterator;
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(into = "Polyline")]
 pub struct LineString(Vec<Coordinate>);
 
 impl LineString {

--- a/src/domain/model/mod.rs
+++ b/src/domain/model/mod.rs
@@ -1,4 +1,4 @@
+pub mod linestring;
 pub mod operation;
-pub mod polyline;
 pub mod route;
 pub mod types;

--- a/src/domain/model/operation.rs
+++ b/src/domain/model/operation.rs
@@ -149,13 +149,13 @@ impl TryFrom<OperationStruct> for Operation {
                 pos: value.pos.ok_or(ApplicationError::DomainError(
                     "No pos given for Operation::Add".into(),
                 ))?,
-                coord: value.polyline.get(0)?.clone(),
+                coord: value.polyline.get(1)?.clone(),
             },
             "rm" => Operation::Remove {
                 pos: value.pos.ok_or(ApplicationError::DomainError(
                     "No pos given for Operation::Remove".into(),
                 ))?,
-                coord: value.polyline.get(1)?.clone(),
+                coord: value.polyline.get(0)?.clone(),
             },
             "mv" => Operation::Move {
                 pos: value.pos.ok_or(ApplicationError::DomainError(

--- a/src/domain/model/operation.rs
+++ b/src/domain/model/operation.rs
@@ -62,24 +62,16 @@ impl Operation {
     }
 
     pub fn reverse(&self) -> Operation {
-        match self {
-            Self::Add { pos, coord } => Self::Remove {
-                pos: *pos,
-                coord: coord.clone(),
-            },
-            Self::Remove { pos, coord } => Self::Add {
-                pos: *pos,
-                coord: coord.clone(),
-            },
+        match self.clone() {
+            Self::Add { pos, coord } => Self::Remove { pos, coord },
+            Self::Remove { pos, coord } => Self::Add { pos, coord },
             Self::Move { pos, from, to } => Self::Move {
-                pos: *pos,
-                from: to.clone(),
-                to: from.clone(),
+                pos,
+                from: to,
+                to: from,
             },
-            Self::Clear { org_list: list } => Self::InitWithList { list: list.clone() },
-            Self::InitWithList { list } => Self::Clear {
-                org_list: list.clone(),
-            },
+            Self::Clear { org_list: list } => Self::InitWithList { list },
+            Self::InitWithList { list } => Self::Clear { org_list: list },
         }
     }
 }

--- a/src/domain/model/operation.rs
+++ b/src/domain/model/operation.rs
@@ -1,4 +1,4 @@
-use crate::domain::model::polyline::{Coordinate, Polyline};
+use crate::domain::model::linestring::{Coordinate, LineString};
 use crate::domain::model::types::RouteId;
 use crate::utils::error::{ApplicationError, ApplicationResult};
 use getset::Getters;
@@ -21,16 +21,16 @@ pub enum Operation {
         to: Coordinate,
     },
     Clear {
-        org_list: Polyline,
+        org_list: LineString,
     },
     // reverse operation for Clear
     InitWithList {
-        list: Polyline,
+        list: LineString,
     },
 }
 
 impl Operation {
-    pub fn apply(&self, polyline: &mut Polyline) -> ApplicationResult<()> {
+    pub fn apply(&self, polyline: &mut LineString) -> ApplicationResult<()> {
         match self {
             Self::Add { pos, coord } => Ok(polyline.insert(*pos, coord.clone())?),
             Self::Remove { pos, coord } => {
@@ -82,7 +82,7 @@ impl Operation {
 pub struct OperationStruct {
     code: String,
     pos: Option<usize>,
-    polyline: Polyline,
+    polyline: LineString,
 }
 
 impl OperationStruct {
@@ -91,7 +91,7 @@ impl OperationStruct {
         pos: Option<usize>,
         org_coord: Option<Coordinate>,
         new_coord: Option<Coordinate>,
-        polyline: Option<Polyline>,
+        polyline: Option<LineString>,
     ) -> ApplicationResult<Self> {
         let polyline = if vec!["clear", "init"].contains(&(&code as &str)) {
             polyline.ok_or(ApplicationError::DomainError(format!(
@@ -99,16 +99,14 @@ impl OperationStruct {
                 code
             )))?
         } else {
-            org_coord.map_or(
-                polyline.ok_or(ApplicationError::DomainError(
+            org_coord
+                .clone()
+                .or(new_coord.clone())
+                .map(|c1| LineString::from(vec![c1, new_coord.or(org_coord).unwrap()]))
+                .or(polyline)
+                .ok_or(ApplicationError::DomainError(
                     "Must give new_coord or org_coord or polyline for OperationStruct::new".into(),
-                ))?,
-                |c1| {
-                    new_coord
-                        .map_or(vec![c1.clone()], |c2| vec![c1.clone(), c2.clone()])
-                        .into()
-                },
-            )
+                ))?
         };
         Ok(Self {
             code,
@@ -157,7 +155,7 @@ impl TryFrom<OperationStruct> for Operation {
                 pos: value.pos.ok_or(ApplicationError::DomainError(
                     "No pos given for Operation::Remove".into(),
                 ))?,
-                coord: value.polyline.get(0)?.clone(),
+                coord: value.polyline.get(1)?.clone(),
             },
             "mv" => Operation::Move {
                 pos: value.pos.ok_or(ApplicationError::DomainError(

--- a/src/domain/model/route.rs
+++ b/src/domain/model/route.rs
@@ -89,3 +89,7 @@ pub trait RouteRepository {
 
     fn delete(&self, id: &RouteId) -> ApplicationResult<()>;
 }
+
+pub trait RouteInterpolationApi {
+    fn interpolate(&self, route: &Route) -> ApplicationResult<String>;
+}

--- a/src/domain/model/route.rs
+++ b/src/domain/model/route.rs
@@ -1,6 +1,7 @@
 use getset::Getters;
 use serde::{Deserialize, Serialize};
 
+use crate::domain::model::linestring::LineString;
 use crate::domain::model::operation::Operation;
 use crate::domain::model::polyline::Polyline;
 use crate::domain::model::types::RouteId;
@@ -19,7 +20,7 @@ impl RouteEditor {
     }
 
     pub fn push_operation(&mut self, op: Operation) -> ApplicationResult<()> {
-        op.apply(&mut self.route.polyline)?;
+        op.apply(&mut self.route.waypoints)?;
         // pos以降の要素は全て捨てる
         self.op_list.truncate(self.route.op_num);
         self.op_list.push(op);
@@ -29,7 +30,7 @@ impl RouteEditor {
 
     pub fn redo_operation(&mut self) -> ApplicationResult<()> {
         if self.route.op_num < self.op_list.len() {
-            self.op_list[self.route.op_num].apply(&mut self.route.polyline)?;
+            self.op_list[self.route.op_num].apply(&mut self.route.waypoints)?;
             self.route.op_num += 1;
             Ok(())
         } else {
@@ -44,7 +45,7 @@ impl RouteEditor {
             self.route.op_num -= 1;
             self.op_list[self.route.op_num]
                 .reverse()
-                .apply(&mut self.route.polyline)?;
+                .apply(&mut self.route.waypoints)?;
             Ok(())
         } else {
             Err(ApplicationError::InvalidOperation(
@@ -59,16 +60,16 @@ impl RouteEditor {
 pub struct Route {
     id: RouteId,
     name: String,
-    polyline: Polyline,
+    waypoints: LineString,
     op_num: usize,
 }
 
 impl Route {
-    pub fn new(id: RouteId, name: &String, polyline: Polyline, op_num: usize) -> Route {
+    pub fn new(id: RouteId, name: &String, waypoints: LineString, op_num: usize) -> Route {
         Route {
             id,
             name: name.clone(),
-            polyline,
+            waypoints,
             op_num,
         }
     }

--- a/src/domain/model/route.rs
+++ b/src/domain/model/route.rs
@@ -3,8 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::domain::model::linestring::LineString;
 use crate::domain::model::operation::Operation;
-use crate::domain::model::polyline::Polyline;
-use crate::domain::model::types::RouteId;
+use crate::domain::model::types::{Polyline, RouteId};
 use crate::utils::error::{ApplicationError, ApplicationResult};
 
 #[derive(Debug, Getters)]
@@ -92,5 +91,5 @@ pub trait RouteRepository {
 }
 
 pub trait RouteInterpolationApi {
-    fn interpolate(&self, route: &Route) -> ApplicationResult<String>;
+    fn interpolate(&self, route: &Route) -> ApplicationResult<Polyline>;
 }

--- a/src/domain/model/route.rs
+++ b/src/domain/model/route.rs
@@ -60,6 +60,7 @@ pub struct Route {
     id: RouteId,
     name: String,
     waypoints: LineString,
+    #[serde(skip_serializing)]
     op_num: usize,
 }
 

--- a/src/domain/model/types.rs
+++ b/src/domain/model/types.rs
@@ -25,6 +25,20 @@ impl RouteId {
     }
 }
 
+#[derive(Display, Debug, Clone, Serialize, Deserialize)]
+pub struct Polyline(String);
+
+impl From<String> for Polyline {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+impl From<Polyline> for String {
+    fn from(value: Polyline) -> Self {
+        value.0
+    }
+}
+
 pub type Latitude = NumericValueObject<f64, 90>;
 pub type Longitude = NumericValueObject<f64, 180>;
 

--- a/src/domain/model/types.rs
+++ b/src/domain/model/types.rs
@@ -28,6 +28,12 @@ impl RouteId {
 #[derive(Display, Debug, Clone, Serialize, Deserialize)]
 pub struct Polyline(String);
 
+impl Polyline {
+    pub fn new() -> Self {
+        Self(String::new())
+    }
+}
+
 impl From<String> for Polyline {
     fn from(value: String) -> Self {
         Self(value)

--- a/src/domain/service/route.rs
+++ b/src/domain/service/route.rs
@@ -1,18 +1,25 @@
 use crate::domain::model::operation::OperationRepository;
-use crate::domain::model::route::{Route, RouteEditor, RouteRepository};
-use crate::domain::model::types::RouteId;
+use crate::domain::model::route::{Route, RouteEditor, RouteInterpolationApi, RouteRepository};
+use crate::domain::model::types::{Polyline, RouteId};
 use crate::utils::error::ApplicationResult;
 
-pub struct RouteService<R: RouteRepository, O: OperationRepository> {
+pub struct RouteService<R, O, I> {
     route_repository: R,
     operation_repository: O,
+    interpolation_api: I,
 }
 
-impl<R: RouteRepository, O: OperationRepository> RouteService<R, O> {
-    pub fn new(route_repository: R, operation_repository: O) -> Self {
+impl<R, O, I> RouteService<R, O, I>
+where
+    R: RouteRepository,
+    O: OperationRepository,
+    I: RouteInterpolationApi,
+{
+    pub fn new(route_repository: R, operation_repository: O, interpolation_api: I) -> Self {
         Self {
             route_repository,
             operation_repository,
+            interpolation_api,
         }
     }
 
@@ -54,5 +61,9 @@ impl<R: RouteRepository, O: OperationRepository> RouteService<R, O> {
     pub fn delete_editor(&self, route_id: &RouteId) -> ApplicationResult<()> {
         self.route_repository.delete(route_id)?;
         self.operation_repository.delete_by_route_id(route_id)
+    }
+
+    pub fn interpolate_route(&self, route: &Route) -> ApplicationResult<Polyline> {
+        self.interpolation_api.interpolate(route)
     }
 }

--- a/src/infrastructure/dto/operation.rs
+++ b/src/infrastructure/dto/operation.rs
@@ -1,6 +1,5 @@
 use crate::domain::model::operation::{Operation, OperationStruct};
-use crate::domain::model::polyline::Polyline;
-use crate::domain::model::types::RouteId;
+use crate::domain::model::types::{Polyline, RouteId};
 use crate::infrastructure::dto::route::RouteDto;
 use crate::infrastructure::schema::operations;
 use crate::utils::error::ApplicationResult;
@@ -26,7 +25,7 @@ impl OperationDto {
             self.pos.map(|u| u as usize),
             None,
             None,
-            Some(Polyline::decode(&self.polyline)?),
+            Some(Polyline::from(self.polyline.clone()).try_into()?),
         )
         .map(OperationStruct::try_into)?
     }
@@ -42,7 +41,7 @@ impl OperationDto {
             index,
             code: opst.code().clone(),
             pos: opst.pos().clone().map(|u| u as u32),
-            polyline: opst.polyline().encode()?,
+            polyline: Polyline::from(opst.polyline().clone()).into(),
         })
     }
 }

--- a/src/infrastructure/dto/route.rs
+++ b/src/infrastructure/dto/route.rs
@@ -1,8 +1,8 @@
-use crate::domain::model::polyline::Polyline;
 use crate::domain::model::route::Route;
-use crate::domain::model::types::RouteId;
+use crate::domain::model::types::{Polyline, RouteId};
 use crate::infrastructure::schema::routes;
 use crate::utils::error::ApplicationResult;
+use std::convert::TryInto;
 
 /// ルートのdto構造体
 #[derive(Identifiable, Queryable, Insertable, Debug, AsChangeset)]
@@ -19,7 +19,7 @@ impl RouteDto {
         Ok(Route::new(
             RouteId::from_string(self.id.clone()),
             &self.name,
-            Polyline::decode(&self.polyline)?,
+            Polyline::from(self.polyline.clone()).try_into()?,
             self.operation_pos as usize,
         ))
     }
@@ -28,7 +28,7 @@ impl RouteDto {
         Ok(RouteDto {
             id: route.id().to_string(),
             name: route.name().clone(),
-            polyline: route.polyline().encode()?,
+            polyline: Polyline::from(route.waypoints().clone()).into(),
             operation_pos: *route.op_num() as u32,
         })
     }

--- a/src/infrastructure/external/mod.rs
+++ b/src/infrastructure/external/mod.rs
@@ -1,0 +1,1 @@
+pub mod osrm;

--- a/src/infrastructure/external/osrm.rs
+++ b/src/infrastructure/external/osrm.rs
@@ -20,13 +20,11 @@ impl RouteInterpolationApi for OsrmApi {
         let target_url = format!(
             "{}/route/v1/bike/polyline({})?overview=full",
             self.api_root,
-            Polyline::from(route.waypoints().clone()).into()
+            String::from(Polyline::from(route.waypoints().clone()))
         );
-        let result = ureq::get(&target_url)
-            .call()
-            .map(|resp| resp.into_json::<serde_json::Value>().unwrap())
+        let result = reqwest::blocking::get(&target_url)
+            .map(|resp| resp.json::<serde_json::Value>().unwrap())
             .map_or(Polyline::from(route.waypoints().clone()), |map| {
-                println!("{}", map);
                 Polyline::from(
                     serde_json::from_value::<String>(map["routes"][0]["geometry"].clone()).unwrap(),
                 )

--- a/src/infrastructure/external/osrm.rs
+++ b/src/infrastructure/external/osrm.rs
@@ -1,0 +1,33 @@
+use crate::domain::model::route::{Route, RouteInterpolationApi};
+use crate::utils::error::ApplicationResult;
+use std::collections::HashMap;
+
+/// osrmでルート補間をするための構造体
+pub struct OsrmApi {
+    api_root: String,
+}
+
+impl OsrmApi {
+    pub fn new() -> Self {
+        Self {
+            api_root: std::env::var("OSRM_ROOT").expect("OSRM_ROOT NOT FOUND"),
+        }
+    }
+}
+
+impl RouteInterpolationApi for OsrmApi {
+    fn interpolate(&self, route: &Route) -> ApplicationResult<String> {
+        let target_url = format!(
+            "{}/route/v1/bike/polyline({})?overview=full",
+            self.api_root,
+            route.polyline().encode()?
+        );
+        let resp = ureq::get(&target_url)
+            .call()
+            .unwrap()
+            .into_json::<HashMap<String, HashMap<String, String>>>()
+            .unwrap();
+        println!("{}", resp["routes"]["geometry"]);
+        todo!()
+    }
+}

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -1,3 +1,4 @@
 pub mod dto;
-pub mod schema;
+pub mod external;
 pub mod repository;
+pub mod schema;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use actix_web::{App, Error, HttpServer, Result};
 use once_cell::sync::Lazy;
 use route_bucket_backend::controller::route::{BuildService, RouteController};
 use route_bucket_backend::domain::service::route::RouteService;
+use route_bucket_backend::infrastructure::external::osrm::OsrmApi;
 use route_bucket_backend::infrastructure::repository::operation::OperationRepositoryMysql;
 use route_bucket_backend::infrastructure::repository::route::RouteRepositoryMysql;
 use route_bucket_backend::usecase::route::RouteUseCase;
@@ -17,7 +18,8 @@ use route_bucket_backend::usecase::route::RouteUseCase;
 //     })
 // }
 
-type StaticRouteController = Lazy<RouteController<RouteRepositoryMysql, OperationRepositoryMysql>>;
+type StaticRouteController =
+    Lazy<RouteController<RouteRepositoryMysql, OperationRepositoryMysql, OsrmApi>>;
 
 #[actix_rt::main]
 async fn main() -> Result<(), Error> {
@@ -27,7 +29,8 @@ async fn main() -> Result<(), Error> {
     static ROUTE_CONTROLLER: StaticRouteController = StaticRouteController::new(|| {
         let route_repository = RouteRepositoryMysql::new();
         let operation_repository = OperationRepositoryMysql::new();
-        let service = RouteService::new(route_repository, operation_repository);
+        let osrm_api = OsrmApi::new();
+        let service = RouteService::new(route_repository, operation_repository, osrm_api);
         let usecase = RouteUseCase::new(service);
         RouteController::new(usecase)
     });

--- a/src/usecase/route.rs
+++ b/src/usecase/route.rs
@@ -1,12 +1,12 @@
 use crate::domain::model::linestring::{Coordinate, LineString};
 use crate::domain::model::operation::{OperationRepository, OperationStruct};
 use crate::domain::model::route::{Route, RouteInterpolationApi, RouteRepository};
-use crate::domain::model::types::{Polyline, RouteId};
+use crate::domain::model::types::RouteId;
 use crate::domain::service::route::RouteService;
 use crate::utils::error::ApplicationResult;
 use getset::Getters;
 use serde::{Deserialize, Serialize};
-use std::convert::TryInto;
+use std::convert::{TryFrom, TryInto};
 
 pub struct RouteUseCase<R, O, I> {
     service: RouteService<R, O, I>,
@@ -25,7 +25,10 @@ where
     pub fn find(&self, route_id: &RouteId) -> ApplicationResult<RouteGetResponse> {
         let route = self.service.find_route(route_id)?;
         let polyline = self.service.interpolate_route(&route)?;
-        Ok(RouteGetResponse { route, polyline })
+        Ok(RouteGetResponse {
+            route,
+            linestring: LineString::try_from(polyline)?,
+        })
     }
 
     pub fn find_all(&self) -> ApplicationResult<RouteGetAllResponse> {
@@ -79,7 +82,7 @@ where
 
         Ok(RouteOperationResponse {
             waypoints: editor.route().waypoints().clone(),
-            polyline,
+            linestring: LineString::try_from(polyline)?,
         })
     }
 
@@ -99,7 +102,7 @@ where
 
         Ok(RouteOperationResponse {
             waypoints: editor.route().waypoints().clone(),
-            polyline,
+            linestring: LineString::try_from(polyline)?,
         })
     }
 
@@ -112,7 +115,7 @@ where
 pub struct RouteGetResponse {
     #[serde(flatten)]
     route: Route,
-    polyline: Polyline,
+    linestring: LineString,
 }
 
 #[derive(Serialize)]
@@ -140,7 +143,7 @@ pub struct NewPointRequest {
 #[derive(Serialize)]
 pub struct RouteOperationResponse {
     pub waypoints: LineString,
-    pub polyline: Polyline,
+    pub linestring: LineString,
 }
 
 #[derive(Getters, Deserialize)]

--- a/src/usecase/route.rs
+++ b/src/usecase/route.rs
@@ -75,9 +75,11 @@ where
         )?;
         editor.push_operation(opst.try_into()?)?;
         self.service.update_editor(&editor)?;
+        let polyline = self.service.interpolate_route(&editor.route())?;
 
         Ok(RouteOperationResponse {
-            polyline: editor.route().waypoints().clone(),
+            waypoints: editor.route().waypoints().clone(),
+            polyline,
         })
     }
 
@@ -93,9 +95,11 @@ where
             editor.undo_operation()?;
         }
         self.service.update_route(&editor.route())?;
+        let polyline = self.service.interpolate_route(&editor.route())?;
 
         Ok(RouteOperationResponse {
-            polyline: editor.route().waypoints().clone(),
+            waypoints: editor.route().waypoints().clone(),
+            polyline,
         })
     }
 
@@ -135,7 +139,8 @@ pub struct NewPointRequest {
 
 #[derive(Serialize)]
 pub struct RouteOperationResponse {
-    pub polyline: LineString,
+    pub waypoints: LineString,
+    pub polyline: Polyline,
 }
 
 #[derive(Getters, Deserialize)]


### PR DESCRIPTION
* **コンテナの情報が変わったので、`docker-compose down`必須**
* **APIの仕様変更あり**

* OSRMでルートを補間するようになった
  * `GET routes/{id}`と`PATCH`の各エンドポイントで、今までの`polyline`（ユーザーの打った点）を`waypoints`に改名し、OSRMで補間されたものを`polyline`とした
  * 今のところ補間されたpolylineはDBに入れず、毎回聞く実装になっている
  * 実装としては、repositoryと同じイメージで、domain層にインターフェスである`trait RouteInterpolationApi`を置き、infrastructure層にその実装である`struct OsrmApi`を置く形をとった
    * これにより、今後ORSに変えたいってなったときはinfrastructureだけいじれば良いはず
* `struct Polyline`の命名が厳しくなってきたので、`LineString`に改名し、これのエンコード先を`String`ではなくて`Polyline`クラスとした
  * `LineString`は`Vec<Coordinate>`をラップした構造体
  * `Polyline`は`LineString`から変換可能な`String`をラップした構造体