### PR TITLE
獲得標高の計算

### DIFF
--- a/openapi/components/schemas/elevation_gain.yml
+++ b/openapi/components/schemas/elevation_gain.yml
@@ -1,0 +1,4 @@
+ElevationGain:
+  type: integer
+  minimum: 0
+  description: 獲得標高

--- a/openapi/components/schemas/route.yml
+++ b/openapi/components/schemas/route.yml
@@ -16,7 +16,7 @@ Route:
 RouteWithPolyline:
   type: object
   description: Polyline付きのRoute
-  required: [ id, name, waypoints, linestring ]
+  required: [ id, name, waypoints, linestring, elevation_gain ]
   properties:
     id:
       type: string
@@ -29,3 +29,5 @@ RouteWithPolyline:
       $ref: ./linestring.yml#/Waypoints
     linestring:
       $ref: ./linestring.yml#/LineString
+    elevation_gain:
+      $ref: ./elevation_gain.yml#/ElevationGain

--- a/openapi/components/schemas/route_edit.yml
+++ b/openapi/components/schemas/route_edit.yml
@@ -1,9 +1,11 @@
 RouteEditResponse:
   type: object
   description: Route編集レスポンス
-  required: [waypoints, linestring]
+  required: [waypoints, linestring, elevation_gain]
   properties:
     waypoints:
       $ref: ./linestring.yml#/Waypoints
     linestring:
       $ref: ./linestring.yml#/LineString
+    elevation_gain:
+      $ref: ./elevation_gain.yml#/ElevationGain

--- a/src/domain/model/linestring.rs
+++ b/src/domain/model/linestring.rs
@@ -3,7 +3,8 @@ use crate::utils::error::{ApplicationError, ApplicationResult};
 use getset::Getters;
 use polyline::{decode_polyline, encode_coordinates};
 use serde::{Deserialize, Serialize};
-use std::convert::TryFrom;
+use std::cmp::max;
+use std::convert::{TryFrom, TryInto};
 use std::iter::FromIterator;
 use std::slice::{Iter, IterMut};
 
@@ -23,6 +24,20 @@ impl LineString {
                 "Index out of range in get.".into(),
             ))
         }
+    }
+
+    pub fn calc_elevation_gain(&self) -> ApplicationResult<Elevation> {
+        let mut gain = 0.try_into().unwrap();
+        let mut prev_elev = Elevation::max();
+
+        self.0.iter().for_each(|coord| {
+            if let Some(elev) = coord.elevation {
+                gain += max(elev - prev_elev, 0.try_into().unwrap());
+                prev_elev = elev;
+            }
+        });
+
+        Ok(gain)
     }
 
     pub fn replace(&mut self, i: usize, val: Coordinate) -> ApplicationResult<Coordinate> {

--- a/src/domain/model/types.rs
+++ b/src/domain/model/types.rs
@@ -1,8 +1,9 @@
-use derive_more::Display;
+use derive_more::{Add, AddAssign, Display, Sub};
 use nanoid::nanoid;
 use serde::{Deserialize, Serialize};
 
 use crate::utils::error::{ApplicationError, ApplicationResult};
+use num_traits::FromPrimitive;
 use std::convert::TryFrom;
 
 // TODO: Value Object用のderive macroを作る
@@ -50,12 +51,18 @@ pub type Longitude = NumericValueObject<f64, 180>;
 pub type Elevation = NumericValueObject<i32, { i32::MAX as u32 }>;
 
 /// Value Object for BigDecimal type
-#[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(
+    Add, AddAssign, Sub, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
 pub struct NumericValueObject<T, const MAX_ABS: u32>(T);
 
-impl<T: Copy, const MAX_ABS: u32> NumericValueObject<T, MAX_ABS> {
+impl<T: Copy + FromPrimitive, const MAX_ABS: u32> NumericValueObject<T, MAX_ABS> {
     pub fn value(&self) -> T {
         self.0
+    }
+
+    pub fn max() -> Self {
+        Self(T::from_u32(MAX_ABS).unwrap())
     }
 }
 


### PR DESCRIPTION
* #41 で追加した各点の標高情報をもとに、獲得標高を計算してレスポンスに加えるようにした
  * 具体的には、`LineString`に`calc_elevation_gain`というメソッドを追加し、それをusecaseから使うことで、レスポンスに載せる実装になっている
* 現状は単純に一点ずつ見て標高が増えたらその差分を足し算するというのをやっているだけなので、獲得標高が大きく出る可能性はあ
  * これがあまりに酷かったら移動平均とるなどする必要ありそう
