### PR TITLE
docker関連の細かい修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
   swagger:
     image: swaggerapi/swagger-ui:v3.45.1
     ports:
-      - "10080:8080"
+      - "4000:8080"
     volumes:
       - ./openapi/:/openapi/
     environment:

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -10,6 +10,9 @@ RUN apt update && \
     apt install -y default-mysql-client && \
     apt search caching-sha2-password
 
+# SRTM elevation data
+RUN ./docker/download_srtm_datas.sh
+
 WORKDIR app
 COPY . .
 COPY ./docker/wait_for_db.sh .
@@ -19,7 +22,7 @@ ENV TMP_DIR /tmp
 # dockerに依存ライブラリのバイナリをキャッシュさせるよう教える
 # これがないとコード変わるたびに毎回ライブラリのインストールから始まるらしい
 # 参考: https://qiita.com/_mkazutaka/items/c4b602327c2ff7913718
-# 普通に/app/target/にバイナリおくと何故か消える（これクソすぎる）ので、
+# 普通に/app/target/にバイナリおくと何故か消えるので、
 # 仮ディレクトリにコピーしてから戻す
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,sharing=private,target=/app/target \
@@ -29,5 +32,3 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cp -r ./target/* $TMP_DIR
 # 元の場所に戻す
 RUN mv -f $TMP_DIR/* ./target
-
-RUN ./docker/download_srtm_datas.sh

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -11,6 +11,7 @@ RUN apt update && \
     apt search caching-sha2-password
 
 # SRTM elevation data
+COPY docker docker
 RUN ./docker/download_srtm_datas.sh
 
 WORKDIR app

--- a/docker/download_srtm_datas.sh
+++ b/docker/download_srtm_datas.sh
@@ -1,3 +1,4 @@
+mkdir -p srtm_data
 cd srtm_data \
 && wget https://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_30x30/TIFF/N30E120.zip \
     -O srtm.zip \


### PR DESCRIPTION
* apiコンテナビルド時に、rustのコンパイル後にsrtmデータをダウンロードするようにしていたために、rustファイルが変更されるたびにダウンロードがやり直しになっていたのを直した
* swaggerの10080ポートは[どうやら使っちゃダメなやつだったっぽい](https://zenn.dev/ota42y/articles/127fee3353bafe)ので、4000に変更した
  * 参考: https://teratail.com/questions/70565#reply-111470