### PR TITLE
DBの全テーブルにid付与 & `RouteRepository::update`の柔軟性向上

### DIFF
--- a/api/domain/src/model/route/operation.rs
+++ b/api/domain/src/model/route/operation.rs
@@ -5,6 +5,8 @@ use getset::Getters;
 
 use route_bucket_utils::{ApplicationError, ApplicationResult};
 
+use crate::model::types::OperationId;
+
 use super::coordinate::Coordinate;
 use super::segment_list::SegmentList;
 
@@ -55,6 +57,7 @@ impl From<OperationType> for String {
 #[derive(Clone, Debug, Getters)]
 #[get = "pub"]
 pub struct Operation {
+    id: OperationId,
     op_type: OperationType,
     pos: usize,
     org_coord: Option<Coordinate>,
@@ -69,6 +72,7 @@ impl Operation {
         new_coord: Option<Coordinate>,
     ) -> Self {
         Self {
+            id: OperationId::new(),
             op_type,
             pos,
             org_coord,

--- a/api/domain/src/model/route/segment_list.rs
+++ b/api/domain/src/model/route/segment_list.rs
@@ -167,9 +167,6 @@ impl SegmentList {
         self.remove_waypoint(pos)?;
         self.insert_waypoint(pos, coord)?;
 
-        let range_start = pos.checked_sub(1).unwrap_or(0);
-        let range_end = pos.checked_add(1).unwrap_or(self.segments.len());
-
         Ok(())
     }
 

--- a/api/domain/src/model/route/segment_list/segment.rs
+++ b/api/domain/src/model/route/segment_list/segment.rs
@@ -50,13 +50,6 @@ impl Segment {
         }
     }
 
-    pub fn reset_endpoints(&mut self, start_op: Option<Coordinate>, goal_op: Option<Coordinate>) {
-        self.start = start_op.unwrap_or(self.start.clone());
-        self.goal = goal_op.unwrap_or(self.goal.clone());
-
-        self.points.clear();
-    }
-
     pub fn is_empty(&self) -> bool {
         self.points.is_empty()
     }

--- a/api/domain/src/model/route/segment_list/segment.rs
+++ b/api/domain/src/model/route/segment_list/segment.rs
@@ -6,11 +6,14 @@ use serde::Serialize;
 
 use route_bucket_utils::{ApplicationError, ApplicationResult};
 
+use crate::model::types::SegmentId;
 use crate::model::{Coordinate, Distance, Polyline};
 
 #[derive(Clone, Debug, Getters, Serialize)]
 #[get = "pub"]
 pub struct Segment {
+    #[serde(skip_serializing)]
+    pub(super) id: SegmentId,
     #[serde(skip_serializing)]
     pub(super) start: Coordinate,
     #[serde(skip_serializing)]
@@ -21,6 +24,7 @@ pub struct Segment {
 impl Segment {
     pub fn new_empty(start: Coordinate, goal: Coordinate) -> Self {
         Self {
+            id: SegmentId::new(),
             start,
             goal,
             points: Vec::new(),
@@ -66,33 +70,19 @@ impl Segment {
     }
 }
 
-impl TryFrom<Vec<Coordinate>> for Segment {
+impl TryFrom<(String, String)> for Segment {
     type Error = ApplicationError;
 
-    fn try_from(points: Vec<Coordinate>) -> ApplicationResult<Self> {
+    fn try_from((id_str, polyline_str): (String, String)) -> ApplicationResult<Self> {
         let err = ApplicationError::DomainError(
             "Cannot Initialize Segment from an empty Vec<Coordinate>!".into(),
         );
+        let points = Vec::try_from(Polyline::from(polyline_str))?;
         Ok(Segment {
+            id: SegmentId::from_string(id_str),
             start: points.first().ok_or(err.clone())?.clone(),
             goal: points.last().ok_or(err.clone())?.clone(),
             points,
         })
-    }
-}
-
-impl TryFrom<Polyline> for Segment {
-    type Error = ApplicationError;
-
-    fn try_from(polyline: Polyline) -> ApplicationResult<Self> {
-        Segment::try_from(Vec::try_from(polyline)?)
-    }
-}
-
-impl TryFrom<String> for Segment {
-    type Error = ApplicationError;
-
-    fn try_from(polyline_str: String) -> ApplicationResult<Self> {
-        Segment::try_from(Polyline::from(polyline_str))
     }
 }

--- a/api/domain/src/model/types.rs
+++ b/api/domain/src/model/types.rs
@@ -5,17 +5,12 @@ use route_bucket_utils::{ApplicationError, ApplicationResult};
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
-// TODO: Value Object用のderive macroを作る
-// ↓みたいな一要素のタプル構造体たちにfrom, valueをデフォルトで実装したい
-// ただのgenericsでSelf(val)やself.0.clone()をしようとすると怒られるので、
-// derive macro + traitでやるしかなさそう
-
 #[derive(Display, Debug, Clone, Serialize, Deserialize)]
-pub struct RouteId(String);
+pub struct NanoId<const LEN: usize>(String);
 
-impl RouteId {
-    pub fn new() -> RouteId {
-        RouteId(nanoid!(11))
+impl<const LEN: usize> NanoId<LEN> {
+    pub fn new() -> Self {
+        Self(nanoid!(LEN))
     }
     pub fn from_string(id: String) -> Self {
         Self(id)
@@ -24,6 +19,11 @@ impl RouteId {
         self.0.clone()
     }
 }
+
+// TODO: Make this an derive macro (ex: #[derive(NanoId)])
+pub type RouteId = NanoId<11>;
+pub type SegmentId = NanoId<21>;
+pub type OperationId = NanoId<21>;
 
 #[derive(Display, From, Into, Debug, Clone, Serialize, Deserialize)]
 pub struct Polyline(String);

--- a/api/infrastructure/src/dto/operation.rs
+++ b/api/infrastructure/src/dto/operation.rs
@@ -7,6 +7,7 @@ use std::convert::TryFrom;
 #[derive(sqlx::FromRow, Getters)]
 #[get = "pub"]
 pub struct OperationDto {
+    id: String,
     route_id: String,
     index: u32,
     code: String,
@@ -46,6 +47,7 @@ impl OperationDto {
         let new_polyline: String = Polyline::from(operation.new_coord().clone()).into();
 
         Ok(OperationDto {
+            id: operation.id().to_string(),
             route_id: route_id.to_string(),
             index,
             code: operation.op_type().clone().into(),

--- a/api/infrastructure/src/dto/segment.rs
+++ b/api/infrastructure/src/dto/segment.rs
@@ -9,6 +9,7 @@ use route_bucket_utils::ApplicationResult;
 #[derive(sqlx::FromRow, Getters)]
 #[get = "pub"]
 pub struct SegmentDto {
+    id: String,
     route_id: String,
     index: u32,
     polyline: String,
@@ -16,7 +17,7 @@ pub struct SegmentDto {
 
 impl SegmentDto {
     pub fn into_model(self) -> ApplicationResult<Segment> {
-        Segment::try_from(Polyline::from(self.polyline))
+        Segment::try_from((self.id, self.polyline))
     }
 
     pub fn from_model(
@@ -25,6 +26,7 @@ impl SegmentDto {
         index: u32,
     ) -> ApplicationResult<SegmentDto> {
         Ok(SegmentDto {
+            id: segment.id().to_string(),
             route_id: route_id.to_string(),
             index: index,
             polyline: Polyline::from(segment.points().clone()).into(),

--- a/api/infrastructure/src/repository/route.rs
+++ b/api/infrastructure/src/repository/route.rs
@@ -2,7 +2,7 @@ use std::ops::Range;
 
 use async_trait::async_trait;
 use futures::FutureExt;
-use itertools::{zip, Itertools};
+use itertools::{enumerate, Itertools};
 use sqlx::mysql::MySqlPoolOptions;
 use sqlx::MySqlPool;
 use tokio::sync::Mutex;
@@ -28,37 +28,6 @@ impl RouteRepositoryMySql {
             .map(|res| res.map(Self))
             .await
             .unwrap()
-    }
-
-    // TODO: この辺を、テーブル名とかWHERE以下を変数にして関数にまとめる
-    async fn shift_segments(
-        id: &RouteId,
-        start_pos: u32,
-        to_right: bool,
-        width: u32,
-        conn: &<Self as Repository>::Connection,
-    ) -> ApplicationResult<()> {
-        let mut conn = conn.lock().await;
-
-        let query = format!(
-            r"
-            UPDATE segments 
-            SET `index` = `index` {} ? 
-            WHERE route_id = ? AND `index` >= ?
-            ORDER BY `route_id` {}
-            ",
-            if to_right { "+" } else { "-" },
-            if to_right { "DESC" } else { "ASC" }
-        );
-        sqlx::query(&query)
-            .bind(width)
-            .bind(id.to_string())
-            .bind(start_pos)
-            .execute(&mut *conn)
-            .await
-            .map_err(gen_err_mapper("failed to shift segments"))?;
-
-        Ok(())
     }
 
     async fn find_op_list(
@@ -146,7 +115,7 @@ impl RouteRepositoryMySql {
         Ok(())
     }
 
-    async fn insert_segment(
+    async fn insert_or_update_segment(
         id: &RouteId,
         pos: u32,
         seg: &Segment,
@@ -158,12 +127,14 @@ impl RouteRepositoryMySql {
         sqlx::query(
             r"
             INSERT INTO segments VALUES (?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE `index` = ?
             ",
         )
         .bind(dto.id())
         .bind(dto.route_id())
         .bind(dto.index())
         .bind(dto.polyline())
+        .bind(dto.index())
         .execute(&mut *conn)
         .await
         .map_err(gen_err_mapper("failed to insert Segment"))?;
@@ -176,24 +147,11 @@ impl RouteRepositoryMySql {
         seg_list: &SegmentList,
         conn: &<Self as Repository>::Connection,
     ) -> ApplicationResult<()> {
-        if let Some(removed_range) = seg_list.removed_range() {
-            let start = removed_range.start as u32;
-            let end = removed_range.end as u32;
-            Self::delete_segments_by_range(id, start..end, conn).await?;
-            Self::shift_segments(id, end, false, end - start, conn).await?;
+        // SQLx cannot bulk insert yet.
+        for (pos, seg) in enumerate(seg_list.segments()) {
+            Self::insert_or_update_segment(id, pos as u32, seg, conn).await?;
         }
-
-        if let Some(inserted_range) = seg_list.inserted_range() {
-            let start = inserted_range.start as u32;
-            let end = inserted_range.end as u32;
-            Self::shift_segments(id, start, true, end - start, conn).await?;
-
-            // SQLx cannot bulk insert yet.
-            for (pos, seg) in zip(start..end, seg_list.get_inserted_slice()?) {
-                Self::insert_segment(id, pos, seg, conn).await?;
-            }
-        }
-
+        Self::delete_segments_except_for(id, seg_list, conn).await?;
         Ok(())
     }
 
@@ -218,27 +176,39 @@ impl RouteRepositoryMySql {
         Ok(())
     }
 
-    async fn delete_segments_by_range(
+    async fn delete_segments_except_for(
         id: &RouteId,
-        range: Range<u32>,
+        segment_list: &SegmentList,
         conn: &<Self as Repository>::Connection,
     ) -> ApplicationResult<()> {
         let mut conn = conn.lock().await;
 
-        sqlx::query(
+        // NOTE: hacky solution in order to use the IN statement
+        //     : waiting for vec binding on SQLx...
+        let seg_id_exception_clause = if segment_list.segments().is_empty() {
+            "TRUE".into()
+        } else {
+            let seg_ids = segment_list
+                .iter()
+                .map(|seg| format!("'{}'", seg.id().to_string()))
+                .collect_vec()
+                .join(",");
+            format!("id NOT IN ({})", seg_ids)
+        };
+
+        let query = format!(
             r"
             DELETE FROM segments 
             WHERE 
-                  `route_id` = ? AND 
-                  ? <= `index` AND `index` < ?
+                  `route_id` = ? AND {}
             ",
-        )
-        .bind(id.to_string())
-        .bind(range.start)
-        .bind(range.end)
-        .execute(&mut *conn)
-        .await
-        .map_err(gen_err_mapper("failed to delete segments by range"))?;
+            seg_id_exception_clause
+        );
+        sqlx::query(&query)
+            .bind(&id.to_string())
+            .execute(&mut *conn)
+            .await
+            .map_err(gen_err_mapper("failed to delete segments"))?;
 
         Ok(())
     }

--- a/api/infrastructure/src/repository/route.rs
+++ b/api/infrastructure/src/repository/route.rs
@@ -156,9 +156,10 @@ impl RouteRepositoryMySql {
 
         sqlx::query(
             r"
-            INSERT INTO segments VALUES (?, ?, ?)
+            INSERT INTO segments VALUES (?, ?, ?, ?)
             ",
         )
+        .bind(dto.id())
         .bind(dto.route_id())
         .bind(dto.index())
         .bind(dto.polyline())

--- a/api/infrastructure/src/repository/route.rs
+++ b/api/infrastructure/src/repository/route.rs
@@ -1,5 +1,3 @@
-use std::ops::Range;
-
 use async_trait::async_trait;
 use futures::FutureExt;
 use itertools::{enumerate, Itertools};

--- a/api/infrastructure/src/repository/route.rs
+++ b/api/infrastructure/src/repository/route.rs
@@ -117,9 +117,10 @@ impl RouteRepositoryMySql {
         sqlx::query(
             r"
             INSERT INTO operations
-            VALUES (?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?)
             ",
         )
+        .bind(dto.id())
         .bind(dto.route_id())
         .bind(dto.index())
         .bind(dto.code())

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -8,7 +8,7 @@ pub use responses::*;
 use route_bucket_domain::external::{
     CallElevationApi, CallRouteInterpolationApi, ElevationApi, RouteInterpolationApi,
 };
-use route_bucket_domain::model::{Distance, Elevation, Operation, Route, RouteId, RouteInfo};
+use route_bucket_domain::model::{Operation, Route, RouteId, RouteInfo};
 use route_bucket_domain::repository::{
     CallRouteRepository, Connection, Repository, RouteRepository,
 };

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -23,7 +23,7 @@ CREATE TABLE operations
     `index`    INTEGER UNSIGNED                   NOT NULL,
     `code`     CHAR(2) CHARACTER SET ascii        NOT NULL,
     `pos`      INTEGER UNSIGNED                   NOT NULL,
-    `polyline` VARCHAR(65000) CHARACTER SET ascii NOT NULL,
+    `polyline` VARCHAR(30) CHARACTER SET ascii NOT NULL,
     INDEX segment_idx (`route_id`, `index`),
     PRIMARY KEY (`id`)
 );

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -8,18 +8,22 @@ CREATE TABLE routes
 
 CREATE TABLE segments
 (
+    `id`       VARCHAR(21)                        NOT NULL,
     `route_id` VARCHAR(11)                        NOT NULL,
     `index`    INTEGER UNSIGNED                   NOT NULL,
     `polyline` VARCHAR(65000) CHARACTER SET ascii NOT NULL,
-    INDEX segment_idx (`route_id`, `index`)
+    INDEX segment_idx (`route_id`, `index`),
+    PRIMARY KEY (`id`)
 );
 
 CREATE TABLE operations
 (
-    `route_id` VARCHAR(11)                      NOT NULL,
-    `index`    INTEGER UNSIGNED                 NOT NULL,
-    `code`     CHAR(2) CHARACTER SET ascii      NOT NULL,
-    `pos`      INTEGER UNSIGNED                 NOT NULL,
+    `id`       VARCHAR(21)                        NOT NULL,
+    `route_id` VARCHAR(11)                        NOT NULL,
+    `index`    INTEGER UNSIGNED                   NOT NULL,
+    `code`     CHAR(2) CHARACTER SET ascii        NOT NULL,
+    `pos`      INTEGER UNSIGNED                   NOT NULL,
     `polyline` VARCHAR(65000) CHARACTER SET ascii NOT NULL,
-    PRIMARY KEY (`route_id`, `index`)
+    INDEX segment_idx (`route_id`, `index`),
+    PRIMARY KEY (`id`)
 );


### PR DESCRIPTION
Closes #78 

* `segments`, `operations`に`id`を追加
  * `routes`の`id`と異なり、URLに現れることはないので、長さをnanoidとして標準の21とした
* ↑に伴い、`Segment`, `Operation`にも`id`を追加
* `segments`に`id`を振ったことにより、`Segment`のどこが更新されたかを表すフィールド（`removed_range`, `inserted_range`）が不要になったため、テストを書く時の状態数が減った（はず）
* `id`を振ったことにより、`RouteRepository::update`の操作が、任意の`Route`を効率的に捌けるようになった
  * 今までは、clear操作には対応していなかった