### PR TITLE
domainでのパスのリファクタ

### DIFF
--- a/api/controller/src/route.rs
+++ b/api/controller/src/route.rs
@@ -1,6 +1,6 @@
 use actix_web::{dev, http, web, HttpResponse, Result};
 
-use route_bucket_domain::model::RouteId;
+use route_bucket_domain::model::route::RouteId;
 use route_bucket_usecase::route::{
     NewPointRequest, RemovePointRequest, RouteCreateRequest, RouteRenameRequest, RouteUseCase,
 };

--- a/api/domain/src/external.rs
+++ b/api/domain/src/external.rs
@@ -3,8 +3,7 @@ use itertools::Itertools;
 
 use route_bucket_utils::ApplicationResult;
 
-use crate::model::route::segment_list::Segment;
-use crate::model::{Coordinate, DrawingMode, Elevation, Route};
+use crate::model::route::{Coordinate, DrawingMode, Elevation, Route, Segment};
 
 #[cfg_attr(feature = "mocking", mockall::automock)]
 #[async_trait]

--- a/api/domain/src/model.rs
+++ b/api/domain/src/model.rs
@@ -1,7 +1,5 @@
-pub use types::{Distance, Elevation, Latitude, Longitude, Polyline};
-
 pub mod route;
-pub(crate) mod types;
+pub mod types;
 
 #[cfg(feature = "fixtures")]
 pub mod fixtures {

--- a/api/domain/src/model.rs
+++ b/api/domain/src/model.rs
@@ -3,11 +3,13 @@ pub mod types;
 
 #[cfg(feature = "fixtures")]
 pub mod fixtures {
-    pub use super::route::bounding_box::tests::BoundingBoxFixture;
-    pub use super::route::coordinate::tests::CoordinateFixtures;
-    pub use super::route::operation::tests::OperationFixtures;
-    pub use super::route::route_gpx::tests::RouteGpxFixtures;
-    pub use super::route::route_info::tests::RouteInfoFixtures;
-    pub use super::route::segment_list::tests::{SegmentFixtures, SegmentListFixture};
-    pub use super::route::tests::RouteFixtures;
+    pub mod route {
+        pub use crate::model::route::bounding_box::tests::BoundingBoxFixture;
+        pub use crate::model::route::coordinate::tests::CoordinateFixtures;
+        pub use crate::model::route::operation::tests::OperationFixtures;
+        pub use crate::model::route::route_gpx::tests::RouteGpxFixtures;
+        pub use crate::model::route::route_info::tests::RouteInfoFixtures;
+        pub use crate::model::route::segment_list::tests::{SegmentFixtures, SegmentListFixture};
+        pub use crate::model::route::tests::RouteFixtures;
+    }
 }

--- a/api/domain/src/model.rs
+++ b/api/domain/src/model.rs
@@ -1,14 +1,6 @@
-// TODO: この辺をmodel/route.rsに移動して、外からもmodel::route::でアクセスさせるようにする
-pub use route::bounding_box::BoundingBox;
-pub use route::coordinate::Coordinate;
-pub use route::operation::{Operation, OperationId, OperationType, SegmentTemplate};
-pub use route::route_gpx::RouteGpx;
-pub use route::route_info::RouteInfo;
-pub use route::segment_list::{DrawingMode, Segment, SegmentList};
-pub use route::{Route, RouteId};
 pub use types::{Distance, Elevation, Latitude, Longitude, Polyline};
 
-pub(crate) mod route;
+pub mod route;
 pub(crate) mod types;
 
 #[cfg(feature = "fixtures")]

--- a/api/domain/src/model/route.rs
+++ b/api/domain/src/model/route.rs
@@ -5,15 +5,13 @@ use getset::Getters;
 
 use route_bucket_utils::{ApplicationError, ApplicationResult};
 
-use crate::model::types::Elevation;
-use crate::model::Distance;
-
 pub use self::bounding_box::BoundingBox;
 pub use self::coordinate::Coordinate;
 pub use self::operation::{Operation, OperationId, OperationType, SegmentTemplate};
 pub use self::route_gpx::RouteGpx;
 pub use self::route_info::RouteInfo;
 pub use self::segment_list::{DrawingMode, Segment, SegmentList};
+pub use self::types::{Distance, Elevation, Latitude, Longitude, Polyline};
 
 use super::types::NanoId;
 
@@ -23,6 +21,7 @@ pub(crate) mod operation;
 pub(crate) mod route_gpx;
 pub(crate) mod route_info;
 pub(crate) mod segment_list;
+pub(crate) mod types;
 
 pub type RouteId = NanoId<Route, 11>;
 

--- a/api/domain/src/model/route.rs
+++ b/api/domain/src/model/route.rs
@@ -8,10 +8,12 @@ use route_bucket_utils::{ApplicationError, ApplicationResult};
 use crate::model::types::Elevation;
 use crate::model::Distance;
 
-use self::coordinate::Coordinate;
-use self::operation::Operation;
-use self::route_info::RouteInfo;
-use self::segment_list::{Segment, SegmentList};
+pub use self::bounding_box::BoundingBox;
+pub use self::coordinate::Coordinate;
+pub use self::operation::{Operation, OperationId, OperationType, SegmentTemplate};
+pub use self::route_gpx::RouteGpx;
+pub use self::route_info::RouteInfo;
+pub use self::segment_list::{DrawingMode, Segment, SegmentList};
 
 use super::types::NanoId;
 

--- a/api/domain/src/model/route/bounding_box.rs
+++ b/api/domain/src/model/route/bounding_box.rs
@@ -1,6 +1,7 @@
-use crate::model::Coordinate;
 use derive_more::From;
 use serde::Serialize;
+
+use super::Coordinate;
 
 #[derive(Clone, Debug, Serialize, From)]
 #[cfg_attr(any(test, feature = "fixtures"), derive(PartialEq))]

--- a/api/domain/src/model/route/coordinate.rs
+++ b/api/domain/src/model/route/coordinate.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use route_bucket_utils::{ApplicationError, ApplicationResult};
 
-use crate::model::types::{Distance, Elevation, Latitude, Longitude, Polyline};
+use super::types::{Distance, Elevation, Latitude, Longitude, Polyline};
 
 /// Value Object for Coordinates
 #[derive(Clone, Debug, PartialEq, Getters, Deserialize, Serialize)]

--- a/api/domain/src/model/route/segment_list.rs
+++ b/api/domain/src/model/route/segment_list.rs
@@ -10,9 +10,9 @@ use serde::Serialize;
 
 use route_bucket_utils::{ApplicationError, ApplicationResult};
 
-use crate::model::{BoundingBox, Distance, Elevation, Latitude, Longitude};
-
+use super::bounding_box::BoundingBox;
 use super::coordinate::Coordinate;
+use super::types::{Distance, Elevation, Latitude, Longitude};
 
 pub use self::segment::{DrawingMode, Segment};
 

--- a/api/domain/src/model/route/segment_list/segment.rs
+++ b/api/domain/src/model/route/segment_list/segment.rs
@@ -8,8 +8,9 @@ use serde::{Deserialize, Serialize};
 
 use route_bucket_utils::{ApplicationError, ApplicationResult};
 
+use super::super::coordinate::Coordinate;
+use super::super::types::{Distance, Polyline};
 use crate::model::types::NanoId;
-use crate::model::{Coordinate, Distance, Polyline};
 
 pub(crate) type SegmentId = NanoId<Segment, 21>;
 

--- a/api/domain/src/model/route/types.rs
+++ b/api/domain/src/model/route/types.rs
@@ -1,0 +1,116 @@
+use std::convert::TryFrom;
+
+use derive_more::{Add, AddAssign, Display, From, Into, Sub, Sum};
+use num_traits::{Bounded, FromPrimitive};
+use serde::{Deserialize, Serialize};
+
+use route_bucket_utils::{ApplicationError, ApplicationResult};
+
+#[derive(Default, Display, From, Into, Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Polyline(String);
+
+impl Polyline {
+    pub fn new() -> Self {
+        Self(String::new())
+    }
+}
+
+pub type Latitude = NumericValueObject<f64, 90>;
+pub type Longitude = NumericValueObject<f64, 180>;
+// NOTE: genericsの特殊化が実装されたら、この0は消せる
+// 参考: https://github.com/rust-lang/rust/issues/31844
+pub type Elevation = NumericValueObject<i32, 1000000>;
+pub type Distance = NumericValueObject<f64, 0>;
+
+/// Value Object for BigDecimal type
+#[derive(
+    Add,
+    AddAssign,
+    Sub,
+    Sum,
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+)]
+pub struct NumericValueObject<T, const MAX_ABS: u32>(T);
+
+impl<T: Copy + FromPrimitive + Bounded, const MAX_ABS: u32> NumericValueObject<T, MAX_ABS> {
+    pub fn value(&self) -> T {
+        self.0
+    }
+
+    pub fn max_value() -> Self {
+        Self(if MAX_ABS == 0 {
+            T::max_value()
+        } else {
+            T::from_u32(MAX_ABS).unwrap()
+        })
+    }
+
+    pub fn zero() -> Self {
+        Self(T::from_u32(0).unwrap())
+    }
+}
+
+impl<const MAX_ABS: u32> NumericValueObject<f64, MAX_ABS> {
+    pub fn min(a: Self, b: Self) -> Self {
+        if a.0 > b.0 {
+            b
+        } else {
+            a
+        }
+    }
+
+    pub fn max(a: Self, b: Self) -> Self {
+        if a.0 < b.0 {
+            b
+        } else {
+            a
+        }
+    }
+}
+
+// NOTE: TryFrom<T>を実装しようとすると、coreのimplとconflictする
+// これも特殊化待ち: https://github.com/rust-lang/rust/issues/31844
+impl<const MAX_ABS: u32> TryFrom<f64> for NumericValueObject<f64, MAX_ABS> {
+    type Error = ApplicationError;
+
+    fn try_from(val: f64) -> ApplicationResult<Self> {
+        if MAX_ABS == 0 || val.abs() <= MAX_ABS.into() {
+            Ok(Self(val))
+        } else {
+            Err(ApplicationError::ValueObjectError(format!(
+                // TODO: stringのconst genericsが追加されたら、
+                // メッセージに具体的なエイリアス名(Latitudeとか)を入れる
+                "Invalid value {} for NumericValueObject<f64, {}>",
+                val,
+                MAX_ABS
+            )))
+        }
+    }
+}
+
+// NOTE: TryFrom<T>を実装しようとすると、coreのimplとconflictする
+impl<const MAX_ABS: u32> TryFrom<i32> for NumericValueObject<i32, MAX_ABS> {
+    type Error = ApplicationError;
+
+    fn try_from(val: i32) -> ApplicationResult<Self> {
+        if MAX_ABS == 0 || val.abs() <= MAX_ABS as i32 {
+            Ok(Self(val))
+        } else {
+            Err(ApplicationError::ValueObjectError(format!(
+                // TODO: stringのconst genericsが追加されたら、
+                // メッセージに具体的なエイリアス名(Latitudeとか)を入れる
+                "Invalid value {} for NumericValueObject<i32, {}>",
+                val,
+                MAX_ABS
+            )))
+        }
+    }
+}

--- a/api/domain/src/model/types.rs
+++ b/api/domain/src/model/types.rs
@@ -1,12 +1,8 @@
-use std::convert::TryFrom;
 use std::marker::PhantomData;
 
-use derive_more::{Add, AddAssign, Display, From, Into, Sub, Sum};
+use derive_more::Display;
 use nanoid::nanoid;
-use num_traits::{Bounded, FromPrimitive};
 use serde::{Deserialize, Serialize};
-
-use route_bucket_utils::{ApplicationError, ApplicationResult};
 
 #[derive(Display, Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[display(fmt = "{}", id)]
@@ -25,115 +21,6 @@ impl<T, const LEN: usize> NanoId<T, LEN> {
         Self {
             id,
             _phantom: PhantomData,
-        }
-    }
-}
-
-#[derive(Default, Display, From, Into, Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct Polyline(String);
-
-impl Polyline {
-    pub fn new() -> Self {
-        Self(String::new())
-    }
-}
-
-pub type Latitude = NumericValueObject<f64, 90>;
-pub type Longitude = NumericValueObject<f64, 180>;
-// NOTE: genericsの特殊化が実装されたら、この0は消せる
-// 参考: https://github.com/rust-lang/rust/issues/31844
-pub type Elevation = NumericValueObject<i32, 1000000>;
-pub type Distance = NumericValueObject<f64, 0>;
-
-/// Value Object for BigDecimal type
-#[derive(
-    Add,
-    AddAssign,
-    Sub,
-    Sum,
-    Copy,
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-)]
-pub struct NumericValueObject<T, const MAX_ABS: u32>(T);
-
-impl<T: Copy + FromPrimitive + Bounded, const MAX_ABS: u32> NumericValueObject<T, MAX_ABS> {
-    pub fn value(&self) -> T {
-        self.0
-    }
-
-    pub fn max_value() -> Self {
-        Self(if MAX_ABS == 0 {
-            T::max_value()
-        } else {
-            T::from_u32(MAX_ABS).unwrap()
-        })
-    }
-
-    pub fn zero() -> Self {
-        Self(T::from_u32(0).unwrap())
-    }
-}
-
-impl<const MAX_ABS: u32> NumericValueObject<f64, MAX_ABS> {
-    pub fn min(a: Self, b: Self) -> Self {
-        if a.0 > b.0 {
-            b
-        } else {
-            a
-        }
-    }
-
-    pub fn max(a: Self, b: Self) -> Self {
-        if a.0 < b.0 {
-            b
-        } else {
-            a
-        }
-    }
-}
-
-// NOTE: TryFrom<T>を実装しようとすると、coreのimplとconflictする
-// これも特殊化待ち: https://github.com/rust-lang/rust/issues/31844
-impl<const MAX_ABS: u32> TryFrom<f64> for NumericValueObject<f64, MAX_ABS> {
-    type Error = ApplicationError;
-
-    fn try_from(val: f64) -> ApplicationResult<Self> {
-        if MAX_ABS == 0 || val.abs() <= MAX_ABS.into() {
-            Ok(Self(val))
-        } else {
-            Err(ApplicationError::ValueObjectError(format!(
-                // TODO: stringのconst genericsが追加されたら、
-                // メッセージに具体的なエイリアス名(Latitudeとか)を入れる
-                "Invalid value {} for NumericValueObject<f64, {}>",
-                val,
-                MAX_ABS
-            )))
-        }
-    }
-}
-
-// NOTE: TryFrom<T>を実装しようとすると、coreのimplとconflictする
-impl<const MAX_ABS: u32> TryFrom<i32> for NumericValueObject<i32, MAX_ABS> {
-    type Error = ApplicationError;
-
-    fn try_from(val: i32) -> ApplicationResult<Self> {
-        if MAX_ABS == 0 || val.abs() <= MAX_ABS as i32 {
-            Ok(Self(val))
-        } else {
-            Err(ApplicationError::ValueObjectError(format!(
-                // TODO: stringのconst genericsが追加されたら、
-                // メッセージに具体的なエイリアス名(Latitudeとか)を入れる
-                "Invalid value {} for NumericValueObject<i32, {}>",
-                val,
-                MAX_ABS
-            )))
         }
     }
 }

--- a/api/domain/src/repository/route.rs
+++ b/api/domain/src/repository/route.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 
 use route_bucket_utils::ApplicationResult;
 
-use crate::model::{Route, RouteId, RouteInfo};
+use crate::model::route::{Route, RouteId, RouteInfo};
 use crate::repository::Repository;
 
 #[async_trait]

--- a/api/infrastructure/src/dto/operation.rs
+++ b/api/infrastructure/src/dto/operation.rs
@@ -1,6 +1,6 @@
 use getset::Getters;
 use itertools::Itertools;
-use route_bucket_domain::model::{
+use route_bucket_domain::model::route::{
     DrawingMode, Operation, OperationId, OperationType, Polyline, RouteId, SegmentTemplate,
 };
 use route_bucket_utils::{ApplicationError, ApplicationResult};

--- a/api/infrastructure/src/dto/route.rs
+++ b/api/infrastructure/src/dto/route.rs
@@ -1,5 +1,5 @@
 use getset::Getters;
-use route_bucket_domain::model::{RouteId, RouteInfo};
+use route_bucket_domain::model::route::{RouteId, RouteInfo};
 use route_bucket_utils::ApplicationResult;
 
 /// ルートのdto構造体

--- a/api/infrastructure/src/dto/segment.rs
+++ b/api/infrastructure/src/dto/segment.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 
 use getset::Getters;
 
-use route_bucket_domain::model::{Polyline, RouteId, Segment};
+use route_bucket_domain::model::route::{Polyline, RouteId, Segment};
 use route_bucket_utils::ApplicationResult;
 
 /// 座標のdto構造体

--- a/api/infrastructure/src/external/osrm.rs
+++ b/api/infrastructure/src/external/osrm.rs
@@ -3,7 +3,7 @@ use std::convert::TryInto;
 use async_trait::async_trait;
 
 use route_bucket_domain::external::RouteInterpolationApi;
-use route_bucket_domain::model::{Coordinate, DrawingMode, Polyline, Segment};
+use route_bucket_domain::model::route::{Coordinate, DrawingMode, Polyline, Segment};
 use route_bucket_utils::{ApplicationError, ApplicationResult};
 
 /// osrmでルート補間をするための構造体

--- a/api/infrastructure/src/external/srtm.rs
+++ b/api/infrastructure/src/external/srtm.rs
@@ -9,7 +9,7 @@ use byteorder::{BigEndian, ByteOrder, LittleEndian, ReadBytesExt};
 use num_traits::FromPrimitive;
 
 use route_bucket_domain::external::ElevationApi;
-use route_bucket_domain::model::{Coordinate, Elevation, Latitude, Longitude};
+use route_bucket_domain::model::route::{Coordinate, Elevation, Latitude, Longitude};
 use route_bucket_utils::{ApplicationError, ApplicationResult};
 
 #[derive(num_derive::FromPrimitive)]

--- a/api/infrastructure/src/repository/route.rs
+++ b/api/infrastructure/src/repository/route.rs
@@ -5,7 +5,9 @@ use sqlx::mysql::MySqlPoolOptions;
 use sqlx::MySqlPool;
 use tokio::sync::Mutex;
 
-use route_bucket_domain::model::{Operation, Route, RouteId, RouteInfo, Segment, SegmentList};
+use route_bucket_domain::model::route::{
+    Operation, Route, RouteId, RouteInfo, Segment, SegmentList,
+};
 use route_bucket_domain::repository::{Connection, Repository, RouteRepository};
 use route_bucket_utils::{ApplicationError, ApplicationResult};
 

--- a/api/src/bin/seed.rs
+++ b/api/src/bin/seed.rs
@@ -1,5 +1,5 @@
 use route_bucket_backend::server::Server;
-use route_bucket_domain::model::{Coordinate, DrawingMode};
+use route_bucket_domain::model::route::{Coordinate, DrawingMode};
 use route_bucket_usecase::route::RouteUseCase;
 
 macro_rules! coord {

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -8,7 +8,7 @@ pub use responses::*;
 use route_bucket_domain::external::{
     CallElevationApi, CallRouteInterpolationApi, ElevationApi, RouteInterpolationApi,
 };
-use route_bucket_domain::model::{Operation, Route, RouteId, RouteInfo};
+use route_bucket_domain::model::route::{Operation, Route, RouteId, RouteInfo};
 use route_bucket_domain::repository::{
     CallRouteRepository, Connection, Repository, RouteRepository,
 };
@@ -309,11 +309,11 @@ mod tests {
     use route_bucket_domain::{
         external::{MockElevationApi, MockRouteInterpolationApi},
         model::{
-            fixtures::{
+            fixtures::route::{
                 CoordinateFixtures, OperationFixtures, RouteFixtures, RouteGpxFixtures,
                 RouteInfoFixtures, SegmentFixtures,
             },
-            Coordinate, DrawingMode, RouteGpx, Segment,
+            route::{Coordinate, DrawingMode, RouteGpx, Segment},
         },
         repository::{MockConnection, MockRouteRepository},
     };

--- a/api/usecase/src/route/requests.rs
+++ b/api/usecase/src/route/requests.rs
@@ -1,7 +1,7 @@
 use derive_more::From;
 use serde::Deserialize;
 
-use route_bucket_domain::model::{Coordinate, DrawingMode};
+use route_bucket_domain::model::route::{Coordinate, DrawingMode};
 
 #[derive(From, Deserialize)]
 pub struct RouteCreateRequest {

--- a/api/usecase/src/route/responses.rs
+++ b/api/usecase/src/route/responses.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 
 use serde::Serialize;
 
-use route_bucket_domain::model::{
+use route_bucket_domain::model::route::{
     BoundingBox, Coordinate, Distance, Elevation, Route, RouteGpx, RouteId, RouteInfo, Segment,
 };
 use route_bucket_utils::ApplicationError;
@@ -76,10 +76,10 @@ impl TryFrom<Route> for RouteOperationResponse {
 
 #[cfg(test)]
 mod tests {
-    use route_bucket_domain::model::fixtures::{
+    use route_bucket_domain::model::fixtures::route::{
         BoundingBoxFixture, CoordinateFixtures, RouteFixtures, RouteInfoFixtures, SegmentFixtures,
     };
-    use route_bucket_domain::model::DrawingMode;
+    use route_bucket_domain::model::route::DrawingMode;
     use rstest::rstest;
     use std::convert::TryInto;
 


### PR DESCRIPTION
importパスが書き換わることによってdiffが多いので、commitごとに見てくれ

* `domain::model`以下を`domain::model::route`以下に移動（ c07ac84 ）
  * 今後`domain::model::user`が出てくる想定で、これと区別する目的
* `domain::model::types`から、routeにのみ関係するtypeたち（`Distance`, `Latitude`など）を取り出し、新たに`domain::model::route::types`を作ってそこに移動した（ bc03a9f ）

それ以降のcommitは、全てimportパスを↑に対応させる作業