### PR TITLE
OSRMの地図の拡大 & 自転車用設定ファイルのカスタマイズ

### DIFF
--- a/osrm/Dockerfile
+++ b/osrm/Dockerfile
@@ -5,10 +5,12 @@ RUN apt-get -q update && \
     apt-get -q install -y wget
 
 # 地図情報のダウンロード（ここいじるとダウンロードやり直しになるので注意）
+# NOTE: リンクをhttpsではなくhttpとしているのは、証明書がexpireしがちだから
+#     : 参考： https://github.com/graphhopper/graphhopper/issues/1417
 RUN mkdir /data && \
-    wget --progress=bar:force:noscroll -O /data/map.osm.pbf https://download.geofabrik.de/asia/japan/kanto-latest.osm.pbf
+    wget --progress=bar:force:noscroll -O /data/map.osm.pbf http://download.geofabrik.de/asia/japan-latest.osm.pbf
 
 # 地図データの前処理
-RUN osrm-extract -p /opt/bicycle.lua /data/map.osm.pbf && \
-    osrm-partition /data/map.osrm && \
-    osrm-customize /data/map.osrm
+RUN osrm-extract -p /opt/bicycle.lua /data/map.osm.pbf
+RUN osrm-partition /data/map.osrm
+RUN osrm-customize /data/map.osrm

--- a/osrm/Dockerfile
+++ b/osrm/Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir /data && \
     wget --progress=bar:force:noscroll -O /data/map.osm.pbf http://download.geofabrik.de/asia/japan-latest.osm.pbf
 
 # 地図データの前処理
-COPY ./bicycle.lua /opt/bicycle.lua
-RUN osrm-extract -p /opt/bicycle.lua /data/map.osm.pbf
+COPY ./customized.lua /opt/customized.lua
+RUN osrm-extract -p /opt/customized.lua /data/map.osm.pbf
 RUN osrm-partition /data/map.osrm
 RUN osrm-customize /data/map.osrm

--- a/osrm/customized.lua
+++ b/osrm/customized.lua
@@ -120,6 +120,8 @@ function setup()
 
     bicycle_speeds = {
       cycleway = default_speed,
+      trunk = default_speed,
+      trunk_link = default_speed,
       primary = default_speed,
       primary_link = default_speed,
       secondary = default_speed,


### PR DESCRIPTION
* 地図の範囲を関東から日本全体に広げた
* デフォルトで入っていた設定ファイルである、`bicycle.lua`を編集し、国道（[`highway=trunk`](https://wiki.openstreetmap.org/wiki/JA:Tag:highway=trunk)）も通れるようにした
  * これにより、中禅寺湖の上の道路が通れなかった問題が解消された
![スクリーンショット 2021-10-21 2 09 55（2）](https://user-images.githubusercontent.com/35961216/138140051-0a48f4cb-a410-46fe-aace-3dd675db0c7a.png)

* 参考
  * OSRMのエディタ：https://www.openstreetmap.org/
    * ここでロマンチック街道のtagを調べた
  * OSRMのconfigをいじる際の参考：charilab氏
    * http://charilab.sakura.ne.jp/blog/2016/12/05/0002/
    * https://github.com/charilab/map-samples/blob/master/routing/profiles/charilab.lua.diff