### PR TITLE
ユーザーが入力した座標の補正

### DIFF
--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -10,11 +10,12 @@ RUN apt update && \
     apt install -y default-mysql-client && \
     apt search caching-sha2-password
 
+WORKDIR app
+
 # SRTM elevation data
 COPY docker docker
 RUN ./docker/download_srtm_datas.sh
 
-WORKDIR app
 COPY . .
 COPY ./docker/wait_for_db.sh .
 

--- a/src/domain/model/linestring.rs
+++ b/src/domain/model/linestring.rs
@@ -87,6 +87,10 @@ impl LineString {
         }
     }
 
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
     pub fn iter(&self) -> Iter<Coordinate> {
         self.0.iter()
     }

--- a/src/domain/model/route.rs
+++ b/src/domain/model/route.rs
@@ -1,7 +1,7 @@
 use getset::Getters;
 use serde::{Deserialize, Serialize};
 
-use crate::domain::model::linestring::LineString;
+use crate::domain::model::linestring::{Coordinate, LineString};
 use crate::domain::model::operation::Operation;
 use crate::domain::model::types::{Polyline, RouteId};
 use crate::utils::error::{ApplicationError, ApplicationResult};
@@ -92,5 +92,7 @@ pub trait RouteRepository {
 }
 
 pub trait RouteInterpolationApi {
+    fn correct_coordinate(&self, coord: &Coordinate) -> ApplicationResult<Coordinate>;
+
     fn interpolate(&self, route: &Route) -> ApplicationResult<Polyline>;
 }

--- a/src/domain/service/route.rs
+++ b/src/domain/service/route.rs
@@ -1,4 +1,4 @@
-use crate::domain::model::linestring::{ElevationApi, LineString};
+use crate::domain::model::linestring::{Coordinate, ElevationApi, LineString};
 use crate::domain::model::operation::OperationRepository;
 use crate::domain::model::route::{Route, RouteEditor, RouteInterpolationApi, RouteRepository};
 use crate::domain::model::types::RouteId;
@@ -71,6 +71,10 @@ where
     pub fn delete_editor(&self, route_id: &RouteId) -> ApplicationResult<()> {
         self.route_repository.delete(route_id)?;
         self.operation_repository.delete_by_route_id(route_id)
+    }
+
+    pub fn correct_coordinate(&self, coord: &Coordinate) -> ApplicationResult<Coordinate> {
+        self.interpolation_api.correct_coordinate(coord)
     }
 
     pub fn interpolate_route(&self, route: &Route) -> ApplicationResult<LineString> {

--- a/src/infrastructure/external/osrm.rs
+++ b/src/infrastructure/external/osrm.rs
@@ -1,6 +1,7 @@
+use crate::domain::model::linestring::Coordinate;
 use crate::domain::model::route::{Route, RouteInterpolationApi};
 use crate::domain::model::types::Polyline;
-use crate::utils::error::ApplicationResult;
+use crate::utils::error::{ApplicationError, ApplicationResult};
 
 /// osrmでルート補間をするための構造体
 pub struct OsrmApi {
@@ -13,32 +14,62 @@ impl OsrmApi {
             api_root: std::env::var("OSRM_ROOT").expect("OSRM_ROOT NOT FOUND"),
         }
     }
+
+    fn request(
+        &self,
+        service: &str,
+        args: &String,
+    ) -> ApplicationResult<reqwest::blocking::Response> {
+        let target_url = format!("{}/{}/v1/bike/{}", self.api_root, service, args);
+        reqwest::blocking::get(target_url.clone()).map_err(|_| {
+            ApplicationError::ExternalError(format!("Failed to request {}", target_url))
+        })
+    }
+
+    fn resp_to_json(resp: reqwest::blocking::Response) -> ApplicationResult<serde_json::Value> {
+        let status = resp.status();
+        let url = resp.url().clone().into_string();
+        status
+            .is_success()
+            .then(|| resp.json::<serde_json::Value>().unwrap())
+            .ok_or(ApplicationError::ExternalError(format!(
+                "Got Unsuccessful status {} from {}",
+                status, url
+            )))
+    }
 }
 
 impl RouteInterpolationApi for OsrmApi {
-    fn interpolate(&self, route: &Route) -> ApplicationResult<Polyline> {
-        let target_url = format!(
-            "{}/route/v1/bike/polyline({})?overview=full",
-            self.api_root,
-            String::from(Polyline::from(route.waypoints().clone()))
-        );
-        let result = reqwest::blocking::get(target_url);
+    fn correct_coordinate(&self, coord: &Coordinate) -> ApplicationResult<Coordinate> {
+        let resp = self.request(
+            "nearest",
+            &format!("{},{}", coord.longitude().value(), coord.latitude().value()),
+        )?;
 
-        // まだif let から&&で繋げない(https://github.com/rust-lang/rust/issues/53667)
-        let polyline = if let Ok(resp) = result {
-            if resp.status().is_success() {
-                let json = resp.json::<serde_json::Value>().unwrap();
+        Self::resp_to_json(resp).map(|json| {
+            let coord =
+                serde_json::from_value::<Vec<f64>>(json["waypoints"][0]["location"].clone())
+                    .unwrap();
+            Coordinate::new(coord[1], coord[0]).unwrap()
+        })
+    }
+
+    fn interpolate(&self, route: &Route) -> ApplicationResult<Polyline> {
+        let resp = self.request(
+            "route",
+            &format!(
+                "polyline({})?overview=full",
+                String::from(Polyline::from(route.waypoints().clone()))
+            ),
+        )?;
+
+        Ok(
+            Self::resp_to_json(resp).map_or(Polyline::from(route.waypoints().clone()), |json| {
                 Polyline::from(
                     serde_json::from_value::<String>(json["routes"][0]["geometry"].clone())
                         .unwrap(),
                 )
-            } else {
-                Polyline::from(route.waypoints().clone())
-            }
-        } else {
-            Polyline::from(route.waypoints().clone())
-        };
-
-        Ok(polyline)
+            }),
+        )
     }
 }

--- a/src/usecase/route.rs
+++ b/src/usecase/route.rs
@@ -76,7 +76,10 @@ where
             op_code.into(),
             pos,
             org_coord,
-            new_coord,
+            // TODO: 道路外でも許容する場合（直線モードとか？）としない場合の区別をする
+            new_coord
+                .map(|coord| self.service.correct_coordinate(&coord))
+                .transpose()?,
             Some(org_polyline),
         )?;
         editor.push_operation(opst.try_into()?)?;


### PR DESCRIPTION
* 現状のAPIはユーザーが入力した座標をそのままDBに取り込んでいたが、これを一旦OSRMに渡して道路上の点へと補正してから取り込むこととした
  * [OSRMのnearest service](http://project-osrm.org/docs/v5.5.1/api/?language=cURL#nearest-service)を用いた
  * `PATCH routes/{id}/add`と`PATCH routes/{id}/move`にて発動する
* 今回は必ず補正を行うようにしているが、いずれ場合わけが必要になりそう（参考： #45） 