### PR TITLE
`RouteUseCase`の単純化 & 一般化

### DIFF
--- a/api/controller/src/route.rs
+++ b/api/controller/src/route.rs
@@ -1,7 +1,9 @@
 use actix_web::{dev, http, web, HttpResponse, Result};
 
 use route_bucket_domain::model::RouteId;
-use route_bucket_usecase::{NewPointRequest, RouteCreateRequest, RouteRenameRequest, RouteUseCase};
+use route_bucket_usecase::route::{
+    NewPointRequest, RouteCreateRequest, RouteRenameRequest, RouteUseCase,
+};
 
 use crate::AddService;
 

--- a/api/domain/src/repository/route.rs
+++ b/api/domain/src/repository/route.rs
@@ -1,10 +1,8 @@
-use std::ops::Range;
-
 use async_trait::async_trait;
 
 use route_bucket_utils::ApplicationResult;
 
-use crate::model::{Operation, Route, RouteId, RouteInfo, Segment};
+use crate::model::{Route, RouteId, RouteInfo};
 use crate::repository::Repository;
 
 #[async_trait]
@@ -33,38 +31,17 @@ pub trait RouteRepository: Repository {
         conn: &<Self as Repository>::Connection,
     ) -> ApplicationResult<()>;
 
-    async fn insert_and_shift_segments(
-        &self,
-        id: &RouteId,
-        pos: u32,
-        seg: &Segment,
-        conn: &<Self as Repository>::Connection,
-    ) -> ApplicationResult<()>;
-
-    async fn insert_and_truncate_operations(
-        &self,
-        id: &RouteId,
-        pos: u32,
-        op: &Operation,
-        conn: &<Self as Repository>::Connection,
-    ) -> ApplicationResult<()>;
-
     async fn update_info(
         &self,
         info: &RouteInfo,
         conn: &<Self as Repository>::Connection,
     ) -> ApplicationResult<()>;
 
+    async fn update(&self, route: &Route, conn: &Self::Connection) -> ApplicationResult<()>;
+
     async fn delete(
         &self,
         id: &RouteId,
-        conn: &<Self as Repository>::Connection,
-    ) -> ApplicationResult<()>;
-
-    async fn delete_and_shift_segments_by_range(
-        &self,
-        id: &RouteId,
-        range: Range<u32>,
         conn: &<Self as Repository>::Connection,
     ) -> ApplicationResult<()>;
 }

--- a/api/src/bin/seed.rs
+++ b/api/src/bin/seed.rs
@@ -1,6 +1,6 @@
 use route_bucket_backend::server::Server;
 use route_bucket_domain::model::Coordinate;
-use route_bucket_usecase::RouteUseCase;
+use route_bucket_usecase::route::RouteUseCase;
 
 macro_rules! coord {
     ( $lat: expr, $lon: expr ) => {

--- a/api/usecase/src/lib.rs
+++ b/api/usecase/src/lib.rs
@@ -1,3 +1,1 @@
-pub use route::*;
-
-mod route;
+pub mod route;

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -61,19 +61,22 @@ pub trait RouteUseCase {
     async fn undo_operation(&self, route_id: &RouteId)
         -> ApplicationResult<RouteOperationResponse>;
 
+    async fn delete(&self, route_id: &RouteId) -> ApplicationResult<()>;
+}
+
+#[async_trait]
+impl<T> RouteUseCase for T
+where
+    T: CallRouteRepository + CallRouteInterpolationApi + CallElevationApi + Sync,
+{
     async fn find(&self, route_id: &RouteId) -> ApplicationResult<RouteGetResponse> {
         let conn = self.route_repository().get_connection().await?;
 
         let mut route = self.route_repository().find(route_id, &conn).await?;
-        self.attach_segment_details(route.seg_list_mut()).await?;
+        route.attach_distance_from_start()?;
+        self.elevation_api().attach_elevations(&mut route)?;
 
-        Ok(RouteGetResponse {
-            route_info: route.info().clone(),
-            waypoints: route.seg_list().gather_waypoints(),
-            segments: route.seg_list().clone().into_segments_in_between(),
-            elevation_gain: route.calc_elevation_gain(),
-            total_distance: route.seg_list().get_total_distance()?,
-        })
+        route.try_into()
     }
 
     async fn find_all(&self) -> ApplicationResult<RouteGetAllResponse> {
@@ -88,13 +91,14 @@ pub trait RouteUseCase {
         let conn = self.route_repository().get_connection().await?;
 
         let mut route = self.route_repository().find(route_id, &conn).await?;
-        self.attach_segment_details(route.seg_list_mut()).await?;
+        route.attach_distance_from_start()?;
+        self.elevation_api().attach_elevations(&mut route)?;
 
         route.try_into()
     }
 
     async fn create(&self, req: &RouteCreateRequest) -> ApplicationResult<RouteCreateResponse> {
-        let route_info = RouteInfo::new(RouteId::new(), req.name(), 0);
+        let route_info = RouteInfo::new(RouteId::new(), &req.name, 0);
 
         let conn = self.route_repository().get_connection().await?;
         self.route_repository()
@@ -115,7 +119,7 @@ pub trait RouteUseCase {
         conn.transaction(|conn| {
             async move {
                 let mut route_info = self.route_repository().find_info(route_id, conn).await?;
-                route_info.rename(req.name());
+                route_info.rename(&req.name);
                 self.route_repository()
                     .update_info(&route_info, conn)
                     .await?;
@@ -137,17 +141,23 @@ pub trait RouteUseCase {
         conn.transaction(|conn| {
             async move {
                 let mut route = self.route_repository().find(route_id, conn).await?;
-                let resp = self
-                    .push_op_and_save(
-                        &mut route,
-                        Operation::new_add(pos, req.coord().clone()),
-                        conn,
-                    )
+                let op = Operation::new_add(
+                    pos,
+                    self.route_interpolation_api()
+                        .correct_coordinate(&req.coord)
+                        .await?,
+                );
+                route.push_operation(op)?;
+
+                self.route_interpolation_api()
+                    .interpolate_empty_segments(&mut route)
                     .await?;
+                self.elevation_api().attach_elevations(&mut route)?;
+                route.attach_distance_from_start()?;
 
-                conn.commit_transaction().await?;
+                self.route_repository().update(&mut route, conn).await?;
 
-                Ok(resp)
+                route.try_into()
             }
             .boxed()
         })
@@ -163,14 +173,18 @@ pub trait RouteUseCase {
         conn.transaction(|conn| {
             async move {
                 let mut route = self.route_repository().find(route_id, conn).await?;
-                let org_waypoints = route.gather_waypoints();
-                let resp = self
-                    .push_op_and_save(&mut route, Operation::new_remove(pos, org_waypoints), conn)
+                let op = Operation::new_remove(pos, route.gather_waypoints());
+                route.push_operation(op)?;
+
+                self.route_interpolation_api()
+                    .interpolate_empty_segments(&mut route)
                     .await?;
+                self.elevation_api().attach_elevations(&mut route)?;
+                route.attach_distance_from_start()?;
 
-                conn.commit_transaction().await?;
+                self.route_repository().update(&mut route, conn).await?;
 
-                Ok(resp)
+                route.try_into()
             }
             .boxed()
         })
@@ -187,16 +201,24 @@ pub trait RouteUseCase {
         conn.transaction(|conn| {
             async move {
                 let mut route = self.route_repository().find(route_id, conn).await?;
-                let org_waypoints = route.gather_waypoints();
-                let resp = self
-                    .push_op_and_save(
-                        &mut route,
-                        Operation::new_move(pos, req.coord().clone(), org_waypoints),
-                        conn,
-                    )
-                    .await?;
+                let op = Operation::new_move(
+                    pos,
+                    self.route_interpolation_api()
+                        .correct_coordinate(&req.coord)
+                        .await?,
+                    route.gather_waypoints(),
+                );
+                route.push_operation(op)?;
 
-                Ok(resp)
+                self.route_interpolation_api()
+                    .interpolate_empty_segments(&mut route)
+                    .await?;
+                self.elevation_api().attach_elevations(&mut route)?;
+                route.attach_distance_from_start()?;
+
+                self.route_repository().update(&mut route, conn).await?;
+
+                route.try_into()
             }
             .boxed()
         })
@@ -208,12 +230,18 @@ pub trait RouteUseCase {
         conn.transaction(|conn| {
             async move {
                 let mut route = self.route_repository().find(route_id, conn).await?;
-                let org_waypoints = route.gather_waypoints();
-                let resp = self
-                    .push_op_and_save(&mut route, Operation::new_clear(org_waypoints), conn)
-                    .await?;
+                let op = Operation::new_clear(route.gather_waypoints());
+                route.push_operation(op)?;
 
-                Ok(resp)
+                self.route_interpolation_api()
+                    .interpolate_empty_segments(&mut route)
+                    .await?;
+                self.elevation_api().attach_elevations(&mut route)?;
+                route.attach_distance_from_start()?;
+
+                self.route_repository().update(&mut route, conn).await?;
+
+                route.try_into()
             }
             .boxed()
         })
@@ -229,9 +257,16 @@ pub trait RouteUseCase {
             async move {
                 let mut route = self.route_repository().find(route_id, conn).await?;
                 route.redo_operation()?;
-                let resp = self.save_edited(&mut route, conn).await?;
 
-                Ok(resp)
+                self.route_interpolation_api()
+                    .interpolate_empty_segments(&mut route)
+                    .await?;
+                self.elevation_api().attach_elevations(&mut route)?;
+                route.attach_distance_from_start()?;
+
+                self.route_repository().update(&mut route, conn).await?;
+
+                route.try_into()
             }
             .boxed()
         })
@@ -247,9 +282,16 @@ pub trait RouteUseCase {
             async move {
                 let mut route = self.route_repository().find(route_id, conn).await?;
                 route.undo_operation()?;
-                let resp = self.save_edited(&mut route, conn).await?;
 
-                Ok(resp)
+                self.route_interpolation_api()
+                    .interpolate_empty_segments(&mut route)
+                    .await?;
+                self.elevation_api().attach_elevations(&mut route)?;
+                route.attach_distance_from_start()?;
+
+                self.route_repository().update(&mut route, conn).await?;
+
+                route.try_into()
             }
             .boxed()
         })
@@ -260,179 +302,4 @@ pub trait RouteUseCase {
         let mut conn = self.route_repository().get_connection().await?;
         self.route_repository().delete(route_id, &mut conn).await
     }
-
-    async fn attach_segment_details(&self, seg_list: &mut SegmentList) -> ApplicationResult<()> {
-        seg_list.attach_distance_from_start()?;
-        seg_list.iter_mut().try_for_each(|seg| {
-            seg.iter_mut()
-                .filter(|coord| coord.elevation().is_none())
-                .try_for_each(|coord| {
-                    coord.set_elevation(self.elevation_api().get_elevation(coord)?)
-                })
-        })
-    }
-
-    async fn interpolate_and_insert_segment(
-        &self,
-        route_id: &RouteId,
-        pos: u32,
-        seg: &mut Segment,
-        conn: &<<Self as CallRouteRepository>::RouteRepository as Repository>::Connection,
-    ) -> ApplicationResult<()> {
-        let corrected_start = self
-            .route_interpolation_api()
-            .correct_coordinate(seg.start())
-            .await?;
-        let corrected_goal = self
-            .route_interpolation_api()
-            .correct_coordinate(seg.goal())
-            .await?;
-        seg.reset_endpoints(Some(corrected_start), Some(corrected_goal));
-
-        self.route_interpolation_api().interpolate(seg).await?;
-        self.route_repository()
-            .insert_and_shift_segments(route_id, pos, seg, conn)
-            .await?;
-        Ok(())
-    }
-
-    async fn interpolate_and_update_seg_list(
-        &self,
-        route_id: &RouteId,
-        seg_list: &mut SegmentList,
-        conn: &<<Self as CallRouteRepository>::RouteRepository as Repository>::Connection,
-    ) -> ApplicationResult<()> {
-        let range =
-            (seg_list.replaced_range().start as u32)..(seg_list.replaced_range().end as u32);
-        self.route_repository()
-            .delete_and_shift_segments_by_range(route_id, range, conn)
-            .await?;
-
-        // 参考：https://www.reddit.com/r/rust/comments/hezhti/help_needed_for_getting_async_and_fnmut_to_work/
-        let conn = Mutex::new(conn);
-
-        futures::future::join_all(
-            seg_list
-                .iter_mut()
-                .enumerate()
-                .filter(|(_, seg)| seg.is_empty())
-                .map(|(i, seg)| {
-                    let conn = &conn;
-                    async move {
-                        self.interpolate_and_insert_segment(
-                            route_id,
-                            i as u32,
-                            seg,
-                            &mut *conn.lock().await,
-                        )
-                        .await
-                    }
-                }),
-        )
-        .await
-        .into_iter()
-        .try_collect()?;
-
-        self.attach_segment_details(seg_list).await
-    }
-
-    async fn save_edited(
-        &self,
-        route: &mut Route,
-        conn: &<<Self as CallRouteRepository>::RouteRepository as Repository>::Connection,
-    ) -> ApplicationResult<RouteOperationResponse> {
-        // TODO: posのrangeチェック
-
-        self.route_repository()
-            .update_info(route.info(), conn)
-            .await?;
-        self.interpolate_and_update_seg_list(
-            &route.info().id().clone(),
-            route.seg_list_mut(),
-            conn,
-        )
-        .await?;
-
-        // NOTE: どうせここでcloneが必要なので、update_routeの戻り値にSegmentListを指定してもいいかもしれない
-        let seg_list = route.seg_list().clone();
-
-        Ok(RouteOperationResponse {
-            waypoints: seg_list.gather_waypoints(),
-            segments: seg_list.into_segments_in_between(),
-            elevation_gain: route.calc_elevation_gain(),
-            total_distance: route.seg_list().get_total_distance()?,
-        })
-    }
-
-    async fn push_op_and_save(
-        &self,
-        route: &mut Route,
-        op: Operation,
-        conn: &<<Self as CallRouteRepository>::RouteRepository as Repository>::Connection,
-    ) -> ApplicationResult<RouteOperationResponse> {
-        self.route_repository()
-            .insert_and_truncate_operations(
-                route.info().id(),
-                *route.info().op_num() as u32,
-                &op,
-                conn,
-            )
-            .await?;
-        route.push_operation(op)?;
-        self.save_edited(route, conn).await
-    }
-}
-
-impl<T> RouteUseCase for T where
-    T: CallRouteRepository + CallRouteInterpolationApi + CallElevationApi + Sync
-{
-}
-
-#[derive(Serialize)]
-pub struct RouteGetResponse {
-    #[serde(flatten)]
-    route_info: RouteInfo,
-    waypoints: Vec<Coordinate>,
-    segments: Vec<Segment>,
-    elevation_gain: Elevation,
-    total_distance: Distance,
-}
-
-#[derive(Serialize)]
-pub struct RouteGetAllResponse {
-    #[serde(rename = "routes")]
-    route_infos: Vec<RouteInfo>,
-}
-
-pub type RouteGetGpxResponse = RouteGpx;
-
-#[derive(From, Getters, Deserialize)]
-#[get = "pub"]
-pub struct RouteCreateRequest {
-    name: String,
-}
-
-#[derive(Serialize)]
-pub struct RouteCreateResponse {
-    pub id: RouteId,
-}
-
-#[derive(From, Getters, Deserialize)]
-#[get = "pub"]
-pub struct NewPointRequest {
-    coord: Coordinate,
-}
-
-#[derive(Serialize)]
-pub struct RouteOperationResponse {
-    waypoints: Vec<Coordinate>,
-    segments: Vec<Segment>,
-    elevation_gain: Elevation,
-    total_distance: Distance,
-}
-
-#[derive(From, Getters, Deserialize)]
-#[get = "pub"]
-pub struct RouteRenameRequest {
-    name: String,
 }

--- a/api/usecase/src/route/requests.rs
+++ b/api/usecase/src/route/requests.rs
@@ -1,0 +1,19 @@
+use derive_more::From;
+use serde::Deserialize;
+
+use route_bucket_domain::model::Coordinate;
+
+#[derive(From, Deserialize)]
+pub struct RouteCreateRequest {
+    pub(super) name: String,
+}
+
+#[derive(From, Deserialize)]
+pub struct NewPointRequest {
+    pub(super) coord: Coordinate,
+}
+
+#[derive(From, Deserialize)]
+pub struct RouteRenameRequest {
+    pub(super) name: String,
+}

--- a/api/usecase/src/route/responses.rs
+++ b/api/usecase/src/route/responses.rs
@@ -1,0 +1,67 @@
+use std::convert::TryFrom;
+
+use serde::Serialize;
+
+use route_bucket_domain::model::{
+    Coordinate, Distance, Elevation, Route, RouteGpx, RouteId, RouteInfo, Segment,
+};
+use route_bucket_utils::ApplicationError;
+
+#[derive(Serialize)]
+pub struct RouteGetResponse {
+    #[serde(flatten)]
+    pub(super) route_info: RouteInfo,
+    pub(super) waypoints: Vec<Coordinate>,
+    pub(super) segments: Vec<Segment>,
+    pub(super) elevation_gain: Elevation,
+    pub(super) total_distance: Distance,
+}
+
+#[derive(Serialize)]
+pub struct RouteGetAllResponse {
+    #[serde(rename = "routes")]
+    pub(super) route_infos: Vec<RouteInfo>,
+}
+
+pub type RouteGetGpxResponse = RouteGpx;
+
+#[derive(Serialize)]
+pub struct RouteCreateResponse {
+    pub(super) id: RouteId,
+}
+
+#[derive(Serialize)]
+pub struct RouteOperationResponse {
+    pub(super) waypoints: Vec<Coordinate>,
+    pub(super) segments: Vec<Segment>,
+    pub(super) elevation_gain: Elevation,
+    pub(super) total_distance: Distance,
+}
+
+impl TryFrom<Route> for RouteGetResponse {
+    type Error = ApplicationError;
+
+    fn try_from(route: Route) -> Result<Self, Self::Error> {
+        let (info, _, seg_list) = route.into();
+        Ok(RouteGetResponse {
+            route_info: info,
+            waypoints: seg_list.gather_waypoints(),
+            elevation_gain: seg_list.calc_elevation_gain(),
+            total_distance: seg_list.get_total_distance()?,
+            segments: seg_list.clone().into_segments_in_between(),
+        })
+    }
+}
+
+impl TryFrom<Route> for RouteOperationResponse {
+    type Error = ApplicationError;
+
+    fn try_from(route: Route) -> Result<Self, Self::Error> {
+        Ok(RouteOperationResponse {
+            waypoints: route.gather_waypoints(),
+            elevation_gain: route.calc_elevation_gain(),
+            total_distance: route.get_total_distance()?,
+            segments: route.into_segments_in_between(),
+        })
+    }
+}

--- a/api/usecase/src/route/responses.rs
+++ b/api/usecase/src/route/responses.rs
@@ -10,32 +10,32 @@ use route_bucket_utils::ApplicationError;
 #[derive(Serialize)]
 pub struct RouteGetResponse {
     #[serde(flatten)]
-    pub(super) route_info: RouteInfo,
-    pub(super) waypoints: Vec<Coordinate>,
-    pub(super) segments: Vec<Segment>,
-    pub(super) elevation_gain: Elevation,
-    pub(super) total_distance: Distance,
+    pub route_info: RouteInfo,
+    pub waypoints: Vec<Coordinate>,
+    pub segments: Vec<Segment>,
+    pub elevation_gain: Elevation,
+    pub total_distance: Distance,
 }
 
 #[derive(Serialize)]
 pub struct RouteGetAllResponse {
     #[serde(rename = "routes")]
-    pub(super) route_infos: Vec<RouteInfo>,
+    pub route_infos: Vec<RouteInfo>,
 }
 
 pub type RouteGetGpxResponse = RouteGpx;
 
 #[derive(Serialize)]
 pub struct RouteCreateResponse {
-    pub(super) id: RouteId,
+    pub id: RouteId,
 }
 
 #[derive(Serialize)]
 pub struct RouteOperationResponse {
-    pub(super) waypoints: Vec<Coordinate>,
-    pub(super) segments: Vec<Segment>,
-    pub(super) elevation_gain: Elevation,
-    pub(super) total_distance: Distance,
+    pub waypoints: Vec<Coordinate>,
+    pub segments: Vec<Segment>,
+    pub elevation_gain: Elevation,
+    pub total_distance: Distance,
 }
 
 impl TryFrom<Route> for RouteGetResponse {

--- a/docs/architecture-ja.md
+++ b/docs/architecture-ja.md
@@ -11,12 +11,13 @@
   * ルーティング
   * リクエストのバリデーション
   * UseCaseレイヤーの呼び出し
-* **UseCase**: アプリケーションの手続きを表現する層
+* **UseCase**: アプリケーションの手続きの流れを表現する層
   * Domainレイヤの操作
   * `Request` / `Response` 構造体の定義、生成
   * トランザクション管理
+  * この層では極力流れの表現に注力し、ロジックは`Domain`や`Infrastructure`に逃すべき
 * **Domain**: 業務上登場する概念やロジックをまとめた層
-* **Infrastructure**: ミドルウェアや外部APIとの繋ぎこみ
+* **Infrastructure**: ミドルウェアや外部APIとの繋ぎこみロジックを表す層
   * ミドルウェア/外部APIの呼び出し
   * 呼び出し結果のドメインモデルへの変換
 
@@ -25,28 +26,28 @@
 ![](./figs/data_flow.png)
 
 
-## `crate`, `struct`設計
-### `struct`一覧
-| crate            | struct (or trait)   | 説明 |
-| ---------------- | ------------------- | --- |
-| `controller`     | `Controller`        | RESTful APIのcontroller |
-| `usecase`        | `UseCase`           | アプリケーションの手続きを表現 <br> トランザクション管理 <br> `Request`, `Response`と`DomainModel`との変換を行う |
-|                  | `Request`           | `Controller`から`UseCase`へ渡すデータオブジェクト <br> jsonから`Deserialize`される <br> validationはここで行うべき |
-|                  | `Response`          | `UseCase`から`Controller`へ渡すデータオブジェクト <br> jsonへ`Serialize`される |
-| `domain`         | `DomainModel`       | Modelとしての振る舞い（＝自身のデータで完結する操作）を記述 |
-|                  | `DomainService`     | 異なる`DomainModel`同士の相互作用を表現 |
-|                  | `trait Repository`  | `infrastructure`でのデータアクセスロジックのインターフェス <br> 取得したデータを`DomainModel`へと変換して返す |
-|                  | `trait Api`         | 外部APIなどへのアクセスロジックのインターフェス <br> 取得したデータを`DomainModel`へと変換して返す |
-| `infrastructure` | `Repository`        | DBなどへのデータアクセスロジック <br> `domain::Repository`を実装 |
-|                  | `Api`               | 外部APIなどへのアクセスロジック <br> `domain::Api`を実装 |
+## `crate`設計
+### component一覧
+| crate            | rust component         | 説明 |
+| ---------------- | ---------------------- | --- |
+| `controller`     | `fn controller`        | RESTful APIの各エンドポイントを表現する関数 |
+| `usecase`        | `trait UseCase`        | アプリケーションの手続きを表現 <br> トランザクション管理 <br> `Request`, `Response`と`DomainModel`との変換を行う |
+|                  | `struct Request`       | `controller`から`UseCase`へ渡すデータオブジェクト <br> jsonから`Deserialize`される <br> validationはここで行うべき |
+|                  | `struct Response`      | `UseCase`から`controller`へ渡すデータオブジェクト <br> jsonへ`Serialize`される |
+| `domain`         | `struct DomainModel`   | Modelとしての振る舞い（＝自身のデータで完結する操作）を記述 |
+|                  | `struct DomainService` | 異なる`DomainModel`同士の相互作用を表現 |
+|                  | `trait Repository`     | `infrastructure`でのデータアクセスロジックのインターフェス <br> 取得したデータを`DomainModel`へと変換して返す |
+|                  | `trait Api`            | 外部APIなどへのアクセスロジックのインターフェス <br> 取得したデータを`DomainModel`へと変換して返す |
+| `infrastructure` | `struct Repository`    | DBなどへのデータアクセスロジック <br> `domain::Repository`を実装 |
+|                  | `struct Api`           | 外部APIなどへのアクセスロジック <br> `domain::Api`を実装 |
 
 ### 呼び出し規則
-| ↓呼出元 \ 呼出先→      | `Controller` | `UseCase` | `Request`/`Response` | `DomainModel` | `DomainService` | `trait Repository` | `trait Api` |
+| ↓呼出元 \ 呼出先→      | `controller` | `UseCase` | `Request`/`Response` | `DomainModel` | `DomainService` | `trait Repository` | `trait Api` |
 | -------------------  | --- | --- | --- | --- | --- | --- | --- |
-| `Controller`         | × | ⭕️ | ⭕️ | × | × | × | × |
+| `controller`         | × | ⭕️ | ⭕️ | × | × | × | × |
 | `UseCase`            | × | × | ⭕️ | ⭕️ | ⭕️ | ⭕️ | ⭕️ |
 | `Request`/`Response` | × | × | × | ⭕️ | × | × | × |
 | `DomainModel`        | × | × | × | ⭕️ （自身が所有するモデルのみ） | × | × | × |
 | `DomainService`      | × | × | × | ⭕️ | × | × | × |
-| `Repository`         | × | × | × | ⭕️ | × | ⭕️ | × |
-| `Api`                | × | × | × | ⭕️ | × | × | ⭕️ |
+| `struct Repository`  | × | × | × | ⭕️ | × | ⭕️ | × |
+| `struct Api`         | × | × | × | ⭕️ | × | × | ⭕️ |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,12 +11,13 @@ that brings together each of the following layers as a crate.
     * Routing
     * Validation of the request
     * Calling the `usecase` layer
-* **UseCase**: A layer that represents the procedures of the application
+* **UseCase**: A layer that represents the procedural flow of the application.
     * Manipulate the Domain layer 
     * Define and create the `Request` / `Response` struct
     * Transaction management
+    * In this layer, we should focus on expressing the "flow" as much as possible, and the "function" should be expressed in `Domain` and `Infrastructure`.
 * **Domain**: A layer that consolidates the concepts and logic that appear in the business
-* **Infrastructure**: Integration with middleware and external APIs
+* **Infrastructure**: A layer that represents the logic for interfacing with middleware and external APIs
     * Calling middleware/external APIs
     * Transforms responses into domain models
 
@@ -24,28 +25,28 @@ that brings together each of the following layers as a crate.
 ## Data Flow
 ![](./figs/data_flow.png)
 
-## `crate`, `struct` design
-### `struct` list
-| crate            | struct (or trait)   | description |
-| ---------------- | ------------------- | --- |
-| `controller`     | `Controller`        | controller for the RESTful API |
-| `usecase`        | `UseCase`           | Represents application procedures <br> Transaction management <br> Perform conversion between `Request`/`Response` and `DomainModel` |
-|                  | `Request`           | Data object to be passed from `Controller` to `UseCase` <br> Deserializable from json <br> Request validation should be done here. |
-|                  | `Response`          | Data object to be passed from `UseCase` to `Controller` <br> Serializable to json |
-| `domain`         | `DomainModel`       | Describes behavior as a Model (i.e., operations that are completed with its own data) |
-|                  | `DomainService`     | Represents of the interaction between different `DomainModel` |
-|                  | `trait Repository`  | Interfaces for data access logic in `infrastructure` <br> Converts the retrieved data to `DomainModel` and returns it |
-|                  | `trait Api`         | Interfaces for access logic to external APIs, etc. <br> Converts the retrieved data to `DomainModel` and returns it |
-| `infrastructure` | `Repository`        | Data access logic to DB, etc. <br> `impl domain::Repository` |
-|                  | `Api`               | Access logic to external APIs, etc. <br> `impl domain::Api` |
+## `crate` design
+### component list
+| crate            | rust component         | description |
+| ---------------- | ---------------------- | --- |
+| `controller`     | `fn controller`        | Functions to represent each endpoint of the RESTful API |
+| `usecase`        | `trait UseCase`        | Represents application procedures <br> Transaction management <br> Perform conversion between `Request`/`Response` and `DomainModel` |
+|                  | `struct Request`       | Data object to be passed from `controller` to `UseCase` <br> Deserializable from json <br> Request validation should be done here. |
+|                  | `struct Response`      | Data object to be passed from `UseCase` to `controller` <br> Serializable to json |
+| `domain`         | `struct DomainModel`   | Describes behavior as a Model (i.e., operations that are completed with its own data) |
+|                  | `struct DomainService` | Represents of the interaction between different `DomainModel` |
+|                  | `trait Repository`     | Interfaces for data access logic in `infrastructure` <br> Converts the retrieved data to `DomainModel` and returns it |
+|                  | `trait Api`            | Interfaces for access logic to external APIs, etc. <br> Converts the retrieved data to `DomainModel` and returns it |
+| `infrastructure` | `struct Repository`    | Data access logic to DB, etc. <br> `impl domain::Repository` |
+|                  | `struct Api`           | Access logic to external APIs, etc. <br> `impl domain::Api` |
 
 ### Access Rule
-| ↓Caller \ Callee→      | `Controller` | `UseCase` | `Request`/`Response` | `DomainModel` | `DomainService` | `trait Repository` | `trait Api` |
+| ↓Caller \ Callee→    | `controller` | `UseCase` | `Request`/`Response` | `DomainModel` | `DomainService` | `trait Repository` | `trait Api` |
 | -------------------  | --- | --- | --- | --- | --- | --- | --- |
-| `Controller`         | × | ⭕️ | ⭕️ | × | × | × | × |
+| `controller`         | × | ⭕️ | ⭕️ | × | × | × | × |
 | `UseCase`            | × | × | ⭕️ | ⭕️ | ⭕️ | ⭕️ | ⭕️ |
 | `Request`/`Response` | × | × | × | ⭕️ | × | × | × |
-| `DomainModel`        | × | × | × | ⭕️ (Owned models only) | × | × | × |
+| `DomainModel`        | × | × | × | ⭕️ （Owned models only） | × | × | × |
 | `DomainService`      | × | × | × | ⭕️ | × | × | × |
-| `Repository`         | × | × | × | ⭕️ | × | ⭕️ | × |
-| `Api`                | × | × | × | ⭕️ | × | × | ⭕️ |
+| `struct Repository`  | × | × | × | ⭕️ | × | ⭕️ | × |
+| `struct Api`         | × | × | × | ⭕️ | × | × | ⭕️ |


### PR DESCRIPTION
Closes #71 
* #71 の通り、テストのMockオブジェクトのために、`RouteUseCase`が直接`CallRouteRepository`などに依存しないようにし、その依存関係は`impl`を通じた特殊化によって提供するようにした
* usecaseはアプリケーションの手続きの流れを示すものであるべきで、ロジックはなるべく`domain`や`infrastructure`に逃すべきだということを学んだので、これを実践すべく、`SegmentList`や`RouteRepository`の高機能化と、それを用いた`RouteUseCase`の単純化を行った
  * 参考：https://qiita.com/sonatard/items/2243bd6dcefa1b85dbda
  * 結果、`RouteRepository`のinterfaceもシンプルになるなどの副作用もあった
* ついでに、`usecase/route.rs`から`requests.rs`と`response.rs`を分離した

## TODO

* [x] ドキュメントの編集