### PR TITLE
各点におけるスタートからの距離の計算

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,6 +553,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if 1.0.0",
+ "lazy_static",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,6 +1286,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg 1.0.1",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1855,6 +1908,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg 1.0.1",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1970,6 +2048,7 @@ dependencies = [
  "once_cell",
  "polyline",
  "r2d2",
+ "rayon",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ num-traits = "0.2.14"
 once_cell = "1.7.2"
 polyline = "0.9.0"
 r2d2 = "0.8.9"
+rayon = "1.5.1"
 reqwest = { version = "0.11.3", features = ["blocking", "json"] }
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"

--- a/openapi/components/schemas/coordinate.yml
+++ b/openapi/components/schemas/coordinate.yml
@@ -16,7 +16,7 @@ Coordinate:
       maximum: 180
       description: 経度
 
-CoordinateWithElevation:
+CoordinateVerbose:
   type: object
   description: 座標
   required: [latitude, longitude]
@@ -36,3 +36,7 @@ CoordinateWithElevation:
     elevation:
       type: integer
       description: 標高
+    distance_from_start:
+      type: number
+      format: double
+      description: ルートのスタート地点からの距離

--- a/openapi/components/schemas/linestring.yml
+++ b/openapi/components/schemas/linestring.yml
@@ -11,7 +11,7 @@ Segment:
     points:
       type: array
       items:
-        $ref: ./coordinate.yml#/CoordinateWithElevation
+        $ref: ./coordinate.yml#/CoordinateVerbose
     distance:
       type: number
       format: double

--- a/src/domain/model/types.rs
+++ b/src/domain/model/types.rs
@@ -1,10 +1,11 @@
+use std::convert::TryFrom;
+
 use derive_more::{Add, AddAssign, Display, From, Into, Sub};
 use nanoid::nanoid;
+use num_traits::{Bounded, FromPrimitive};
 use serde::{Deserialize, Serialize};
 
 use crate::utils::error::{ApplicationError, ApplicationResult};
-use num_traits::{Bounded, FromPrimitive};
-use std::convert::TryFrom;
 
 // TODO: Value Object用のderive macroを作る
 // ↓みたいな一要素のタプル構造体たちにfrom, valueをデフォルトで実装したい

--- a/src/domain/model/types.rs
+++ b/src/domain/model/types.rs
@@ -78,7 +78,7 @@ impl<const MAX_ABS: u32> TryFrom<f64> for NumericValueObject<f64, MAX_ABS> {
             Err(ApplicationError::ValueObjectError(format!(
                 // TODO: stringのconst genericsが追加されたら、
                 // メッセージに具体的なエイリアス名(Latitudeとか)を入れる
-                "Invalid value {} for BigDecimalValueObject<f64{}>",
+                "Invalid value {} for NumericValueObject<f64, {}>",
                 val,
                 MAX_ABS
             )))
@@ -97,7 +97,7 @@ impl<const MAX_ABS: u32> TryFrom<i32> for NumericValueObject<i32, MAX_ABS> {
             Err(ApplicationError::ValueObjectError(format!(
                 // TODO: stringのconst genericsが追加されたら、
                 // メッセージに具体的なエイリアス名(Latitudeとか)を入れる
-                "Invalid value {} for BigDecimalValueObject<i32, {}>",
+                "Invalid value {} for NumericValueObject<i32, {}>",
                 val,
                 MAX_ABS
             )))

--- a/src/domain/model/types.rs
+++ b/src/domain/model/types.rs
@@ -1,9 +1,9 @@
-use derive_more::{Add, AddAssign, Display, Sub};
+use derive_more::{Add, AddAssign, Display, From, Into, Sub};
 use nanoid::nanoid;
 use serde::{Deserialize, Serialize};
 
 use crate::utils::error::{ApplicationError, ApplicationResult};
-use num_traits::FromPrimitive;
+use num_traits::{Bounded, FromPrimitive};
 use std::convert::TryFrom;
 
 // TODO: Value Object用のderive macroを作る
@@ -26,7 +26,7 @@ impl RouteId {
     }
 }
 
-#[derive(Display, Debug, Clone, Serialize, Deserialize)]
+#[derive(Display, From, Into, Debug, Clone, Serialize, Deserialize)]
 pub struct Polyline(String);
 
 impl Polyline {
@@ -35,21 +35,12 @@ impl Polyline {
     }
 }
 
-impl From<String> for Polyline {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-impl From<Polyline> for String {
-    fn from(value: Polyline) -> Self {
-        value.0
-    }
-}
-
 pub type Latitude = NumericValueObject<f64, 90>;
 pub type Longitude = NumericValueObject<f64, 180>;
-pub type Elevation = NumericValueObject<i32, { i32::MAX as u32 }>;
-pub type Distance = NumericValueObject<f64, { f64::MAX as u32 }>;
+// NOTE: genericsの特殊化が実装されたら、この0は消せる
+// 参考: https://github.com/rust-lang/rust/issues/31844
+pub type Elevation = NumericValueObject<i32, 0>;
+pub type Distance = NumericValueObject<f64, 0>;
 
 /// Value Object for BigDecimal type
 #[derive(
@@ -57,28 +48,37 @@ pub type Distance = NumericValueObject<f64, { f64::MAX as u32 }>;
 )]
 pub struct NumericValueObject<T, const MAX_ABS: u32>(T);
 
-impl<T: Copy + FromPrimitive, const MAX_ABS: u32> NumericValueObject<T, MAX_ABS> {
+impl<T: Copy + FromPrimitive + Bounded, const MAX_ABS: u32> NumericValueObject<T, MAX_ABS> {
     pub fn value(&self) -> T {
         self.0
     }
 
     pub fn max() -> Self {
-        Self(T::from_u32(MAX_ABS).unwrap())
+        Self(if MAX_ABS == 0 {
+            T::max_value()
+        } else {
+            T::from_u32(MAX_ABS).unwrap()
+        })
+    }
+
+    pub fn zero() -> Self {
+        Self(T::from_u32(0).unwrap())
     }
 }
 
 // NOTE: TryFrom<T>を実装しようとすると、coreのimplとconflictする
+// これも特殊化待ち: https://github.com/rust-lang/rust/issues/31844
 impl<const MAX_ABS: u32> TryFrom<f64> for NumericValueObject<f64, MAX_ABS> {
     type Error = ApplicationError;
 
     fn try_from(val: f64) -> ApplicationResult<Self> {
-        if val.abs() <= MAX_ABS.into() {
+        if MAX_ABS == 0 || val.abs() <= MAX_ABS.into() {
             Ok(Self(val))
         } else {
             Err(ApplicationError::ValueObjectError(format!(
                 // TODO: stringのconst genericsが追加されたら、
                 // メッセージに具体的なエイリアス名(Latitudeとか)を入れる
-                "Invalid value {} for BigDecimalValueObject<{}>",
+                "Invalid value {} for BigDecimalValueObject<f64{}>",
                 val,
                 MAX_ABS
             )))
@@ -86,17 +86,18 @@ impl<const MAX_ABS: u32> TryFrom<f64> for NumericValueObject<f64, MAX_ABS> {
     }
 }
 
+// NOTE: TryFrom<T>を実装しようとすると、coreのimplとconflictする
 impl<const MAX_ABS: u32> TryFrom<i32> for NumericValueObject<i32, MAX_ABS> {
     type Error = ApplicationError;
 
     fn try_from(val: i32) -> ApplicationResult<Self> {
-        if val.abs() <= MAX_ABS as i32 {
+        if MAX_ABS == 0 || val.abs() <= MAX_ABS as i32 {
             Ok(Self(val))
         } else {
             Err(ApplicationError::ValueObjectError(format!(
                 // TODO: stringのconst genericsが追加されたら、
                 // メッセージに具体的なエイリアス名(Latitudeとか)を入れる
-                "Invalid value {} for BigDecimalValueObject<{}>",
+                "Invalid value {} for BigDecimalValueObject<i32, {}>",
                 val,
                 MAX_ABS
             )))

--- a/src/usecase/route.rs
+++ b/src/usecase/route.rs
@@ -95,7 +95,7 @@ where
 
         Ok(RouteOperationResponse {
             waypoints: editor.route().waypoints().clone(),
-            segments,
+            segments: seg_list,
             elevation_gain,
         })
     }

--- a/src/usecase/route.rs
+++ b/src/usecase/route.rs
@@ -30,7 +30,8 @@ where
 
     pub fn find(&self, route_id: &RouteId) -> ApplicationResult<RouteGetResponse> {
         let route = self.service.find_route(route_id)?;
-        let seg_list = self.service.find_segment_list(route_id)?;
+        let mut seg_list = self.service.find_segment_list(route_id)?;
+        seg_list.attach_distance_from_start()?;
         let elevation_gain = seg_list.calc_elevation_gain()?;
         Ok(RouteGetResponse {
             route,
@@ -88,12 +89,13 @@ where
             Some(org_polyline),
         )?;
         editor.push_operation(opst.try_into()?)?;
-        let seg_list = self.service.update_editor(&editor)?;
+        let mut seg_list = self.service.update_editor(&editor)?;
+        seg_list.attach_distance_from_start()?;
         let elevation_gain = seg_list.calc_elevation_gain()?;
 
         Ok(RouteOperationResponse {
             waypoints: editor.route().waypoints().clone(),
-            segments: seg_list,
+            segments,
             elevation_gain,
         })
     }
@@ -109,12 +111,12 @@ where
         } else {
             editor.undo_operation()?;
         }
-        let seg_list = self.service.update_editor(&editor)?;
-        let elevation_gain = seg_list.calc_elevation_gain()?;
+        let segments = self.service.update_editor(&editor)?;
+        let elevation_gain = segments.calc_elevation_gain()?;
 
         Ok(RouteOperationResponse {
             waypoints: editor.route().waypoints().clone(),
-            segments: seg_list,
+            segments,
             elevation_gain,
         })
     }


### PR DESCRIPTION
Closes #52 

* [haversine formula](https://en.wikipedia.org/wiki/Haversine_formula)というやつを用いて二点間の距離を求めるtrait `geo::HaversineDistance`を`Coordinate`に追加した
  * `Coordinate`に`distance_from_start`というフィールドを追加
* `HaversineDistance`を用いて`SegmentList`内の各`Coordinate`についてスタートからの累計距離を計算する`SegmentList::attach_distance_from_start`を追加
  * iterに対して`par_bridge`を呼ぶことで、勝手に並列処理してくれてるらしい
* これをUseCaseで呼ぶことで、レスポンスに反映させている
* ついでにtypes.rsを若干リファクタした

主な変更の入ってるcommit: f4d258f