### PR TITLE
Clear操作の単純化

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,0 @@
-api/target
-api/resources/srtm_data/*.tif

--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,2 @@
+./target
+./resources/srtm_data/*.tif

--- a/api/domain/src/model/route/coordinate.rs
+++ b/api/domain/src/model/route/coordinate.rs
@@ -112,6 +112,42 @@ impl TryFrom<Polyline> for Vec<Coordinate> {
     }
 }
 
+impl From<Coordinate> for Polyline {
+    fn from(value: Coordinate) -> Self {
+        vec![value].into()
+    }
+}
+
+impl TryFrom<Polyline> for Coordinate {
+    type Error = ApplicationError;
+
+    fn try_from(value: Polyline) -> Result<Self, Self::Error> {
+        let mut coords = Vec::try_from(value)?;
+        if !coords.is_empty() {
+            Ok(coords.swap_remove(0))
+        } else {
+            Err(ApplicationError::DomainError(
+                "Cannot convert an empty Polyline into a Coordinate!".into(),
+            ))
+        }
+    }
+}
+
+impl From<Option<Coordinate>> for Polyline {
+    fn from(value: Option<Coordinate>) -> Self {
+        value.map(Polyline::from).unwrap_or(Polyline::new())
+    }
+}
+
+impl TryFrom<Polyline> for Option<Coordinate> {
+    type Error = ApplicationError;
+
+    fn try_from(value: Polyline) -> Result<Self, Self::Error> {
+        let mut coords = Vec::try_from(value)?;
+        Ok((!coords.is_empty()).then(|| coords.swap_remove(0)))
+    }
+}
+
 impl HaversineDistance<Distance> for Coordinate {
     fn haversine_distance(&self, rhs: &Self) -> Distance {
         geo::Point::new(self.longitude.value(), self.latitude.value())

--- a/api/domain/src/model/route/operation.rs
+++ b/api/domain/src/model/route/operation.rs
@@ -8,13 +8,11 @@ use route_bucket_utils::{ApplicationError, ApplicationResult};
 use super::coordinate::Coordinate;
 use super::segment_list::SegmentList;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum OperationType {
     Add,
     Remove,
     Move,
-    Clear,
-    InitWithList, // reverse operation for Clear
 }
 
 impl OperationType {
@@ -23,8 +21,6 @@ impl OperationType {
             OperationType::Add => OperationType::Remove,
             OperationType::Remove => OperationType::Add,
             OperationType::Move => OperationType::Move,
-            OperationType::Clear => OperationType::InitWithList,
-            OperationType::InitWithList => OperationType::Clear,
         }
     }
 }
@@ -37,8 +33,6 @@ impl TryFrom<String> for OperationType {
             "ad" => Ok(OperationType::Add),
             "rm" => Ok(OperationType::Remove),
             "mv" => Ok(OperationType::Move),
-            "cl" => Ok(OperationType::Clear),
-            "in" => Ok(OperationType::InitWithList),
             _ => Err(ApplicationError::DomainError(format!(
                 "Cannot convert {} into OperationType!",
                 value
@@ -53,8 +47,6 @@ impl From<OperationType> for String {
             OperationType::Add => "ad",
             OperationType::Remove => "rm",
             OperationType::Move => "mv",
-            OperationType::Clear => "cl",
-            OperationType::InitWithList => "in",
         }
         .into()
     }
@@ -64,53 +56,61 @@ impl From<OperationType> for String {
 #[get = "pub"]
 pub struct Operation {
     op_type: OperationType,
-    start_pos: usize,
-    org_coords: Vec<Coordinate>,
-    new_coords: Vec<Coordinate>,
+    pos: usize,
+    org_coord: Option<Coordinate>,
+    new_coord: Option<Coordinate>,
 }
 
 impl Operation {
     pub fn new(
         op_type: OperationType,
-        start_pos: usize,
-        org_coords: Vec<Coordinate>,
-        new_coords: Vec<Coordinate>,
+        pos: usize,
+        org_coord: Option<Coordinate>,
+        new_coord: Option<Coordinate>,
     ) -> Self {
         Self {
             op_type,
-            start_pos,
-            org_coords,
-            new_coords,
+            pos,
+            org_coord,
+            new_coord,
         }
     }
 
     pub fn new_add(pos: usize, coord: Coordinate) -> Self {
-        Self::new(OperationType::Add, pos, Vec::new(), vec![coord])
+        Self::new(OperationType::Add, pos, None, Some(coord))
     }
 
     pub fn new_remove(pos: usize, org_waypoints: Vec<Coordinate>) -> Self {
         let org = org_waypoints[pos].clone();
-        Self::new(OperationType::Remove, pos, vec![org], Vec::new())
+        Self::new(OperationType::Remove, pos, Some(org), None)
     }
 
     pub fn new_move(pos: usize, coord: Coordinate, org_waypoints: Vec<Coordinate>) -> Self {
         let org = org_waypoints[pos].clone();
-        Self::new(OperationType::Move, pos, vec![org], vec![coord])
-    }
-
-    pub fn new_clear(org_waypoints: Vec<Coordinate>) -> Self {
-        Self::new(OperationType::Clear, 0, org_waypoints, Vec::new())
+        Self::new(OperationType::Move, pos, Some(org), Some(coord))
     }
 
     pub fn apply(&self, seg_list: &mut SegmentList) -> ApplicationResult<()> {
-        seg_list.replace_range(
-            self.start_pos..self.start_pos + self.org_coords.len(),
-            self.new_coords.clone(),
-        )
+        match self.op_type {
+            OperationType::Remove => seg_list.remove_waypoint(self.pos),
+            OperationType::Add | OperationType::Move => {
+                if let Some(new_coord) = self.new_coord.clone() {
+                    if self.op_type == OperationType::Add {
+                        seg_list.insert_waypoint(self.pos, new_coord)
+                    } else {
+                        seg_list.move_waypoint(self.pos, new_coord)
+                    }
+                } else {
+                    Err(ApplicationError::DomainError(
+                        "OperationType::{Add | Move} must have new_coord!".into(),
+                    ))
+                }
+            }
+        }
     }
 
     pub fn reverse(&mut self) {
         self.op_type = self.op_type.reverse();
-        swap(&mut self.org_coords, &mut self.new_coords);
+        swap(&mut self.org_coord, &mut self.new_coord);
     }
 }

--- a/api/domain/src/model/route/route_info.rs
+++ b/api/domain/src/model/route/route_info.rs
@@ -25,6 +25,10 @@ impl RouteInfo {
     pub fn rename(&mut self, name: &String) {
         self.name = name.clone();
     }
+
+    pub fn clear_route(&mut self) {
+        self.op_num = 0;
+    }
 }
 
 impl From<RouteInfo> for Metadata {

--- a/api/domain/src/model/route/segment_list.rs
+++ b/api/domain/src/model/route/segment_list.rs
@@ -128,7 +128,7 @@ impl SegmentList {
             Ok(())
         } else {
             Err(ApplicationError::DomainError(format!(
-                "pos({}) cannot be greater than segment.len()({})",
+                "pos({}) cannot be greater than segments.len()({}) at SegmentList::insert_waypoint",
                 pos,
                 self.segments.len()
             )))
@@ -160,7 +160,7 @@ impl SegmentList {
             Ok(())
         } else {
             Err(ApplicationError::DomainError(format!(
-                "pos({}) cannot be greater than segment.len()({})",
+                "pos({}) cannot be greater than or equal to segments.len()({}) at SegmentList::remove_waypoint",
                 pos,
                 self.segments.len()
             )))

--- a/api/infrastructure/src/dto/operation.rs
+++ b/api/infrastructure/src/dto/operation.rs
@@ -24,22 +24,17 @@ impl OperationDto {
         } = self;
         let op_type = OperationType::try_from(code)?;
 
-        let [org_coords, new_coords] = <[Vec<Coordinate>; 2]>::try_from(
+        let [org_coord, new_coord] = <[Option<Coordinate>; 2]>::try_from(
             polyline
                 .split(" ")
                 .map(String::from)
                 .map(Polyline::from)
-                .map(Vec::try_from)
+                .map(Option::try_from)
                 .collect::<ApplicationResult<Vec<_>>>()?,
         )
         .unwrap();
 
-        Ok(Operation::new(
-            op_type,
-            pos as usize,
-            org_coords,
-            new_coords,
-        ))
+        Ok(Operation::new(op_type, pos as usize, org_coord, new_coord))
     }
 
     pub fn from_model(
@@ -47,14 +42,14 @@ impl OperationDto {
         route_id: &RouteId,
         index: u32,
     ) -> ApplicationResult<OperationDto> {
-        let org_polyline: String = Polyline::from(operation.org_coords().clone()).into();
-        let new_polyline: String = Polyline::from(operation.new_coords().clone()).into();
+        let org_polyline: String = Polyline::from(operation.org_coord().clone()).into();
+        let new_polyline: String = Polyline::from(operation.new_coord().clone()).into();
 
         Ok(OperationDto {
             route_id: route_id.to_string(),
             index,
             code: operation.op_type().clone().into(),
-            pos: *operation.start_pos() as u32,
+            pos: *operation.pos() as u32,
             polyline: [org_polyline, new_polyline].join(" "),
         })
     }

--- a/api/src/bin/seed.rs
+++ b/api/src/bin/seed.rs
@@ -51,9 +51,6 @@ async fn main() {
         .await
         .unwrap();
 
-    server.clear_route(&route_id2).await.unwrap();
-    server.undo_operation(&route_id2).await.unwrap();
-
     log::info!("Route {} added!", route_id1);
     log::info!("Route {} added!", route_id2);
 }


### PR DESCRIPTION
Closes #69 

#22 に向けて、主に`SegmentList`の挙動を単純化する目的

ついでに`.dockerignore`の置き場所がおかしかったので移動した

* `clear`と`init_with_list`が`OperationType`からなくなり、これらのundoやredoができなくなった
  * `clear`は`route_id`に紐づく`operations`と`segment`を全削除する操作に変更となった
* 単純化という意味では今回は準備段階で、メインは↓になる
  * 今回は主にUseCase側の変更
  * ↓のあといい加減テストを書きます
* これに伴ったDBの変更（`operations`のカラム長を短くするなど）は、 #78 とともに行う予定
  * idの追加をやると、`SegmentList`にDBとの差分の情報（`inserted_range`や`removed_range`）を入れる必要がなくなり、テストが割とシンプルになるはず（ついでに可読性も上がる）
  * 現状`RouteUseCase::clear_route`は`Route`を完全削除してから`RouteInfo`を復元するという遠回りをしているが、idの追加後に`RouteRepository::update`をさらに高機能化し、clearもここでできるようにする予定
  * いつもだったら、おそらくまとめて1PRにしていたが、これからはある程度粒度を気にして出していこうと思う
