### PR TITLE
`UseCase`のtrait化 & `actix-web`の`Data`の使用

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -1948,17 +1948,16 @@ dependencies = [
  "route-bucket-domain",
  "route-bucket-infrastructure",
  "route-bucket-usecase",
- "tokio",
 ]
 
 [[package]]
 name = "route-bucket-controller"
 version = "0.1.0"
 dependencies = [
+ "actix-service",
  "actix-web",
  "route-bucket-domain",
  "route-bucket-usecase",
- "tokio",
 ]
 
 [[package]]
@@ -2005,6 +2004,7 @@ dependencies = [
 name = "route-bucket-usecase"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "derive_more",
  "futures",
  "getset",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -24,4 +24,3 @@ route-bucket-controller = { path = "./controller" }
 route-bucket-domain = { path = "./domain" }
 route-bucket-infrastructure = { path = "./infrastructure" }
 route-bucket-usecase = { path = "./usecase" }
-tokio = "1.8.1"

--- a/api/controller/Cargo.toml
+++ b/api/controller/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+actix-service = "2.0.0"
 actix-web = "4.0.0-beta.8"
 route-bucket-domain = { path = "../domain" }
 route-bucket-usecase = { path = "../usecase" }
-tokio = "1.8.1"

--- a/api/controller/src/lib.rs
+++ b/api/controller/src/lib.rs
@@ -1,3 +1,34 @@
-pub use route::{BuildService, RouteController};
+use actix_service::ServiceFactory;
+use actix_web::body::MessageBody;
+use actix_web::dev::{HttpServiceFactory, ServiceRequest, ServiceResponse};
+use actix_web::error::Error;
+use actix_web::App;
+
+pub use route::BuildRouteService;
 
 mod route;
+
+pub trait AddService: Sized {
+    fn add_service<F>(self, factory: F) -> Self
+    where
+        F: HttpServiceFactory + 'static;
+}
+
+impl<T, B> AddService for App<T, B>
+where
+    B: MessageBody,
+    T: ServiceFactory<
+        ServiceRequest,
+        Config = (),
+        Response = ServiceResponse<B>,
+        Error = Error,
+        InitError = (),
+    >,
+{
+    fn add_service<F>(self, factory: F) -> Self
+    where
+        F: HttpServiceFactory + 'static,
+    {
+        self.service(factory)
+    }
+}

--- a/api/controller/src/route.rs
+++ b/api/controller/src/route.rs
@@ -1,152 +1,133 @@
-use actix_web::{dev, http, web, HttpResponse, Result, Scope};
-use tokio::sync::OnceCell;
+use actix_web::{dev, http, web, HttpResponse, Result};
 
-use route_bucket_domain::external::{ElevationApi, RouteInterpolationApi};
 use route_bucket_domain::model::RouteId;
-use route_bucket_domain::repository::RouteRepository;
 use route_bucket_usecase::{NewPointRequest, RouteCreateRequest, RouteRenameRequest, RouteUseCase};
 
-pub struct RouteController<R, I, E> {
-    usecase: RouteUseCase<R, I, E>,
+use crate::AddService;
+
+async fn get<U: 'static + RouteUseCase>(
+    usecase: web::Data<U>,
+    id: web::Path<RouteId>,
+) -> Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(usecase.find(id.as_ref()).await?))
 }
 
-impl<R, I, E> RouteController<R, I, E>
-where
-    R: RouteRepository,
-    I: RouteInterpolationApi,
-    E: ElevationApi,
-{
-    pub fn new(usecase: RouteUseCase<R, I, E>) -> Self {
-        Self { usecase }
-    }
-
-    async fn get(&self, id: web::Path<RouteId>) -> Result<HttpResponse> {
-        Ok(HttpResponse::Ok().json(self.usecase.find(id.as_ref()).await?))
-    }
-
-    async fn get_all(&self) -> Result<HttpResponse> {
-        Ok(HttpResponse::Ok().json(self.usecase.find_all().await?))
-    }
-
-    async fn get_gpx(&self, id: web::Path<RouteId>) -> Result<HttpResponse> {
-        let gpx_resp = self.usecase.find_gpx(id.as_ref()).await?;
-
-        Ok(HttpResponse::Ok()
-            .insert_header((
-                http::header::CONTENT_DISPOSITION,
-                "attachment;filename=\"route.gpx\"",
-            ))
-            .content_type("application/gpx+xml")
-            .body(dev::Body::from_slice(gpx_resp.as_slice())))
-    }
-
-    async fn post(&self, req: web::Json<RouteCreateRequest>) -> Result<HttpResponse> {
-        Ok(HttpResponse::Created().json(self.usecase.create(&req).await?))
-    }
-
-    async fn patch_rename(
-        &self,
-        id: web::Path<RouteId>,
-        req: web::Json<RouteRenameRequest>,
-    ) -> Result<HttpResponse> {
-        Ok(HttpResponse::Ok().json(self.usecase.rename(&id, &req).await?))
-    }
-
-    async fn patch_add(
-        &self,
-        path_params: web::Path<(RouteId, usize)>,
-        req: web::Json<NewPointRequest>,
-    ) -> Result<HttpResponse> {
-        let (route_id, pos) = path_params.into_inner();
-        Ok(HttpResponse::Ok().json(self.usecase.add_point(&route_id, pos, &req).await?))
-    }
-
-    async fn patch_remove(&self, path_params: web::Path<(RouteId, usize)>) -> Result<HttpResponse> {
-        let (route_id, pos) = path_params.into_inner();
-        Ok(HttpResponse::Ok().json(self.usecase.remove_point(&route_id, pos).await?))
-    }
-
-    async fn patch_move(
-        &self,
-        path_params: web::Path<(RouteId, usize)>,
-        req: web::Json<NewPointRequest>,
-    ) -> Result<HttpResponse> {
-        let (route_id, pos) = path_params.into_inner();
-        Ok(HttpResponse::Ok().json(self.usecase.move_point(&route_id, pos, &req).await?))
-    }
-
-    async fn patch_clear(&self, route_id: web::Path<RouteId>) -> Result<HttpResponse> {
-        Ok(HttpResponse::Ok().json(self.usecase.clear_route(&route_id).await?))
-    }
-
-    async fn patch_undo(&self, route_id: web::Path<RouteId>) -> Result<HttpResponse> {
-        Ok(HttpResponse::Ok().json(self.usecase.undo_operation(&route_id).await?))
-    }
-
-    async fn patch_redo(&self, route_id: web::Path<RouteId>) -> Result<HttpResponse> {
-        Ok(HttpResponse::Ok().json(self.usecase.redo_operation(&route_id).await?))
-    }
-
-    async fn delete(&self, id: web::Path<RouteId>) -> Result<HttpResponse> {
-        self.usecase.delete(&id).await?;
-        Ok(HttpResponse::Ok().finish())
-    }
+async fn get_all<U: 'static + RouteUseCase>(usecase: web::Data<U>) -> Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(usecase.find_all().await?))
 }
 
-pub trait BuildService<S: dev::HttpServiceFactory + 'static> {
-    fn build_service(self) -> S;
+async fn get_gpx<U: 'static + RouteUseCase>(
+    usecase: web::Data<U>,
+    id: web::Path<RouteId>,
+) -> Result<HttpResponse> {
+    let gpx_resp = usecase.find_gpx(id.as_ref()).await?;
+
+    Ok(HttpResponse::Ok()
+        .insert_header((
+            http::header::CONTENT_DISPOSITION,
+            "attachment;filename=\"route.gpx\"",
+        ))
+        .content_type("application/gpx+xml")
+        .body(dev::Body::from_slice(gpx_resp.as_slice())))
 }
 
-impl<R, I, E> BuildService<Scope> for &'static OnceCell<RouteController<R, I, E>>
-where
-    R: RouteRepository,
-    I: RouteInterpolationApi,
-    E: ElevationApi,
-{
-    fn build_service(self) -> Scope {
-        let controller = self.get().unwrap();
+async fn post<U: 'static + RouteUseCase>(
+    usecase: web::Data<U>,
+    req: web::Json<RouteCreateRequest>,
+) -> Result<HttpResponse> {
+    Ok(HttpResponse::Created().json(usecase.create(&req).await?))
+}
+
+async fn patch_rename<U: 'static + RouteUseCase>(
+    usecase: web::Data<U>,
+    id: web::Path<RouteId>,
+    req: web::Json<RouteRenameRequest>,
+) -> Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(usecase.rename(&id, &req).await?))
+}
+
+async fn patch_add<U: 'static + RouteUseCase>(
+    usecase: web::Data<U>,
+    path_params: web::Path<(RouteId, usize)>,
+    req: web::Json<NewPointRequest>,
+) -> Result<HttpResponse> {
+    let (route_id, pos) = path_params.into_inner();
+    Ok(HttpResponse::Ok().json(usecase.add_point(&route_id, pos, &req).await?))
+}
+
+async fn patch_remove<U: 'static + RouteUseCase>(
+    usecase: web::Data<U>,
+    path_params: web::Path<(RouteId, usize)>,
+) -> Result<HttpResponse> {
+    let (route_id, pos) = path_params.into_inner();
+    Ok(HttpResponse::Ok().json(usecase.remove_point(&route_id, pos).await?))
+}
+
+async fn patch_move<U: 'static + RouteUseCase>(
+    usecase: web::Data<U>,
+    path_params: web::Path<(RouteId, usize)>,
+    req: web::Json<NewPointRequest>,
+) -> Result<HttpResponse> {
+    let (route_id, pos) = path_params.into_inner();
+    Ok(HttpResponse::Ok().json(usecase.move_point(&route_id, pos, &req).await?))
+}
+
+async fn patch_clear<U: 'static + RouteUseCase>(
+    usecase: web::Data<U>,
+    route_id: web::Path<RouteId>,
+) -> Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(usecase.clear_route(&route_id).await?))
+}
+
+async fn patch_undo<U: 'static + RouteUseCase>(
+    usecase: web::Data<U>,
+    route_id: web::Path<RouteId>,
+) -> Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(usecase.undo_operation(&route_id).await?))
+}
+
+async fn patch_redo<U: 'static + RouteUseCase>(
+    usecase: web::Data<U>,
+    route_id: web::Path<RouteId>,
+) -> Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(usecase.redo_operation(&route_id).await?))
+}
+
+async fn delete<U: 'static + RouteUseCase>(
+    usecase: web::Data<U>,
+    id: web::Path<RouteId>,
+) -> Result<HttpResponse> {
+    usecase.delete(&id).await?;
+    Ok(HttpResponse::Ok().finish())
+}
+
+pub trait BuildRouteService: AddService {
+    fn build_route_service<U: 'static + RouteUseCase>(self) -> Self {
         // TODO: /の過不足は許容する ex) "/{id}/"
-        web::scope("/routes")
-            .service(
-                web::resource("/")
-                    .route(web::get().to(move || controller.get_all()))
-                    .route(web::post().to(move |req| controller.post(req))),
-            )
-            .service(
-                web::resource("/{id}")
-                    .route(web::get().to(move |id| controller.get(id)))
-                    .route(web::delete().to(move |id| controller.delete(id))),
-            )
-            .service(
-                web::resource("/{id}/gpx/").route(web::get().to(move |id| controller.get_gpx(id))),
-            )
-            .service(
-                web::resource("/{id}/rename/")
-                    .route(web::patch().to(move |id, req| controller.patch_rename(id, req))),
-            )
-            .service(
-                web::resource("/{id}/add/{pos}")
-                    .route(web::patch().to(move |path, req| controller.patch_add(path, req))),
-            )
-            .service(
-                web::resource("/{id}/remove/{pos}")
-                    .route(web::patch().to(move |path| controller.patch_remove(path))),
-            )
-            .service(
-                web::resource("/{id}/move/{pos}")
-                    .route(web::patch().to(move |path, req| controller.patch_move(path, req))),
-            )
-            .service(
-                web::resource("/{id}/clear/")
-                    .route(web::patch().to(move |id| controller.patch_clear(id))),
-            )
-            .service(
-                web::resource("/{id}/undo/")
-                    .route(web::patch().to(move |id| controller.patch_undo(id))),
-            )
-            .service(
-                web::resource("/{id}/redo/")
-                    .route(web::patch().to(move |id| controller.patch_redo(id))),
-            )
+        self.add_service(
+            web::scope("/routes")
+                .service(
+                    web::resource("/")
+                        .route(web::get().to(get_all::<U>))
+                        .route(web::post().to(post::<U>)),
+                )
+                .service(
+                    web::resource("/{id}")
+                        .route(web::get().to(get::<U>))
+                        .route(web::delete().to(delete::<U>)),
+                )
+                .service(web::resource("/{id}/gpx/").route(web::get().to(get_gpx::<U>)))
+                .service(web::resource("/{id}/rename/").route(web::patch().to(patch_rename::<U>)))
+                .service(web::resource("/{id}/add/{pos}").route(web::patch().to(patch_add::<U>)))
+                .service(
+                    web::resource("/{id}/remove/{pos}").route(web::patch().to(patch_remove::<U>)),
+                )
+                .service(web::resource("/{id}/move/{pos}").route(web::patch().to(patch_move::<U>)))
+                .service(web::resource("/{id}/clear/").route(web::patch().to(patch_clear::<U>)))
+                .service(web::resource("/{id}/undo/").route(web::patch().to(patch_undo::<U>)))
+                .service(web::resource("/{id}/redo/").route(web::patch().to(patch_redo::<U>))),
+        )
     }
 }
+
+impl<T: AddService> BuildRouteService for T {}

--- a/api/controller/src/route.rs
+++ b/api/controller/src/route.rs
@@ -1,8 +1,9 @@
 use actix_web::{dev, http, web, HttpResponse, Result, Scope};
 use tokio::sync::OnceCell;
 
+use route_bucket_domain::external::{ElevationApi, RouteInterpolationApi};
 use route_bucket_domain::model::RouteId;
-use route_bucket_domain::repository::{ElevationApi, RouteInterpolationApi, RouteRepository};
+use route_bucket_domain::repository::RouteRepository;
 use route_bucket_usecase::{NewPointRequest, RouteCreateRequest, RouteRenameRequest, RouteUseCase};
 
 pub struct RouteController<R, I, E> {

--- a/api/domain/src/external.rs
+++ b/api/domain/src/external.rs
@@ -1,0 +1,16 @@
+use async_trait::async_trait;
+
+use route_bucket_utils::ApplicationResult;
+
+use crate::model::{Coordinate, Elevation, Segment};
+
+#[async_trait]
+pub trait RouteInterpolationApi: Send + Sync {
+    async fn correct_coordinate(&self, coord: &Coordinate) -> ApplicationResult<Coordinate>;
+
+    async fn interpolate(&self, seg: &mut Segment) -> ApplicationResult<()>;
+}
+
+pub trait ElevationApi: Send + Sync {
+    fn get_elevation(&self, coord: &Coordinate) -> ApplicationResult<Option<Elevation>>;
+}

--- a/api/domain/src/external.rs
+++ b/api/domain/src/external.rs
@@ -11,6 +11,18 @@ pub trait RouteInterpolationApi: Send + Sync {
     async fn interpolate(&self, seg: &mut Segment) -> ApplicationResult<()>;
 }
 
+pub trait CallRouteInterpolationApi {
+    type RouteInterpolationApi: RouteInterpolationApi;
+
+    fn route_interpolation_api(&self) -> &Self::RouteInterpolationApi;
+}
+
 pub trait ElevationApi: Send + Sync {
     fn get_elevation(&self, coord: &Coordinate) -> ApplicationResult<Option<Elevation>>;
+}
+
+pub trait CallElevationApi {
+    type ElevationApi: ElevationApi;
+
+    fn elevation_api(&self) -> &Self::ElevationApi;
 }

--- a/api/domain/src/lib.rs
+++ b/api/domain/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod external;
 pub mod model;
 pub mod repository;

--- a/api/domain/src/repository.rs
+++ b/api/domain/src/repository.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use futures::future::BoxFuture;
 
-pub use route::RouteRepository;
+pub use route::{CallRouteRepository, RouteRepository};
 use route_bucket_utils::ApplicationResult;
 
 pub(crate) mod route;

--- a/api/domain/src/repository/route.rs
+++ b/api/domain/src/repository/route.rs
@@ -1,0 +1,70 @@
+use std::ops::Range;
+
+use async_trait::async_trait;
+
+use route_bucket_utils::ApplicationResult;
+
+use crate::model::{Operation, Route, RouteId, RouteInfo, Segment};
+use crate::repository::Repository;
+
+#[async_trait]
+pub trait RouteRepository: Repository {
+    // type Connection = <Self as Repository>::Connection;
+    // | error[E0658]: associated type defaults are unstable
+    // | see issue #29661 <https://github.com/rust-lang/rust/issues/29661> for more information
+
+    async fn find(
+        &self,
+        id: &RouteId,
+        conn: &<Self as Repository>::Connection,
+    ) -> ApplicationResult<Route>;
+
+    async fn find_info(
+        &self,
+        id: &RouteId,
+        conn: &<Self as Repository>::Connection,
+    ) -> ApplicationResult<RouteInfo>;
+
+    async fn find_all_infos(&self, conn: &Self::Connection) -> ApplicationResult<Vec<RouteInfo>>;
+
+    async fn insert_info(
+        &self,
+        info: &RouteInfo,
+        conn: &<Self as Repository>::Connection,
+    ) -> ApplicationResult<()>;
+
+    async fn insert_and_shift_segments(
+        &self,
+        id: &RouteId,
+        pos: u32,
+        seg: &Segment,
+        conn: &<Self as Repository>::Connection,
+    ) -> ApplicationResult<()>;
+
+    async fn insert_and_truncate_operations(
+        &self,
+        id: &RouteId,
+        pos: u32,
+        op: &Operation,
+        conn: &<Self as Repository>::Connection,
+    ) -> ApplicationResult<()>;
+
+    async fn update_info(
+        &self,
+        info: &RouteInfo,
+        conn: &<Self as Repository>::Connection,
+    ) -> ApplicationResult<()>;
+
+    async fn delete(
+        &self,
+        id: &RouteId,
+        conn: &<Self as Repository>::Connection,
+    ) -> ApplicationResult<()>;
+
+    async fn delete_and_shift_segments_by_range(
+        &self,
+        id: &RouteId,
+        range: Range<u32>,
+        conn: &<Self as Repository>::Connection,
+    ) -> ApplicationResult<()>;
+}

--- a/api/domain/src/repository/route.rs
+++ b/api/domain/src/repository/route.rs
@@ -68,3 +68,9 @@ pub trait RouteRepository: Repository {
         conn: &<Self as Repository>::Connection,
     ) -> ApplicationResult<()>;
 }
+
+pub trait CallRouteRepository {
+    type RouteRepository: RouteRepository;
+
+    fn route_repository(&self) -> &Self::RouteRepository;
+}

--- a/api/infrastructure/src/external/osrm.rs
+++ b/api/infrastructure/src/external/osrm.rs
@@ -1,8 +1,10 @@
-use async_trait::async_trait;
-use route_bucket_domain::model::{Coordinate, Polyline, Segment};
-use route_bucket_domain::repository::RouteInterpolationApi;
-use route_bucket_utils::{ApplicationError, ApplicationResult};
 use std::convert::TryInto;
+
+use async_trait::async_trait;
+
+use route_bucket_domain::external::RouteInterpolationApi;
+use route_bucket_domain::model::{Coordinate, Polyline, Segment};
+use route_bucket_utils::{ApplicationError, ApplicationResult};
 
 /// osrmでルート補間をするための構造体
 pub struct OsrmApi {

--- a/api/infrastructure/src/external/srtm.rs
+++ b/api/infrastructure/src/external/srtm.rs
@@ -1,14 +1,16 @@
-use byteorder::{BigEndian, ByteOrder, LittleEndian, ReadBytesExt};
-use num_traits::FromPrimitive;
-use route_bucket_domain::model::{Coordinate, Elevation, Latitude, Longitude};
-use route_bucket_domain::repository::ElevationApi;
-use route_bucket_utils::{ApplicationError, ApplicationResult};
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
+
+use byteorder::{BigEndian, ByteOrder, LittleEndian, ReadBytesExt};
+use num_traits::FromPrimitive;
+
+use route_bucket_domain::external::ElevationApi;
+use route_bucket_domain::model::{Coordinate, Elevation, Latitude, Longitude};
+use route_bucket_utils::{ApplicationError, ApplicationResult};
 
 #[derive(num_derive::FromPrimitive)]
 enum SrtmByteOrder {

--- a/api/src/bin/seed.rs
+++ b/api/src/bin/seed.rs
@@ -1,5 +1,5 @@
+use route_bucket_backend::server::Server;
 use route_bucket_domain::model::Coordinate;
-use route_bucket_infrastructure::{OsrmApi, RouteRepositoryMySql, SrtmReader};
 use route_bucket_usecase::RouteUseCase;
 
 macro_rules! coord {
@@ -12,50 +12,47 @@ macro_rules! coord {
 async fn main() {
     env_logger::init();
 
-    let route_repository = RouteRepositoryMySql::new().await;
-    let osrm_api = OsrmApi::new();
-    let srtm_reader = SrtmReader::new().unwrap();
-    let route_usecase = RouteUseCase::new(route_repository, osrm_api, srtm_reader);
+    let server = Server::new().await;
 
-    let route_id1 = route_usecase
+    let route_id1 = server
         .create(&String::from("sample1").into())
         .await
         .unwrap()
         .id;
 
-    let route_id2 = route_usecase
+    let route_id2 = server
         .create(&String::from("sample2: 皇居ラン").into())
         .await
         .unwrap()
         .id;
 
-    route_usecase
+    server
         .add_point(&route_id2, 0, &coord!(35.68136, 139.75875).into())
         .await
         .unwrap();
-    route_usecase
+    server
         .add_point(&route_id2, 1, &coord!(35.69053, 139.75681).into())
         .await
         .unwrap();
-    route_usecase
+    server
         .add_point(&route_id2, 2, &coord!(35.69510, 139.75139).into())
         .await
         .unwrap();
-    route_usecase
+    server
         .add_point(&route_id2, 3, &coord!(35.68942, 139.74547).into())
         .await
         .unwrap();
-    route_usecase
+    server
         .add_point(&route_id2, 4, &coord!(35.68418, 139.74424).into())
         .await
         .unwrap();
-    route_usecase
+    server
         .add_point(&route_id2, 5, &coord!(35.68136, 139.75875).into())
         .await
         .unwrap();
 
-    route_usecase.clear_route(&route_id2).await.unwrap();
-    route_usecase.undo_operation(&route_id2).await.unwrap();
+    server.clear_route(&route_id2).await.unwrap();
+    server.undo_operation(&route_id2).await.unwrap();
 
     log::info!("Route {} added!", route_id1);
     log::info!("Route {} added!", route_id2);

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod server;

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,46 +1,23 @@
 use actix_cors::Cors;
 use actix_web::middleware::Logger;
-use actix_web::{App, Error, HttpServer, Result};
-use tokio::sync::OnceCell;
+use actix_web::{web, App, Error, HttpServer, Result};
 
-use route_bucket_controller::{BuildService, RouteController};
-use route_bucket_infrastructure::OsrmApi;
-use route_bucket_infrastructure::{RouteRepositoryMySql, SrtmReader};
-use route_bucket_usecase::RouteUseCase;
-
-// TODO: ControllerとRepositoryMysql系のstructに共通trait実装してcontrollerの初期化を↓みたいに共通化したい
-// fn create_static_controller<Controller, Repository>() -> Lazy<Controller> {
-//     Lazy::new(|| {
-//         let pool = create_pool();
-//         let route_repository = Repository::new(pool);
-//         Controller::new(route_repository)
-//     })
-// }
-
-type StaticRouteController = OnceCell<RouteController<RouteRepositoryMySql, OsrmApi, SrtmReader>>;
+use route_bucket_backend::server::Server;
+use route_bucket_controller::BuildRouteService;
 
 #[actix_web::main]
 async fn main() -> Result<(), Error> {
     env_logger::init();
 
-    // staticじゃないと↓で怒られる
-    static ROUTE_CONTROLLER: StaticRouteController = OnceCell::const_new();
-    ROUTE_CONTROLLER
-        .get_or_init(|| async {
-            let route_repository = RouteRepositoryMySql::new().await;
-            let osrm_api = OsrmApi::new();
-            let srtm_reader = SrtmReader::new().unwrap();
-            let usecase = RouteUseCase::new(route_repository, osrm_api, srtm_reader);
-            RouteController::new(usecase)
-        })
-        .await;
+    let server = web::Data::new(Server::new().await);
 
     HttpServer::new(move || {
         App::new()
             // TODO: swagger以外からのアクセス(or development以外の環境)ではcorsを避けたい
             .wrap(Cors::permissive())
             .wrap(Logger::new("%a \"%r\" %s (%T s)"))
-            .service(ROUTE_CONTROLLER.build_service())
+            .app_data(server.clone())
+            .build_route_service::<Server>()
     })
     .bind("0.0.0.0:8080")?
     .run()

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -1,0 +1,44 @@
+use route_bucket_domain::external::{CallElevationApi, CallRouteInterpolationApi};
+use route_bucket_domain::repository::CallRouteRepository;
+use route_bucket_infrastructure::{OsrmApi, RouteRepositoryMySql, SrtmReader};
+
+pub struct Server {
+    route_repository: RouteRepositoryMySql,
+    srtm_reader: SrtmReader,
+    osrm_api: OsrmApi,
+}
+
+impl Server {
+    pub async fn new() -> Self {
+        Self {
+            route_repository: RouteRepositoryMySql::new().await,
+            srtm_reader: SrtmReader::new().unwrap(),
+            osrm_api: OsrmApi::new(),
+        }
+    }
+}
+
+// TODO: この辺のboiler plateたちをmacroでどうにかする
+impl CallRouteRepository for Server {
+    type RouteRepository = RouteRepositoryMySql;
+
+    fn route_repository(&self) -> &Self::RouteRepository {
+        &self.route_repository
+    }
+}
+
+impl CallElevationApi for Server {
+    type ElevationApi = SrtmReader;
+
+    fn elevation_api(&self) -> &Self::ElevationApi {
+        &self.srtm_reader
+    }
+}
+
+impl CallRouteInterpolationApi for Server {
+    type RouteInterpolationApi = OsrmApi;
+
+    fn route_interpolation_api(&self) -> &Self::RouteInterpolationApi {
+        &self.osrm_api
+    }
+}

--- a/api/usecase/Cargo.toml
+++ b/api/usecase/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = "0.1.50"
 derive_more = "0.99.16"
 futures = "0.3.15"
 getset = "0.1.1"

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -1,18 +1,19 @@
+use std::convert::TryInto;
+
 use derive_more::From;
 use futures::FutureExt;
 use getset::Getters;
 use itertools::Itertools;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+use route_bucket_domain::external::{ElevationApi, RouteInterpolationApi};
 use route_bucket_domain::model::{
     Coordinate, Distance, Elevation, Operation, Route, RouteGpx, RouteId, RouteInfo, Segment,
     SegmentList,
 };
-use route_bucket_domain::repository::{
-    Connection, ElevationApi, RouteInterpolationApi, RouteRepository,
-};
+use route_bucket_domain::repository::{Connection, RouteRepository};
 use route_bucket_utils::ApplicationResult;
-use serde::{Deserialize, Serialize};
-use std::convert::TryInto;
-use tokio::sync::Mutex;
 
 pub struct RouteUseCase<R, I, E> {
     repository: R,

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -1,5 +1,6 @@
 use std::convert::TryInto;
 
+use async_trait::async_trait;
 use derive_more::From;
 use futures::FutureExt;
 use getset::Getters;
@@ -7,38 +8,30 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 
-use route_bucket_domain::external::{ElevationApi, RouteInterpolationApi};
+use route_bucket_domain::external::{
+    CallElevationApi, CallRouteInterpolationApi, ElevationApi, RouteInterpolationApi,
+};
 use route_bucket_domain::model::{
     Coordinate, Distance, Elevation, Operation, Route, RouteGpx, RouteId, RouteInfo, Segment,
     SegmentList,
 };
-use route_bucket_domain::repository::{Connection, RouteRepository};
+use route_bucket_domain::repository::{
+    CallRouteRepository, Connection, Repository, RouteRepository,
+};
 use route_bucket_utils::ApplicationResult;
 
-pub struct RouteUseCase<R, I, E> {
-    repository: R,
-    interpolation_api: I,
-    elevation_api: E,
-}
-
-impl<R, I, E> RouteUseCase<R, I, E>
-where
-    R: RouteRepository,
-    I: RouteInterpolationApi,
-    E: ElevationApi,
+#[async_trait]
+pub trait RouteUseCase:
+    CallRouteRepository + CallRouteInterpolationApi + CallElevationApi + Sync
 {
-    pub fn new(repository: R, interpolation_api: I, elevation_api: E) -> Self {
-        Self {
-            repository,
-            interpolation_api,
-            elevation_api,
-        }
-    }
+    // type Connection = <<Self as CallRouteRepository>::RouteRepository as Repository>::Connection;
+    // --> error[E0658]: associated type defaults are unstable
+    // --> = note: see issue #29661 <https://github.com/rust-lang/rust/issues/29661> for more information
 
-    pub async fn find(&self, route_id: &RouteId) -> ApplicationResult<RouteGetResponse> {
-        let conn = self.repository.get_connection().await?;
+    async fn find(&self, route_id: &RouteId) -> ApplicationResult<RouteGetResponse> {
+        let conn = self.route_repository().get_connection().await?;
 
-        let mut route = self.repository.find(route_id, &conn).await?;
+        let mut route = self.route_repository().find(route_id, &conn).await?;
         self.attach_segment_details(route.seg_list_mut()).await?;
 
         Ok(RouteGetResponse {
@@ -50,45 +43,49 @@ where
         })
     }
 
-    pub async fn find_all(&self) -> ApplicationResult<RouteGetAllResponse> {
-        let conn = self.repository.get_connection().await?;
+    async fn find_all(&self) -> ApplicationResult<RouteGetAllResponse> {
+        let conn = self.route_repository().get_connection().await?;
 
         Ok(RouteGetAllResponse {
-            route_infos: self.repository.find_all_infos(&conn).await?,
+            route_infos: self.route_repository().find_all_infos(&conn).await?,
         })
     }
 
-    pub async fn find_gpx(&self, route_id: &RouteId) -> ApplicationResult<RouteGetGpxResponse> {
-        let conn = self.repository.get_connection().await?;
+    async fn find_gpx(&self, route_id: &RouteId) -> ApplicationResult<RouteGetGpxResponse> {
+        let conn = self.route_repository().get_connection().await?;
 
-        let mut route = self.repository.find(route_id, &conn).await?;
+        let mut route = self.route_repository().find(route_id, &conn).await?;
         self.attach_segment_details(route.seg_list_mut()).await?;
 
         route.try_into()
     }
 
-    pub async fn create(&self, req: &RouteCreateRequest) -> ApplicationResult<RouteCreateResponse> {
+    async fn create(&self, req: &RouteCreateRequest) -> ApplicationResult<RouteCreateResponse> {
         let route_info = RouteInfo::new(RouteId::new(), req.name(), 0);
 
-        let conn = self.repository.get_connection().await?;
-        self.repository.insert_info(&route_info, &conn).await?;
+        let conn = self.route_repository().get_connection().await?;
+        self.route_repository()
+            .insert_info(&route_info, &conn)
+            .await?;
 
         Ok(RouteCreateResponse {
             id: route_info.id().clone(),
         })
     }
 
-    pub async fn rename(
+    async fn rename(
         &self,
         route_id: &RouteId,
         req: &RouteRenameRequest,
     ) -> ApplicationResult<RouteInfo> {
-        let conn = self.repository.get_connection().await?;
+        let conn = self.route_repository().get_connection().await?;
         conn.transaction(|conn| {
             async move {
-                let mut route_info = self.repository.find_info(route_id, conn).await?;
+                let mut route_info = self.route_repository().find_info(route_id, conn).await?;
                 route_info.rename(req.name());
-                self.repository.update_info(&route_info, conn).await?;
+                self.route_repository()
+                    .update_info(&route_info, conn)
+                    .await?;
 
                 Ok(route_info)
             }
@@ -97,16 +94,16 @@ where
         .await
     }
 
-    pub async fn add_point(
+    async fn add_point(
         &self,
         route_id: &RouteId,
         pos: usize,
         req: &NewPointRequest,
     ) -> ApplicationResult<RouteOperationResponse> {
-        let conn = self.repository.get_connection().await?;
+        let conn = self.route_repository().get_connection().await?;
         conn.transaction(|conn| {
             async move {
-                let mut route = self.repository.find(route_id, conn).await?;
+                let mut route = self.route_repository().find(route_id, conn).await?;
                 let resp = self
                     .push_op_and_save(
                         &mut route,
@@ -124,15 +121,15 @@ where
         .await
     }
 
-    pub async fn remove_point(
+    async fn remove_point(
         &self,
         route_id: &RouteId,
         pos: usize,
     ) -> ApplicationResult<RouteOperationResponse> {
-        let conn = self.repository.get_connection().await?;
+        let conn = self.route_repository().get_connection().await?;
         conn.transaction(|conn| {
             async move {
-                let mut route = self.repository.find(route_id, conn).await?;
+                let mut route = self.route_repository().find(route_id, conn).await?;
                 let org_waypoints = route.gather_waypoints();
                 let resp = self
                     .push_op_and_save(&mut route, Operation::new_remove(pos, org_waypoints), conn)
@@ -147,16 +144,16 @@ where
         .await
     }
 
-    pub async fn move_point(
+    async fn move_point(
         &self,
         route_id: &RouteId,
         pos: usize,
         req: &NewPointRequest,
     ) -> ApplicationResult<RouteOperationResponse> {
-        let conn = self.repository.get_connection().await?;
+        let conn = self.route_repository().get_connection().await?;
         conn.transaction(|conn| {
             async move {
-                let mut route = self.repository.find(route_id, conn).await?;
+                let mut route = self.route_repository().find(route_id, conn).await?;
                 let org_waypoints = route.gather_waypoints();
                 let resp = self
                     .push_op_and_save(
@@ -173,14 +170,11 @@ where
         .await
     }
 
-    pub async fn clear_route(
-        &self,
-        route_id: &RouteId,
-    ) -> ApplicationResult<RouteOperationResponse> {
-        let conn = self.repository.get_connection().await?;
+    async fn clear_route(&self, route_id: &RouteId) -> ApplicationResult<RouteOperationResponse> {
+        let conn = self.route_repository().get_connection().await?;
         conn.transaction(|conn| {
             async move {
-                let mut route = self.repository.find(route_id, conn).await?;
+                let mut route = self.route_repository().find(route_id, conn).await?;
                 let org_waypoints = route.gather_waypoints();
                 let resp = self
                     .push_op_and_save(&mut route, Operation::new_clear(org_waypoints), conn)
@@ -193,14 +187,14 @@ where
         .await
     }
 
-    pub async fn redo_operation(
+    async fn redo_operation(
         &self,
         route_id: &RouteId,
     ) -> ApplicationResult<RouteOperationResponse> {
-        let conn = self.repository.get_connection().await?;
+        let conn = self.route_repository().get_connection().await?;
         conn.transaction(|conn| {
             async move {
-                let mut route = self.repository.find(route_id, conn).await?;
+                let mut route = self.route_repository().find(route_id, conn).await?;
                 route.redo_operation()?;
                 let resp = self.save_edited(&mut route, conn).await?;
 
@@ -211,14 +205,14 @@ where
         .await
     }
 
-    pub async fn undo_operation(
+    async fn undo_operation(
         &self,
         route_id: &RouteId,
     ) -> ApplicationResult<RouteOperationResponse> {
-        let conn = self.repository.get_connection().await?;
+        let conn = self.route_repository().get_connection().await?;
         conn.transaction(|conn| {
             async move {
-                let mut route = self.repository.find(route_id, conn).await?;
+                let mut route = self.route_repository().find(route_id, conn).await?;
                 route.undo_operation()?;
                 let resp = self.save_edited(&mut route, conn).await?;
 
@@ -229,9 +223,9 @@ where
         .await
     }
 
-    pub async fn delete(&self, route_id: &RouteId) -> ApplicationResult<()> {
-        let mut conn = self.repository.get_connection().await?;
-        self.repository.delete(route_id, &mut conn).await
+    async fn delete(&self, route_id: &RouteId) -> ApplicationResult<()> {
+        let mut conn = self.route_repository().get_connection().await?;
+        self.route_repository().delete(route_id, &mut conn).await
     }
 
     async fn attach_segment_details(&self, seg_list: &mut SegmentList) -> ApplicationResult<()> {
@@ -239,7 +233,9 @@ where
         seg_list.iter_mut().try_for_each(|seg| {
             seg.iter_mut()
                 .filter(|coord| coord.elevation().is_none())
-                .try_for_each(|coord| coord.set_elevation(self.elevation_api.get_elevation(coord)?))
+                .try_for_each(|coord| {
+                    coord.set_elevation(self.elevation_api().get_elevation(coord)?)
+                })
         })
     }
 
@@ -248,20 +244,20 @@ where
         route_id: &RouteId,
         pos: u32,
         seg: &mut Segment,
-        conn: &R::Connection,
+        conn: &<<Self as CallRouteRepository>::RouteRepository as Repository>::Connection,
     ) -> ApplicationResult<()> {
         let corrected_start = self
-            .interpolation_api
+            .route_interpolation_api()
             .correct_coordinate(seg.start())
             .await?;
         let corrected_goal = self
-            .interpolation_api
+            .route_interpolation_api()
             .correct_coordinate(seg.goal())
             .await?;
         seg.reset_endpoints(Some(corrected_start), Some(corrected_goal));
 
-        self.interpolation_api.interpolate(seg).await?;
-        self.repository
+        self.route_interpolation_api().interpolate(seg).await?;
+        self.route_repository()
             .insert_and_shift_segments(route_id, pos, seg, conn)
             .await?;
         Ok(())
@@ -271,11 +267,11 @@ where
         &self,
         route_id: &RouteId,
         seg_list: &mut SegmentList,
-        conn: &R::Connection,
+        conn: &<<Self as CallRouteRepository>::RouteRepository as Repository>::Connection,
     ) -> ApplicationResult<()> {
         let range =
             (seg_list.replaced_range().start as u32)..(seg_list.replaced_range().end as u32);
-        self.repository
+        self.route_repository()
             .delete_and_shift_segments_by_range(route_id, range, conn)
             .await?;
 
@@ -310,11 +306,13 @@ where
     async fn save_edited(
         &self,
         route: &mut Route,
-        conn: &R::Connection,
+        conn: &<<Self as CallRouteRepository>::RouteRepository as Repository>::Connection,
     ) -> ApplicationResult<RouteOperationResponse> {
         // TODO: posのrangeチェック
 
-        self.repository.update_info(route.info(), conn).await?;
+        self.route_repository()
+            .update_info(route.info(), conn)
+            .await?;
         self.interpolate_and_update_seg_list(
             &route.info().id().clone(),
             route.seg_list_mut(),
@@ -337,9 +335,9 @@ where
         &self,
         route: &mut Route,
         op: Operation,
-        conn: &R::Connection,
+        conn: &<<Self as CallRouteRepository>::RouteRepository as Repository>::Connection,
     ) -> ApplicationResult<RouteOperationResponse> {
-        self.repository
+        self.route_repository()
             .insert_and_truncate_operations(
                 route.info().id(),
                 *route.info().op_num() as u32,
@@ -350,6 +348,11 @@ where
         route.push_operation(op)?;
         self.save_edited(route, conn).await
     }
+}
+
+impl<T> RouteUseCase for T where
+    T: CallRouteRepository + CallRouteInterpolationApi + CallElevationApi + Sync
+{
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
Closes #48 

* #48 で指摘した通り、`RouteUseCase`をstructからtraitに変えることで、型パラメータが`Controller`まで浸食する汚さを回避しつつ、今後行うテストの実装をしやすくした（はず）
  * `RouteUseCase`は`RouteRepository`に直接依存するのではなく、`RouteRepository`を持つオブジェクトを返す`CallRouteRepository`というtraitに依存する形としている
    * これにより、他のusecaseが出てきたときに、`RouteRepository`の実体を簡単に共有できるようになる
  * テスト用のmockを作りたければ、そのtraitを実装した空のオブジェクトを作れば良い
  * 参考：https://keens.github.io/blog/2017/12/01/rustnodi/
* 今までは、`RouteController`という構造体を無理やりグローバル変数にして、それをクロージャで渡すことで、アプリケーションの状態を管理していたが、`actix-web`に元から入っている`Data`を使用する形に書き換えた
  * かなり奇妙で無理やり感満載の書き方だったため

今回の変更で、アーキテクチャが変わったので、ドキュメントも変更すべきだが、 #71 でもう少し手を加える予定なので、ドキュメントはそのときにまとめて更新する

今回もレイヤーごとにcommitを分けたので、commitごとに見てもらえると良さそう