### PR TITLE
IDのtypeたちをコンパイラで区別できるようにした

### DIFF
--- a/api/domain/src/model.rs
+++ b/api/domain/src/model.rs
@@ -1,12 +1,12 @@
 // TODO: この辺をmodel/route.rsに移動して、外からもmodel::route::でアクセスさせるようにする
 pub use route::bounding_box::BoundingBox;
 pub use route::coordinate::Coordinate;
-pub use route::operation::{Operation, OperationType, SegmentTemplate};
+pub use route::operation::{Operation, OperationId, OperationType, SegmentTemplate};
 pub use route::route_gpx::RouteGpx;
 pub use route::route_info::RouteInfo;
 pub use route::segment_list::{DrawingMode, Segment, SegmentList};
-pub use route::Route;
-pub use types::{Distance, Elevation, Latitude, Longitude, OperationId, Polyline, RouteId};
+pub use route::{Route, RouteId};
+pub use types::{Distance, Elevation, Latitude, Longitude, Polyline};
 
 pub(crate) mod route;
 pub(crate) mod types;

--- a/api/domain/src/model/route.rs
+++ b/api/domain/src/model/route.rs
@@ -13,12 +13,16 @@ use self::operation::Operation;
 use self::route_info::RouteInfo;
 use self::segment_list::{Segment, SegmentList};
 
+use super::types::NanoId;
+
 pub(crate) mod bounding_box;
 pub(crate) mod coordinate;
 pub(crate) mod operation;
 pub(crate) mod route_gpx;
 pub(crate) mod route_info;
 pub(crate) mod segment_list;
+
+pub type RouteId = NanoId<Route, 11>;
 
 #[derive(Clone, Debug, From, Into, Getters)]
 #[get = "pub"]

--- a/api/domain/src/model/route/operation.rs
+++ b/api/domain/src/model/route/operation.rs
@@ -6,13 +6,15 @@ use serde::{Deserialize, Serialize};
 
 use route_bucket_utils::{ApplicationError, ApplicationResult};
 
-use crate::model::types::OperationId;
+use crate::model::types::NanoId;
 
 use super::coordinate::Coordinate;
 use super::segment_list::{DrawingMode, Segment, SegmentList};
 
 #[cfg(any(test, feature = "fixtures"))]
 use derivative::Derivative;
+
+pub type OperationId = NanoId<Operation, 21>;
 
 #[derive(Clone, Debug, PartialEq, Eq, strum::Display, strum::EnumString)]
 pub enum OperationType {

--- a/api/domain/src/model/route/route_info.rs
+++ b/api/domain/src/model/route/route_info.rs
@@ -1,10 +1,10 @@
 use getset::Getters;
 use serde::{Deserialize, Serialize};
 
-use crate::model::RouteId;
-
 #[cfg(any(test, feature = "fixtures"))]
 use derivative::Derivative;
+
+use super::RouteId;
 
 #[derive(Clone, Debug, Getters, Deserialize, Serialize)]
 #[get = "pub"]

--- a/api/domain/src/model/route/segment_list/segment.rs
+++ b/api/domain/src/model/route/segment_list/segment.rs
@@ -8,8 +8,10 @@ use serde::{Deserialize, Serialize};
 
 use route_bucket_utils::{ApplicationError, ApplicationResult};
 
-use crate::model::types::SegmentId;
+use crate::model::types::NanoId;
 use crate::model::{Coordinate, Distance, Polyline};
+
+pub(crate) type SegmentId = NanoId<Segment, 21>;
 
 #[derive(
     Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,

--- a/api/domain/src/model/types.rs
+++ b/api/domain/src/model/types.rs
@@ -1,4 +1,5 @@
 use std::convert::TryFrom;
+use std::marker::PhantomData;
 
 use derive_more::{Add, AddAssign, Display, From, Into, Sub, Sum};
 use nanoid::nanoid;
@@ -8,21 +9,25 @@ use serde::{Deserialize, Serialize};
 use route_bucket_utils::{ApplicationError, ApplicationResult};
 
 #[derive(Display, Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct NanoId<const LEN: usize>(String);
-
-impl<const LEN: usize> NanoId<LEN> {
-    pub fn new() -> Self {
-        Self(nanoid!(LEN))
-    }
-    pub fn from_string(id: String) -> Self {
-        Self(id)
-    }
+#[display(fmt = "{}", id)]
+#[serde(transparent)]
+pub struct NanoId<T, const LEN: usize> {
+    id: String,
+    #[serde(skip)]
+    _phantom: PhantomData<T>,
 }
 
-// TODO: Make this an derive macro (ex: #[derive(NanoId)])
-pub type RouteId = NanoId<11>;
-pub type SegmentId = NanoId<21>;
-pub type OperationId = NanoId<21>;
+impl<T, const LEN: usize> NanoId<T, LEN> {
+    pub fn new() -> Self {
+        Self::from_string(nanoid!(LEN))
+    }
+    pub fn from_string(id: String) -> Self {
+        Self {
+            id,
+            _phantom: PhantomData,
+        }
+    }
+}
 
 #[derive(Default, Display, From, Into, Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Polyline(String);


### PR DESCRIPTION
今までは単に`NanoId`にエイリアスを貼っていただけなので、例えば`SegmentId`と`OperationId`はともに`NanoId<21>`に対応していて、相互に代入が可能となってしまっていた

これを、`Phantom`を用いることにより解消した

これにより、今後は同じ長さのIDであっても別のPhantomTypeを指定していれば相互代入などはコンパイルエラーになってくれる

参考：https://keens.github.io/blog/2018/12/15/rustdetsuyomenikatawotsukerupart_1__new_type_pattern/