### PR TITLE
ドメインモデルのリファクタ

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,13 +598,14 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.14"
+version = "0.99.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc7b9cef1e351660e5443924e4f43ab25fbbed3e9a5f052df3677deb4d6b320"
+checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
+ "rustc_version 0.3.3",
  "syn",
 ]
 
@@ -1571,6 +1572,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
 name = "pin-project"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2073,7 +2083,16 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
 ]
 
 [[package]]
@@ -2136,7 +2155,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.2",
 ]
 
 [[package]]
@@ -2144,6 +2172,15 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -2271,7 +2308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
 dependencies = [
  "discard",
- "rustc_version",
+ "rustc_version 0.2.3",
  "stdweb-derive",
  "stdweb-internal-macros",
  "stdweb-internal-runtime",
@@ -2590,6 +2627,12 @@ name = "typenum"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ actix-cors = "0.5.4"
 actix-rt = "1.1.0"
 actix-web = "3.3.2"
 byteorder = "1.4.3"
-derive_more = "0.99.11"
+derive_more = "0.99.16"
 diesel = { version = "1.4.6", features = ["mysql", "numeric", "r2d2"] }
 env_logger = "0.8.3"
 geo = "0.17.1"

--- a/migrations/2021-07-02-070305_remove_waypoint_polyline/down.sql
+++ b/migrations/2021-07-02-070305_remove_waypoint_polyline/down.sql
@@ -1,2 +1,3 @@
 -- This file should undo anything in `up.sql`
 ALTER TABLE routes ADD `waypoint_polyline` VARCHAR(65000) CHAR SET ascii NOT NULL;
+ALTER TABLE segments ADD `distance` DOUBLE NOT NULL

--- a/migrations/2021-07-02-070305_remove_waypoint_polyline/down.sql
+++ b/migrations/2021-07-02-070305_remove_waypoint_polyline/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE routes ADD `waypoint_polyline` VARCHAR(65000) CHAR SET ascii NOT NULL;

--- a/migrations/2021-07-02-070305_remove_waypoint_polyline/down.sql
+++ b/migrations/2021-07-02-070305_remove_waypoint_polyline/down.sql
@@ -1,3 +1,8 @@
 -- This file should undo anything in `up.sql`
-ALTER TABLE routes ADD `waypoint_polyline` VARCHAR(65000) CHAR SET ascii NOT NULL;
-ALTER TABLE segments ADD `distance` DOUBLE NOT NULL
+ALTER TABLE routes
+    ADD `waypoint_polyline` VARCHAR(65000) CHAR SET ascii NOT NULL;
+ALTER TABLE segments
+    ADD `distance` DOUBLE NOT NULL;
+ALTER TABLE operations
+    CHANGE `pos` `pos`   INTEGER UNSIGNED,
+    CHANGE `code` `code` CHAR(5) NOT NULL;

--- a/migrations/2021-07-02-070305_remove_waypoint_polyline/up.sql
+++ b/migrations/2021-07-02-070305_remove_waypoint_polyline/up.sql
@@ -1,0 +1,2 @@
+-- Your SQL goes here
+ALTER TABLE routes DROP COLUMN `waypoint_polyline`;

--- a/migrations/2021-07-02-070305_remove_waypoint_polyline/up.sql
+++ b/migrations/2021-07-02-070305_remove_waypoint_polyline/up.sql
@@ -1,2 +1,3 @@
 -- Your SQL goes here
 ALTER TABLE routes DROP COLUMN `waypoint_polyline`;
+ALTER TABLE segments DROP COLUMN `distance`;

--- a/migrations/2021-07-02-070305_remove_waypoint_polyline/up.sql
+++ b/migrations/2021-07-02-070305_remove_waypoint_polyline/up.sql
@@ -1,3 +1,8 @@
 -- Your SQL goes here
-ALTER TABLE routes DROP COLUMN `waypoint_polyline`;
-ALTER TABLE segments DROP COLUMN `distance`;
+ALTER TABLE routes
+    DROP COLUMN `waypoint_polyline`;
+ALTER TABLE segments
+    DROP COLUMN `distance`;
+ALTER TABLE operations
+    CHANGE `pos` `pos`   INTEGER UNSIGNED       NOT NULL,
+    CHANGE `code` `code` CHAR(2) CHAR SET ascii NOT NULL;

--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -1,6 +1,6 @@
-use route_bucket_backend::domain::model::linestring::{Coordinate, LineString};
+use route_bucket_backend::domain::model::coordinate::Coordinate;
 use route_bucket_backend::domain::model::operation::Operation;
-use route_bucket_backend::domain::model::route::Route;
+use route_bucket_backend::domain::model::route::RouteInfo;
 use route_bucket_backend::domain::model::types::RouteId;
 use route_bucket_backend::domain::service::route::RouteService;
 use route_bucket_backend::infrastructure::external::osrm::OsrmApi;
@@ -15,18 +15,18 @@ macro_rules! coord {
     };
 }
 
-macro_rules! linestring {
-    [] => {
-        LineString::from(vec![])
-    };
-    [ $(($lat: expr, $lon: expr)),+ $(,)?] => {
-        LineString::from(vec![
-            $(
-                coord!($lat, $lon),
-            )+
-        ])
-    };
-}
+// macro_rules! linestring {
+//     [] => {
+//         LineString::from(vec![])
+//     };
+//     [ $(($lat: expr, $lon: expr)),+ $(,)?] => {
+//         LineString::from(vec![
+//             $(
+//                 coord!($lat, $lon),
+//             )+
+//         ])
+//     };
+// }
 
 fn main() {
     env_logger::init();
@@ -46,10 +46,9 @@ fn main() {
 
     let route_id1 = RouteId::new();
     route_service
-        .register_route(&Route::new(
+        .register_route(&RouteInfo::new(
             route_id1.clone(),
             &String::from("sample1"),
-            linestring![],
             0,
         ))
         .unwrap();
@@ -57,80 +56,59 @@ fn main() {
 
     let route_id2 = RouteId::new();
     route_service
-        .register_route(&Route::new(
+        .register_route(&RouteInfo::new(
             route_id2.clone(),
             &String::from("sample2: 皇居ラン"),
-            linestring![],
             0,
         ))
         .unwrap();
 
-    let mut sample2 = route_service.find_editor(&route_id2).unwrap();
+    let mut sample2 = route_service.find_route(&route_id2).unwrap();
 
     // let sample2
     sample2
-        .push_operation(Operation::Add {
-            pos: 0,
-            coord: coord!(35.68136, 139.75875),
-        })
+        .push_operation(Operation::new_add(0, coord!(35.68136, 139.75875)))
         .unwrap();
-    route_service.update_editor(&sample2).unwrap();
+    route_service.update_route(&mut sample2).unwrap();
     sample2
-        .push_operation(Operation::Add {
-            pos: 1,
-            coord: coord!(35.69053, 139.75681),
-        })
+        .push_operation(Operation::new_add(1, coord!(35.69053, 139.75681)))
         .unwrap();
-    route_service.update_editor(&sample2).unwrap();
+    route_service.update_route(&mut sample2).unwrap();
 
     sample2
-        .push_operation(Operation::Add {
-            pos: 2,
-            coord: coord!(35.69510, 139.75139),
-        })
+        .push_operation(Operation::new_add(2, coord!(35.69510, 139.75139)))
         .unwrap();
-    route_service.update_editor(&sample2).unwrap();
+    route_service.update_route(&mut sample2).unwrap();
 
     sample2
-        .push_operation(Operation::Add {
-            pos: 3,
-            coord: coord!(35.68942, 139.74547),
-        })
+        .push_operation(Operation::new_add(3, coord!(35.68942, 139.74547)))
         .unwrap();
-    route_service.update_editor(&sample2).unwrap();
+    route_service.update_route(&mut sample2).unwrap();
 
     sample2
-        .push_operation(Operation::Add {
-            pos: 4,
-            coord: coord!(35.68418, 139.74424),
-        })
+        .push_operation(Operation::new_add(4, coord!(35.68418, 139.74424)))
         .unwrap();
-    route_service.update_editor(&sample2).unwrap();
+    route_service.update_route(&mut sample2).unwrap();
 
     sample2
-        .push_operation(Operation::Add {
-            pos: 5,
-            coord: coord!(35.68136, 139.75875),
-        })
+        .push_operation(Operation::new_add(5, coord!(35.68136, 139.75875)))
         .unwrap();
-    route_service.update_editor(&sample2).unwrap();
+    route_service.update_route(&mut sample2).unwrap();
 
     sample2
-        .push_operation(Operation::Clear {
-            org_list: linestring![
-                (35.68136, 139.75875),
-                (35.69053, 139.75681),
-                (35.69510, 139.75139),
-                (35.68942, 139.74547),
-                (35.68418, 139.74424),
-                (35.68136, 139.75875)
-            ],
-        })
+        .push_operation(Operation::new_clear(vec![
+            coord!(35.68136, 139.75875),
+            coord!(35.69053, 139.75681),
+            coord!(35.69510, 139.75139),
+            coord!(35.68942, 139.74547),
+            coord!(35.68418, 139.74424),
+            coord!(35.68136, 139.75875),
+        ]))
         .unwrap();
-    route_service.update_editor(&sample2).unwrap();
+    route_service.update_route(&mut sample2).unwrap();
 
     sample2.undo_operation().unwrap();
-    route_service.update_editor(&sample2).unwrap();
+    route_service.update_route(&mut sample2).unwrap();
 
-    log::info!("Route {} added!", sample2.route().id());
+    log::info!("Route {} added!", sample2.info().id());
 }

--- a/src/domain/model/linestring.rs
+++ b/src/domain/model/linestring.rs
@@ -2,134 +2,13 @@ use std::convert::{TryFrom, TryInto};
 use std::iter::FromIterator;
 use std::slice::{Iter, IterMut};
 
+use geo::algorithm::haversine_distance::HaversineDistance;
 use getset::Getters;
 use polyline::{decode_polyline, encode_coordinates};
 use serde::{Deserialize, Serialize};
 
 use crate::domain::model::types::{Distance, Elevation, Latitude, Longitude, Polyline};
 use crate::utils::error::{ApplicationError, ApplicationResult};
-use geo::algorithm::haversine_distance::HaversineDistance;
-
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-pub struct LineString(Vec<Coordinate>);
-
-impl LineString {
-    pub fn new() -> LineString {
-        LineString(Vec::new())
-    }
-
-    pub fn get(&self, i: usize) -> ApplicationResult<&Coordinate> {
-        if i < self.0.len() {
-            Ok(&self.0[i])
-        } else {
-            Err(ApplicationError::DomainError(
-                "Index out of range in get.".into(),
-            ))
-        }
-    }
-
-    pub fn replace(&mut self, i: usize, val: Coordinate) -> ApplicationResult<Coordinate> {
-        if i < self.0.len() {
-            Ok(std::mem::replace(&mut self.0[i], val))
-        } else {
-            Err(ApplicationError::DomainError(
-                "Index out of range in set.".into(),
-            ))
-        }
-    }
-
-    pub fn insert(&mut self, pos: usize, point: Coordinate) -> ApplicationResult<()> {
-        if pos > self.0.len() {
-            // TODO: ここの説明の改善
-            Err(ApplicationError::DomainError(
-                "Failed to insert point.".into(),
-            ))
-        } else {
-            Ok(self.0.insert(pos, point))
-        }
-    }
-
-    pub fn remove(&mut self, pos: usize) -> ApplicationResult<Coordinate> {
-        if pos > self.0.len() {
-            Err(ApplicationError::DomainError(
-                "Failed to remove point.".into(),
-            ))
-        } else {
-            Ok(self.0.remove(pos))
-        }
-    }
-
-    pub fn clear(&mut self) -> LineString {
-        std::mem::replace(self, LineString::new())
-    }
-
-    // only when points is empty
-    pub fn init_if_empty(&mut self, points: LineString) -> ApplicationResult<()> {
-        if !self.0.is_empty() {
-            Err(ApplicationError::DomainError(
-                "Failed to set points. self.points was already inited.".into(),
-            ))
-        } else {
-            self.0 = points.0;
-            Ok(())
-        }
-    }
-
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    pub fn iter(&self) -> Iter<Coordinate> {
-        self.0.iter()
-    }
-
-    pub fn iter_mut(&mut self) -> IterMut<Coordinate> {
-        self.0.iter_mut()
-    }
-}
-
-impl From<LineString> for geo::LineString<f64> {
-    fn from(value: LineString) -> Self {
-        geo::LineString::from_iter(value.0.into_iter())
-    }
-}
-
-impl TryFrom<geo::LineString<f64>> for LineString {
-    type Error = ApplicationError;
-
-    fn try_from(value: geo::LineString<f64>) -> Result<Self, Self::Error> {
-        value
-            .into_iter()
-            .map(|coord| Coordinate::new(coord.y, coord.x))
-            .collect::<ApplicationResult<Vec<_>>>()
-            .map(LineString::from)
-    }
-}
-
-impl From<Vec<Coordinate>> for LineString {
-    fn from(points: Vec<Coordinate>) -> Self {
-        LineString(points)
-    }
-}
-
-impl From<LineString> for Polyline {
-    fn from(value: LineString) -> Self {
-        let line_str = geo::LineString::from(value);
-        // 範囲チェックはCoordinateで行っているので、unwrapで大丈夫
-        encode_coordinates(line_str, 5).map(Polyline::from).unwrap()
-    }
-}
-
-impl TryFrom<Polyline> for LineString {
-    type Error = ApplicationError;
-
-    fn try_from(value: Polyline) -> Result<Self, Self::Error> {
-        let line_str = decode_polyline(&String::from(value), 5).map_err(|err| {
-            ApplicationError::DomainError(format!("failed to encode polyline: {}", err))
-        })?;
-        LineString::try_from(line_str)
-    }
-}
 
 /// Value Object for Coordinates
 #[derive(Clone, Debug, PartialEq, Getters, Deserialize, Serialize)]
@@ -181,6 +60,25 @@ impl From<Coordinate> for geo::Coordinate<f64> {
 impl From<Coordinate> for (f64, f64) {
     fn from(coord: Coordinate) -> (f64, f64) {
         (coord.latitude.value(), coord.longitude.value())
+    }
+}
+
+impl From<Vec<Coordinate>> for Polyline {
+    fn from(value: Vec<Coordinate>) -> Self {
+        let line_str = geo::LineString::from_iter(value.into_iter());
+        // 範囲チェックはCoordinateで行っているので、unwrapで大丈夫
+        encode_coordinates(line_str, 5).map(Polyline::from).unwrap()
+    }
+}
+
+impl TryFrom<Polyline> for Vec<Coordinate> {
+    type Error = ApplicationError;
+
+    fn try_from(value: Polyline) -> Result<Self, Self::Error> {
+        let line_str = decode_polyline(&String::from(value), 5).map_err(|err| {
+            ApplicationError::DomainError(format!("failed to encode polyline: {}", err))
+        })?;
+        Ok(Vec::from_iter(line_str.into_iter()))
     }
 }
 

--- a/src/domain/model/mod.rs
+++ b/src/domain/model/mod.rs
@@ -1,4 +1,4 @@
-pub mod linestring;
+pub mod coordinate;
 pub mod operation;
 pub mod route;
 pub mod segment;

--- a/src/domain/model/operation.rs
+++ b/src/domain/model/operation.rs
@@ -1,7 +1,6 @@
 use std::convert::TryFrom;
 
 use getset::Getters;
-use serde::{Deserialize, Serialize};
 
 use crate::domain::model::coordinate::Coordinate;
 use crate::domain::model::segment::SegmentList;
@@ -18,14 +17,14 @@ pub enum OperationType {
 }
 
 impl OperationType {
-    pub fn reverse(mut self) {
-        self = match self {
+    pub fn reverse(&self) -> Self {
+        match *self {
             OperationType::Add => OperationType::Remove,
             OperationType::Remove => OperationType::Add,
             OperationType::Move => OperationType::Move,
             OperationType::Clear => OperationType::InitWithList,
             OperationType::InitWithList => OperationType::Clear,
-        };
+        }
     }
 }
 
@@ -110,7 +109,7 @@ impl Operation {
     }
 
     pub fn reverse(&mut self) {
-        self.op_type.reverse();
+        self.op_type = self.op_type.reverse();
         swap(&mut self.org_coords, &mut self.new_coords);
     }
 }

--- a/src/domain/model/operation.rs
+++ b/src/domain/model/operation.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 use getset::Getters;
 use serde::{Deserialize, Serialize};
 
-use crate::domain::model::linestring::{Coordinate, LineString};
+use crate::domain::model::coordinate::Coordinate;
 use crate::domain::model::segment::SegmentList;
 use crate::utils::error::{ApplicationError, ApplicationResult};
 use std::mem::swap;

--- a/src/domain/model/route.rs
+++ b/src/domain/model/route.rs
@@ -64,7 +64,7 @@ impl Route {
         }
     }
 
-    pub fn calc_elevation_gain(&self) -> ApplicationResult<Elevation> {
+    pub fn calc_elevation_gain(&self) -> Elevation {
         self.seg_list.calc_elevation_gain()
     }
 

--- a/src/domain/model/route.rs
+++ b/src/domain/model/route.rs
@@ -1,7 +1,7 @@
 use getset::Getters;
 use serde::{Deserialize, Serialize};
 
-use crate::domain::model::linestring::LineString;
+use crate::domain::model::coordinate::Coordinate;
 use crate::domain::model::operation::Operation;
 use crate::domain::model::segment::SegmentList;
 use crate::domain::model::types::RouteId;

--- a/src/domain/model/route.rs
+++ b/src/domain/model/route.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::domain::model::linestring::LineString;
 use crate::domain::model::operation::Operation;
+use crate::domain::model::segment::SegmentList;
 use crate::domain::model::types::RouteId;
 use crate::utils::error::{ApplicationError, ApplicationResult};
 
@@ -11,7 +12,7 @@ use crate::utils::error::{ApplicationError, ApplicationResult};
 pub struct Route {
     info: RouteInfo,
     op_list: Vec<Operation>,
-    last_op: Option<Operation>,
+    seg_list: SegmentList,
 }
 
 impl Route {
@@ -19,7 +20,7 @@ impl Route {
         Self {
             info,
             op_list,
-            last_op: None,
+            seg_list,
         }
     }
 

--- a/src/domain/model/segment.rs
+++ b/src/domain/model/segment.rs
@@ -6,7 +6,6 @@ use std::slice::{Iter, IterMut};
 use geo::algorithm::haversine_distance::HaversineDistance;
 use getset::Getters;
 use itertools::Itertools;
-use num_traits::Zero;
 use rayon::iter::{ParallelBridge, ParallelIterator};
 use serde::Serialize;
 
@@ -22,10 +21,10 @@ pub struct SegmentList {
 }
 
 impl SegmentList {
-    pub fn calc_elevation_gain(&self) -> ApplicationResult<Elevation> {
+    pub fn calc_elevation_gain(&self) -> Elevation {
         self.iter()
             .par_bridge()
-            .fold(i32::zero, |total_gain, seg| {
+            .fold(Elevation::zero, |total_gain, seg| {
                 let mut gain = Elevation::zero();
                 let mut prev_elev = Elevation::max();
                 seg.iter().for_each(|coord| {
@@ -36,10 +35,9 @@ impl SegmentList {
                 });
                 // NOTE: const genericsのあるNumericValueObjectに、Sumがderiveできないので、i32にしている
                 // pull request -> https://github.com/JelteF/derive_more/pull/167
-                total_gain + gain.value()
+                total_gain + gain
             })
-            .sum::<i32>()
-            .try_into()
+            .sum::<Elevation>()
     }
 
     pub fn attach_distance_from_start(&mut self) -> ApplicationResult<()> {

--- a/src/domain/model/segment.rs
+++ b/src/domain/model/segment.rs
@@ -10,7 +10,7 @@ use num_traits::{clamp, Zero};
 use rayon::iter::{ParallelBridge, ParallelIterator};
 use serde::Serialize;
 
-use crate::domain::model::linestring::{Coordinate, LineString};
+use crate::domain::model::coordinate::Coordinate;
 use crate::domain::model::types::{Distance, Elevation, Polyline};
 use crate::utils::error::{ApplicationError, ApplicationResult};
 

--- a/src/domain/model/types.rs
+++ b/src/domain/model/types.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 
-use derive_more::{Add, AddAssign, Display, From, Into, Sub};
+use derive_more::{Add, AddAssign, Display, From, Into, Sub, Sum};
 use nanoid::nanoid;
 use num_traits::{Bounded, FromPrimitive};
 use serde::{Deserialize, Serialize};
@@ -45,7 +45,19 @@ pub type Distance = NumericValueObject<f64, 0>;
 
 /// Value Object for BigDecimal type
 #[derive(
-    Add, AddAssign, Sub, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+    Add,
+    AddAssign,
+    Sub,
+    Sum,
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
 )]
 pub struct NumericValueObject<T, const MAX_ABS: u32>(T);
 

--- a/src/domain/model/types.rs
+++ b/src/domain/model/types.rs
@@ -40,7 +40,7 @@ pub type Latitude = NumericValueObject<f64, 90>;
 pub type Longitude = NumericValueObject<f64, 180>;
 // NOTE: genericsの特殊化が実装されたら、この0は消せる
 // 参考: https://github.com/rust-lang/rust/issues/31844
-pub type Elevation = NumericValueObject<i32, 0>;
+pub type Elevation = NumericValueObject<i32, 1000000>;
 pub type Distance = NumericValueObject<f64, 0>;
 
 /// Value Object for BigDecimal type

--- a/src/domain/repository.rs
+++ b/src/domain/repository.rs
@@ -57,7 +57,7 @@ pub trait SegmentRepository {
 pub trait RouteInterpolationApi {
     fn correct_coordinate(&self, coord: &Coordinate) -> ApplicationResult<Coordinate>;
 
-    fn interpolate(&self, from: Coordinate, to: Coordinate) -> ApplicationResult<Segment>;
+    fn interpolate(&self, seg: &mut Segment) -> ApplicationResult<()>;
 }
 
 pub trait ElevationApi {

--- a/src/domain/repository.rs
+++ b/src/domain/repository.rs
@@ -1,4 +1,4 @@
-use crate::domain::model::linestring::Coordinate;
+use crate::domain::model::coordinate::Coordinate;
 use crate::domain::model::operation::Operation;
 use crate::domain::model::route::RouteInfo;
 use crate::domain::model::segment::{Segment, SegmentList};

--- a/src/domain/repository.rs
+++ b/src/domain/repository.rs
@@ -4,6 +4,7 @@ use crate::domain::model::route::RouteInfo;
 use crate::domain::model::segment::{Segment, SegmentList};
 use crate::domain::model::types::{Elevation, RouteId};
 use crate::utils::error::ApplicationResult;
+use std::ops::Range;
 
 pub trait RouteRepository {
     fn find(&self, id: &RouteId) -> ApplicationResult<RouteInfo>;
@@ -45,6 +46,12 @@ pub trait SegmentRepository {
     ) -> ApplicationResult<()>;
 
     fn delete_by_route_id(&self, route_id: &RouteId) -> ApplicationResult<()>;
+
+    fn delete_by_route_id_and_range(
+        &self,
+        route_id: &RouteId,
+        range: Range<u32>,
+    ) -> ApplicationResult<()>;
 }
 
 pub trait RouteInterpolationApi {

--- a/src/domain/repository.rs
+++ b/src/domain/repository.rs
@@ -1,18 +1,18 @@
 use crate::domain::model::linestring::Coordinate;
 use crate::domain::model::operation::Operation;
-use crate::domain::model::route::Route;
+use crate::domain::model::route::RouteInfo;
 use crate::domain::model::segment::{Segment, SegmentList};
 use crate::domain::model::types::{Elevation, RouteId};
 use crate::utils::error::ApplicationResult;
 
 pub trait RouteRepository {
-    fn find(&self, id: &RouteId) -> ApplicationResult<Route>;
+    fn find(&self, id: &RouteId) -> ApplicationResult<RouteInfo>;
 
-    fn find_all(&self) -> ApplicationResult<Vec<Route>>;
+    fn find_all(&self) -> ApplicationResult<Vec<RouteInfo>>;
 
-    fn register(&self, route: &Route) -> ApplicationResult<()>;
+    fn register(&self, route_info: &RouteInfo) -> ApplicationResult<()>;
 
-    fn update(&self, route: &Route) -> ApplicationResult<()>;
+    fn update(&self, route_info: &RouteInfo) -> ApplicationResult<()>;
 
     fn delete(&self, id: &RouteId) -> ApplicationResult<()>;
 }

--- a/src/domain/service/route.rs
+++ b/src/domain/service/route.rs
@@ -1,8 +1,7 @@
 use itertools::Itertools;
 use rayon::iter::{ParallelBridge, ParallelIterator};
 
-use crate::domain::model::linestring::{Coordinate, LineString};
-use crate::domain::model::operation::Operation;
+use crate::domain::model::coordinate::Coordinate;
 use crate::domain::model::route::{Route, RouteInfo};
 use crate::domain::model::segment::{Segment, SegmentList};
 use crate::domain::model::types::RouteId;

--- a/src/domain/service/route.rs
+++ b/src/domain/service/route.rs
@@ -43,19 +43,20 @@ where
         }
     }
 
-    pub fn find_route(&self, route_id: &RouteId) -> ApplicationResult<RouteInfo> {
+    pub fn find_info(&self, route_id: &RouteId) -> ApplicationResult<RouteInfo> {
         self.route_repository.find(route_id)
     }
 
-    pub fn find_all_routes(&self) -> ApplicationResult<Vec<RouteInfo>> {
+    pub fn find_all_infos(&self) -> ApplicationResult<Vec<RouteInfo>> {
         self.route_repository.find_all()
     }
 
-    pub fn find_editor(&self, route_id: &RouteId) -> ApplicationResult<Route> {
-        let route_info = self.find_route(route_id)?;
-        let operations = self.operation_repository.find_by_route_id(route_id)?;
+    pub fn find_route(&self, route_id: &RouteId) -> ApplicationResult<Route> {
+        let route_info = self.find_info(route_id)?;
+        let op_list = self.operation_repository.find_by_route_id(route_id)?;
+        let seg_list = self.find_segment_list(route_id)?;
 
-        Ok(Route::new(route_info, operations))
+        Ok(Route::new(route_info, op_list, seg_list))
     }
 
     pub fn find_segment_list(&self, route_id: &RouteId) -> ApplicationResult<SegmentList> {

--- a/src/domain/service/route.rs
+++ b/src/domain/service/route.rs
@@ -1,4 +1,5 @@
 use itertools::Itertools;
+use rayon::iter::{ParallelBridge, ParallelIterator};
 
 use crate::domain::model::linestring::{Coordinate, LineString};
 use crate::domain::model::operation::Operation;
@@ -242,6 +243,7 @@ where
     fn attach_elevation(&self, seg_list: &mut SegmentList) -> ApplicationResult<()> {
         seg_list
             .iter_mut()
+            .par_bridge()
             .map(|seg| {
                 seg.iter_mut()
                     .map(|coord| coord.set_elevation(self.elevation_api.get_elevation(coord)?))

--- a/src/domain/service/route.rs
+++ b/src/domain/service/route.rs
@@ -61,6 +61,7 @@ where
     pub fn find_segment_list(&self, route_id: &RouteId) -> ApplicationResult<SegmentList> {
         let mut seg_list = self.segment_repository.find_by_route_id(route_id)?;
         self.attach_elevation(&mut seg_list)?;
+        seg_list.attach_distance_from_start()?;
         Ok(seg_list)
     }
 

--- a/src/infrastructure/dto/operation.rs
+++ b/src/infrastructure/dto/operation.rs
@@ -1,9 +1,13 @@
-use crate::domain::model::operation::{Operation, OperationStruct};
+use std::convert::{TryFrom, TryInto};
+
+use itertools::Itertools;
+
+use crate::domain::model::linestring::Coordinate;
+use crate::domain::model::operation::{Operation, OperationStruct, OperationType};
 use crate::domain::model::types::{Polyline, RouteId};
 use crate::infrastructure::dto::route::RouteDto;
 use crate::infrastructure::schema::operations;
 use crate::utils::error::ApplicationResult;
-use std::convert::{TryFrom, TryInto};
 
 /// 座標のdto構造体
 #[derive(Identifiable, Queryable, Insertable, Associations, Debug)]
@@ -14,20 +18,31 @@ pub struct OperationDto {
     route_id: String,
     index: u32,
     code: String,
-    pos: Option<u32>,
+    pos: u32,
     polyline: String,
 }
 
 impl OperationDto {
     pub fn to_model(&self) -> ApplicationResult<Operation> {
-        OperationStruct::new(
-            self.code.clone(),
-            self.pos.map(|u| u as usize),
-            None,
-            None,
-            Some(Polyline::from(self.polyline.clone()).try_into()?),
+        let op_type = OperationType::try_from(self.code.clone())?;
+
+        let [org_coords, new_coords] = <[Vec<Coordinate>; 2]>::try_from(
+            self.polyline
+                .clone()
+                .split(" ")
+                .map(String::from)
+                .map(Polyline::from)
+                .map(Vec::try_from)
+                .try_collect()?,
         )
-        .map(OperationStruct::try_into)?
+        .unwrap();
+
+        Ok(Operation::new(
+            op_type,
+            *self.pos as usize,
+            org_coords,
+            new_coords,
+        ))
     }
 
     pub fn from_model(
@@ -35,13 +50,15 @@ impl OperationDto {
         route_id: &RouteId,
         index: u32,
     ) -> ApplicationResult<OperationDto> {
-        let opst = OperationStruct::try_from(operation.clone())?;
+        let org_polyline: String = operation.org_coords().clone().into();
+        let new_polyline: String = operation.new_coords().clone().into();
+
         Ok(OperationDto {
             route_id: route_id.to_string(),
             index,
-            code: opst.code().clone(),
-            pos: opst.pos().clone().map(|u| u as u32),
-            polyline: Polyline::from(opst.polyline().clone()).into(),
+            code: operation.op_type().into(),
+            pos: operation.start_pos() as u32,
+            polyline: [org_polyline, new_polyline].join(" "),
         })
     }
 }

--- a/src/infrastructure/dto/operation.rs
+++ b/src/infrastructure/dto/operation.rs
@@ -1,9 +1,7 @@
 use std::convert::{TryFrom, TryInto};
 
-use itertools::Itertools;
-
-use crate::domain::model::linestring::Coordinate;
-use crate::domain::model::operation::{Operation, OperationStruct, OperationType};
+use crate::domain::model::coordinate::Coordinate;
+use crate::domain::model::operation::{Operation, OperationType};
 use crate::domain::model::types::{Polyline, RouteId};
 use crate::infrastructure::dto::route::RouteDto;
 use crate::infrastructure::schema::operations;

--- a/src/infrastructure/dto/operation.rs
+++ b/src/infrastructure/dto/operation.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 
 use crate::domain::model::coordinate::Coordinate;
 use crate::domain::model::operation::{Operation, OperationType};
@@ -31,13 +31,13 @@ impl OperationDto {
                 .map(String::from)
                 .map(Polyline::from)
                 .map(Vec::try_from)
-                .try_collect()?,
+                .collect::<ApplicationResult<Vec<_>>>()?,
         )
         .unwrap();
 
         Ok(Operation::new(
             op_type,
-            *self.pos as usize,
+            self.pos as usize,
             org_coords,
             new_coords,
         ))
@@ -48,14 +48,14 @@ impl OperationDto {
         route_id: &RouteId,
         index: u32,
     ) -> ApplicationResult<OperationDto> {
-        let org_polyline: String = operation.org_coords().clone().into();
-        let new_polyline: String = operation.new_coords().clone().into();
+        let org_polyline: String = Polyline::from(operation.org_coords().clone()).into();
+        let new_polyline: String = Polyline::from(operation.new_coords().clone()).into();
 
         Ok(OperationDto {
             route_id: route_id.to_string(),
             index,
-            code: operation.op_type().into(),
-            pos: operation.start_pos() as u32,
+            code: operation.op_type().clone().into(),
+            pos: *operation.start_pos() as u32,
             polyline: [org_polyline, new_polyline].join(" "),
         })
     }

--- a/src/infrastructure/dto/route.rs
+++ b/src/infrastructure/dto/route.rs
@@ -1,4 +1,4 @@
-use crate::domain::model::route::Route;
+use crate::domain::model::route::RouteInfo;
 use crate::domain::model::types::{Polyline, RouteId};
 use crate::infrastructure::schema::routes;
 use crate::utils::error::ApplicationResult;
@@ -14,19 +14,19 @@ pub struct RouteDto {
 }
 
 impl RouteDto {
-    pub fn to_model(&self) -> ApplicationResult<Route> {
-        Ok(Route::new(
+    pub fn to_model(&self) -> ApplicationResult<RouteInfo> {
+        Ok(RouteInfo::new(
             RouteId::from_string(self.id.clone()),
             &self.name,
             self.operation_pos as usize,
         ))
     }
 
-    pub fn from_model(route: &Route) -> ApplicationResult<RouteDto> {
+    pub fn from_model(route_info: &RouteInfo) -> ApplicationResult<RouteDto> {
         Ok(RouteDto {
-            id: route.id().to_string(),
-            name: route.name().clone(),
-            operation_pos: *route.op_num() as u32,
+            id: route_info.id().to_string(),
+            name: route_info.name().clone(),
+            operation_pos: *route_info.op_num() as u32,
         })
     }
 }

--- a/src/infrastructure/dto/route.rs
+++ b/src/infrastructure/dto/route.rs
@@ -10,7 +10,6 @@ use std::convert::TryInto;
 pub struct RouteDto {
     id: String,
     name: String,
-    waypoint_polyline: String,
     operation_pos: u32,
 }
 
@@ -19,7 +18,6 @@ impl RouteDto {
         Ok(Route::new(
             RouteId::from_string(self.id.clone()),
             &self.name,
-            Polyline::from(self.waypoint_polyline.clone()).try_into()?,
             self.operation_pos as usize,
         ))
     }
@@ -28,7 +26,6 @@ impl RouteDto {
         Ok(RouteDto {
             id: route.id().to_string(),
             name: route.name().clone(),
-            waypoint_polyline: Polyline::from(route.waypoints().clone()).into(),
             operation_pos: *route.op_num() as u32,
         })
     }

--- a/src/infrastructure/dto/route.rs
+++ b/src/infrastructure/dto/route.rs
@@ -1,8 +1,7 @@
 use crate::domain::model::route::RouteInfo;
-use crate::domain::model::types::{Polyline, RouteId};
+use crate::domain::model::types::RouteId;
 use crate::infrastructure::schema::routes;
 use crate::utils::error::ApplicationResult;
-use std::convert::TryInto;
 
 /// ルートのdto構造体
 #[derive(Identifiable, Queryable, Insertable, Debug, AsChangeset)]

--- a/src/infrastructure/dto/segment.rs
+++ b/src/infrastructure/dto/segment.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 
 use crate::domain::model::segment::Segment;
-use crate::domain::model::types::{Distance, Polyline, RouteId};
+use crate::domain::model::types::{Polyline, RouteId};
 use crate::infrastructure::dto::route::RouteDto;
 use crate::infrastructure::schema::segments;
 use crate::utils::error::ApplicationResult;

--- a/src/infrastructure/dto/segment.rs
+++ b/src/infrastructure/dto/segment.rs
@@ -14,18 +14,14 @@ use crate::utils::error::ApplicationResult;
 pub struct SegmentDto {
     route_id: String,
     // UNSIGNEDにすると、なぜかdieselでインクリメントのアップデートができない
-    // 参考：
+    // 参考：https://github.com/diesel-rs/diesel/issues/2382
     index: i32,
     polyline: String,
-    distance: f64,
 }
 
 impl SegmentDto {
     pub fn to_model(&self) -> ApplicationResult<Segment> {
-        Segment::try_from((
-            Polyline::from(self.polyline.clone()),
-            Distance::try_from(self.distance)?,
-        ))
+        Segment::try_from(Polyline::from(self.polyline.clone()))
     }
 
     pub fn from_model(
@@ -37,7 +33,6 @@ impl SegmentDto {
             route_id: route_id.to_string(),
             index: index as i32,
             polyline: Polyline::from(segment.points().clone()).into(),
-            distance: segment.distance().value(),
         })
     }
 }

--- a/src/infrastructure/external/osrm.rs
+++ b/src/infrastructure/external/osrm.rs
@@ -1,8 +1,8 @@
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryInto;
 
 use crate::domain::model::coordinate::Coordinate;
 use crate::domain::model::segment::Segment;
-use crate::domain::model::types::{Distance, Polyline};
+use crate::domain::model::types::Polyline;
 use crate::domain::repository::RouteInterpolationApi;
 use crate::utils::error::{ApplicationError, ApplicationResult};
 
@@ -64,14 +64,16 @@ impl RouteInterpolationApi for OsrmApi {
             "route",
             &format!(
                 "polyline({})?overview=full",
-                String::from(Polyline::from(LineString::from(vec![from, to])))
+                String::from(Polyline::from(vec![
+                    seg.start().clone(),
+                    seg.goal().clone()
+                ]))
             ),
         )?;
 
         let polyline =
             serde_json::from_value::<Polyline>(json["routes"][0]["geometry"].clone()).unwrap();
-        seg.set_points(polyline.try_into()?);
 
-        Ok(())
+        seg.set_points(polyline.try_into()?)
     }
 }

--- a/src/infrastructure/external/osrm.rs
+++ b/src/infrastructure/external/osrm.rs
@@ -1,6 +1,6 @@
 use std::convert::{TryFrom, TryInto};
 
-use crate::domain::model::linestring::{Coordinate, LineString};
+use crate::domain::model::coordinate::Coordinate;
 use crate::domain::model::segment::Segment;
 use crate::domain::model::types::{Distance, Polyline};
 use crate::domain::repository::RouteInterpolationApi;

--- a/src/infrastructure/external/srtm.rs
+++ b/src/infrastructure/external/srtm.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use byteorder::{BigEndian, ByteOrder, LittleEndian, ReadBytesExt};
 use num_traits::FromPrimitive;
 
-use crate::domain::model::linestring::Coordinate;
+use crate::domain::model::coordinate::Coordinate;
 use crate::domain::model::types::{Elevation, Latitude, Longitude};
 use crate::domain::repository::ElevationApi;
 use crate::utils::error::{ApplicationError, ApplicationResult};

--- a/src/infrastructure/repository/route.rs
+++ b/src/infrastructure/repository/route.rs
@@ -1,6 +1,6 @@
 use diesel::{associations::HasTable, QueryDsl, RunQueryDsl};
 
-use crate::domain::model::route::Route;
+use crate::domain::model::route::RouteInfo;
 use crate::domain::model::types::RouteId;
 use crate::domain::repository::RouteRepository;
 use crate::infrastructure::dto::route::RouteDto;
@@ -20,7 +20,7 @@ impl RouteRepositoryMysql {
 }
 
 impl RouteRepository for RouteRepositoryMysql {
-    fn find(&self, route_id: &RouteId) -> ApplicationResult<Route> {
+    fn find(&self, route_id: &RouteId) -> ApplicationResult<RouteInfo> {
         let conn = self.pool.get_connection()?;
         let route_dto = RouteDto::table()
             .find(&route_id.to_string())
@@ -35,7 +35,7 @@ impl RouteRepository for RouteRepositoryMysql {
         Ok(route_dto.to_model()?)
     }
 
-    fn find_all(&self) -> ApplicationResult<Vec<Route>> {
+    fn find_all(&self) -> ApplicationResult<Vec<RouteInfo>> {
         let conn = self.pool.get_connection()?;
 
         let route_dtos = RouteDto::table().load::<RouteDto>(&conn).or_else(|_| {
@@ -47,13 +47,13 @@ impl RouteRepository for RouteRepositoryMysql {
         Ok(route_dtos
             .iter()
             .map(|dto| dto.to_model())
-            .collect::<ApplicationResult<Vec<Route>>>()?)
+            .collect::<ApplicationResult<Vec<RouteInfo>>>()?)
     }
 
-    fn register(&self, route: &Route) -> ApplicationResult<()> {
+    fn register(&self, route_info: &RouteInfo) -> ApplicationResult<()> {
         let conn = self.pool.get_connection()?;
 
-        let route_dto = RouteDto::from_model(route)?;
+        let route_dto = RouteDto::from_model(route_info)?;
 
         diesel::insert_into(RouteDto::table())
             .values(route_dto)
@@ -67,10 +67,10 @@ impl RouteRepository for RouteRepositoryMysql {
         Ok(())
     }
 
-    fn update(&self, route: &Route) -> ApplicationResult<()> {
+    fn update(&self, route_info: &RouteInfo) -> ApplicationResult<()> {
         let conn = self.pool.get_connection()?;
 
-        let route_dto = RouteDto::from_model(route)?;
+        let route_dto = RouteDto::from_model(route_info)?;
 
         diesel::update(&route_dto)
             .set(&route_dto)
@@ -78,7 +78,7 @@ impl RouteRepository for RouteRepositoryMysql {
             .or_else(|_| {
                 Err(ApplicationError::DataBaseError(format!(
                     "Failed to update Route {}",
-                    route.id()
+                    route_info.id()
                 )))
             })?;
 

--- a/src/infrastructure/schema.rs
+++ b/src/infrastructure/schema.rs
@@ -12,7 +12,6 @@ table! {
     routes (id) {
         id -> Varchar,
         name -> Varchar,
-        waypoint_polyline -> Varchar,
         operation_pos -> Unsigned<Integer>,
     }
 }

--- a/src/infrastructure/schema.rs
+++ b/src/infrastructure/schema.rs
@@ -3,7 +3,7 @@ table! {
         route_id -> Varchar,
         index -> Unsigned<Integer>,
         code -> Char,
-        pos -> Nullable<Unsigned<Integer>>,
+        pos -> Unsigned<Integer>,
         polyline -> Varchar,
     }
 }
@@ -21,7 +21,6 @@ table! {
         route_id -> Varchar,
         index -> Integer,
         polyline -> Varchar,
-        distance -> Double,
     }
 }
 

--- a/src/usecase/route.rs
+++ b/src/usecase/route.rs
@@ -31,7 +31,7 @@ where
     pub fn find(&self, route_id: &RouteId) -> ApplicationResult<RouteGetResponse> {
         let route_info = self.service.find_info(route_id)?;
         let seg_list = self.service.find_segment_list(route_id)?;
-        let elevation_gain = seg_list.calc_elevation_gain()?;
+        let elevation_gain = seg_list.calc_elevation_gain();
 
         let waypoints = seg_list.gather_waypoints();
         let segments = seg_list.into_segments_in_between();
@@ -129,7 +129,7 @@ where
         // TODO: posのrangeチェック
 
         self.service.update_route(route)?;
-        let elevation_gain = route.calc_elevation_gain()?;
+        let elevation_gain = route.calc_elevation_gain();
 
         // NOTE: どうせここでcloneが必要なので、update_routeの戻り値にSegmentListを指定してもいいかもしれない
         let seg_list = route.seg_list().clone();

--- a/src/usecase/route.rs
+++ b/src/usecase/route.rs
@@ -1,16 +1,18 @@
+use std::convert::TryInto;
+
+use getset::Getters;
+use serde::{Deserialize, Serialize};
+
 use crate::domain::model::linestring::{Coordinate, LineString};
 use crate::domain::model::operation::OperationStruct;
-use crate::domain::model::route::Route;
-use crate::domain::model::segment::SegmentList;
+use crate::domain::model::route::{Route, RouteInfo};
+use crate::domain::model::segment::{Segment, SegmentList};
 use crate::domain::model::types::{Elevation, RouteId};
 use crate::domain::repository::{
     ElevationApi, OperationRepository, RouteInterpolationApi, RouteRepository, SegmentRepository,
 };
 use crate::domain::service::route::RouteService;
 use crate::utils::error::ApplicationResult;
-use getset::Getters;
-use serde::{Deserialize, Serialize};
-use std::convert::TryInto;
 
 pub struct RouteUseCase<R, O, S, I, E> {
     service: RouteService<R, O, S, I, E>,
@@ -29,38 +31,42 @@ where
     }
 
     pub fn find(&self, route_id: &RouteId) -> ApplicationResult<RouteGetResponse> {
-        let route = self.service.find_route(route_id)?;
+        let route_info = self.service.find_info(route_id)?;
         let mut seg_list = self.service.find_segment_list(route_id)?;
         seg_list.attach_distance_from_start()?;
         let elevation_gain = seg_list.calc_elevation_gain()?;
+
+        let (waypoints, segments): (Vec<Coordinate>, Vec<Segment>) = seg_list.into();
+
         Ok(RouteGetResponse {
-            route,
-            segments: seg_list,
+            route_info,
+            waypoints,
+            segments,
             elevation_gain,
         })
     }
 
     pub fn find_all(&self) -> ApplicationResult<RouteGetAllResponse> {
         Ok(RouteGetAllResponse {
-            routes: self.service.find_all_routes()?,
+            route_infos: self.service.find_all_routes()?,
         })
     }
 
     pub fn create(&self, req: &RouteCreateRequest) -> ApplicationResult<RouteCreateResponse> {
-        let route = Route::new(RouteId::new(), req.name(), LineString::new(), 0);
+        let route_info = RouteInfo::new(RouteId::new(), req.name(), 0);
 
-        self.service.register_route(&route)?;
+        self.service.register_route(&route_info)?;
 
         Ok(RouteCreateResponse {
-            id: route.id().clone(),
+            id: route_info.id().clone(),
         })
     }
 
     pub fn rename(&self, route_id: &RouteId, req: &RouteRenameRequest) -> ApplicationResult<Route> {
-        let mut route = self.service.find_route(route_id)?;
-        route.rename(req.name());
-        self.service.update_route(&route)?;
-        Ok(route)
+        let mut route_info = self.service.find_route(route_id)?;
+        route_info.rename(req.name());
+        self.service.update_route(&route_info)?;
+        Ok(route_info)
     }
 
     pub fn edit(
@@ -70,9 +76,9 @@ where
         pos: Option<usize>,
         new_coord: Option<Coordinate>,
     ) -> ApplicationResult<RouteOperationResponse> {
-        let mut editor = self.service.find_editor(route_id)?;
+        let mut route = self.service.find_editor(route_id)?;
 
-        let org_polyline = editor.route().waypoints().clone();
+        let org_polyline = route.route().waypoints().clone();
 
         let org_coord = pos.map_or(None, |pos| {
             org_polyline.get(pos).ok().map(Coordinate::clone)
@@ -88,14 +94,16 @@ where
                 .transpose()?,
             Some(org_polyline),
         )?;
-        editor.push_operation(opst.try_into()?)?;
-        let mut seg_list = self.service.update_editor(&editor)?;
+        route.push_operation(opst.try_into()?)?;
+        let mut seg_list = self.service.update_editor(&route)?;
         seg_list.attach_distance_from_start()?;
         let elevation_gain = seg_list.calc_elevation_gain()?;
 
+        let (waypoints, segments): (Vec<Coordinate>, Vec<Segment>) = seg_list.into();
+
         Ok(RouteOperationResponse {
-            waypoints: editor.route().waypoints().clone(),
-            segments: seg_list,
+            waypoints,
+            segments,
             elevation_gain,
         })
     }
@@ -129,14 +137,16 @@ where
 #[derive(Serialize)]
 pub struct RouteGetResponse {
     #[serde(flatten)]
-    route: Route,
-    segments: SegmentList,
+    route_info: RouteInfo,
+    waypoints: Vec<Coordinate>,
+    segments: Vec<Segment>,
     elevation_gain: Elevation,
 }
 
 #[derive(Serialize)]
 pub struct RouteGetAllResponse {
-    routes: Vec<Route>,
+    #[serde(rename = "routes")]
+    route_infos: Vec<RouteInfo>,
 }
 
 #[derive(Getters, Deserialize)]
@@ -158,8 +168,8 @@ pub struct NewPointRequest {
 
 #[derive(Serialize)]
 pub struct RouteOperationResponse {
-    waypoints: LineString,
-    segments: SegmentList,
+    waypoints: Vec<Coordinate>,
+    segments: Vec<Segment>,
     elevation_gain: Elevation,
 }
 

--- a/src/usecase/route.rs
+++ b/src/usecase/route.rs
@@ -3,8 +3,8 @@ use std::convert::TryInto;
 use getset::Getters;
 use serde::{Deserialize, Serialize};
 
-use crate::domain::model::linestring::{Coordinate, LineString};
-use crate::domain::model::operation::OperationStruct;
+use crate::domain::model::coordinate::Coordinate;
+use crate::domain::model::operation::Operation;
 use crate::domain::model::route::{Route, RouteInfo};
 use crate::domain::model::segment::{Segment, SegmentList};
 use crate::domain::model::types::{Elevation, RouteId};

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -8,7 +8,7 @@ use crate::hashmap;
 pub type ApplicationResult<T> = Result<T, ApplicationError>;
 
 /// actix-webを用いて直接リクエストに変換できる自作エラークラス
-#[derive(Debug, Display, Error)]
+#[derive(Clone, Debug, Display, Error)]
 pub enum ApplicationError {
     #[display(fmt = "DataBaseError: {}", _0)]
     DataBaseError(String),


### PR DESCRIPTION
Closes #54 
* `GET /routes/`ではDBの`segments`は触らず、`routes`のみ呼び出すということをしているが、`routes`には`GET /routes/`で不要な`waypoint_polylines`が入ってしまっており、毎回不要でそこそこ大きめのデータを引くということになっていた
  * `Route`を`RouteInfo`と改名し、ルートのメタデータのみを持つstructとした
  * `RouteEditor`を`Route`と改名し、ここに新たに`SegmentList`を持たせるようにした
* `SegmentList`に端点の位置を持たせるようにし、これによってserviceに最後に行った`Operation`を渡さなくて良くなった
* `Operation`は、操作によって別の形のデータを持つ`Enum`となっていたが、これにより処理が複雑になっていた
  * これを、「`SegmentList`のある範囲をある`Vec<Coordinate>`を用いて置き換える」というように一般化することで、同じ構造で全ての操作を持てるようにし、その結果行数が削減された