### PR TITLE
作成者idによるルート検索

### DIFF
--- a/api/controller/src/route.rs
+++ b/api/controller/src/route.rs
@@ -1,6 +1,6 @@
 use actix_web::{dev, http, web, HttpResponse, Result};
 
-use route_bucket_domain::model::route::RouteId;
+use route_bucket_domain::model::route::{RouteId, RouteSearchQuery};
 use route_bucket_usecase::route::{
     NewPointRequest, RemovePointRequest, RouteCreateRequest, RouteRenameRequest, RouteUseCase,
 };
@@ -16,6 +16,13 @@ async fn get<U: 'static + RouteUseCase>(
 
 async fn get_all<U: 'static + RouteUseCase>(usecase: web::Data<U>) -> Result<HttpResponse> {
     Ok(HttpResponse::Ok().json(usecase.find_all().await?))
+}
+
+async fn get_search<U: 'static + RouteUseCase>(
+    usecase: web::Data<U>,
+    query: web::Query<RouteSearchQuery>,
+) -> Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(usecase.search(query.into_inner()).await?))
 }
 
 async fn get_gpx<U: 'static + RouteUseCase>(
@@ -114,6 +121,7 @@ pub trait BuildRouteService: AddService {
                         .route(web::get().to(get_all::<U>))
                         .route(web::post().to(post::<U>)),
                 )
+                .service(web::resource("/search").route(web::get().to(get_search::<U>)))
                 .service(
                     web::resource("/{id}")
                         .route(web::get().to(get::<U>))

--- a/api/domain/src/model.rs
+++ b/api/domain/src/model.rs
@@ -10,6 +10,7 @@ pub mod fixtures {
         pub use crate::model::route::operation::tests::OperationFixtures;
         pub use crate::model::route::route_gpx::tests::RouteGpxFixtures;
         pub use crate::model::route::route_info::tests::RouteInfoFixtures;
+        pub use crate::model::route::search_query::tests::RouteSearchQueryFixtures;
         pub use crate::model::route::segment_list::tests::{SegmentFixtures, SegmentListFixture};
         pub use crate::model::route::tests::RouteFixtures;
     }

--- a/api/domain/src/model/route.rs
+++ b/api/domain/src/model/route.rs
@@ -10,6 +10,7 @@ pub use self::coordinate::Coordinate;
 pub use self::operation::{Operation, OperationId, OperationType, SegmentTemplate};
 pub use self::route_gpx::RouteGpx;
 pub use self::route_info::RouteInfo;
+pub use self::search_query::RouteSearchQuery;
 pub use self::segment_list::{DrawingMode, Segment, SegmentList};
 pub use self::types::{Distance, Elevation, Latitude, Longitude, Polyline};
 
@@ -20,6 +21,7 @@ pub(crate) mod coordinate;
 pub(crate) mod operation;
 pub(crate) mod route_gpx;
 pub(crate) mod route_info;
+pub(crate) mod search_query;
 pub(crate) mod segment_list;
 pub(crate) mod types;
 

--- a/api/domain/src/model/route/route_info.rs
+++ b/api/domain/src/model/route/route_info.rs
@@ -44,6 +44,8 @@ impl RouteInfo {
 pub(crate) mod tests {
     use rstest::{fixture, rstest};
 
+    use crate::model::user::tests::UserIdFixtures;
+
     use super::*;
 
     #[fixture]
@@ -73,6 +75,7 @@ pub(crate) mod tests {
             RouteInfo {
                 id: RouteId::new(),
                 name: "route0".into(),
+                owner_id: UserId::guest(),
                 op_num,
             }
         }
@@ -81,6 +84,7 @@ pub(crate) mod tests {
             RouteInfo {
                 id: RouteId::new(),
                 name: "route1".into(),
+                owner_id: UserId::guest(),
                 op_num,
             }
         }

--- a/api/domain/src/model/route/route_info.rs
+++ b/api/domain/src/model/route/route_info.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 #[cfg(any(test, feature = "fixtures"))]
 use derivative::Derivative;
 
+use crate::model::user::UserId;
+
 use super::RouteId;
 
 #[derive(Clone, Debug, Getters, Deserialize, Serialize)]
@@ -14,15 +16,17 @@ pub struct RouteInfo {
     #[cfg_attr(any(test, feature = "fixtures"), derivative(PartialEq = "ignore"))]
     pub(super) id: RouteId,
     pub(super) name: String,
+    pub(super) owner_id: UserId,
     #[serde(skip_serializing)]
     pub(super) op_num: usize,
 }
 
 impl RouteInfo {
-    pub fn new(id: RouteId, name: &str, op_num: usize) -> RouteInfo {
+    pub fn new(id: RouteId, name: &str, owner_id: UserId, op_num: usize) -> RouteInfo {
         RouteInfo {
             id,
             name: name.to_string(),
+            owner_id,
             op_num,
         }
     }

--- a/api/domain/src/model/route/search_query.rs
+++ b/api/domain/src/model/route/search_query.rs
@@ -1,0 +1,15 @@
+use serde::{Deserialize, Serialize};
+
+use crate::model::user::UserId;
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct RouteSearchQuery {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    owner_id: Option<UserId>,
+}
+
+impl RouteSearchQuery {
+    pub fn empty() -> Self {
+        Default::default()
+    }
+}

--- a/api/domain/src/model/route/search_query.rs
+++ b/api/domain/src/model/route/search_query.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::model::user::UserId;
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "fixtures"), derive(PartialEq))]
 pub struct RouteSearchQuery {
     #[serde(skip_serializing_if = "Option::is_none")]
     owner_id: Option<UserId>,
@@ -12,4 +13,21 @@ impl RouteSearchQuery {
     pub fn empty() -> Self {
         Default::default()
     }
+}
+
+#[cfg(any(test, feature = "fixtures"))]
+pub(crate) mod tests {
+    use crate::model::user::tests::UserIdFixtures;
+
+    use super::*;
+
+    pub trait RouteSearchQueryFixtures {
+        fn search_guest() -> RouteSearchQuery {
+            RouteSearchQuery {
+                owner_id: Some(UserId::guest()),
+            }
+        }
+    }
+
+    impl RouteSearchQueryFixtures for RouteSearchQuery {}
 }

--- a/api/domain/src/model/user.rs
+++ b/api/domain/src/model/user.rs
@@ -62,6 +62,10 @@ pub(crate) mod tests {
         fn porzingis() -> UserId {
             UserId::from("kporzee".to_string())
         }
+
+        fn guest() -> UserId {
+            UserId::from("guest".to_string())
+        }
     }
 
     impl UserIdFixtures for UserId {}

--- a/api/domain/src/repository/route.rs
+++ b/api/domain/src/repository/route.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 
 use route_bucket_utils::ApplicationResult;
 
+use crate::model::route::search_query::RouteSearchQuery;
 use crate::model::route::{Route, RouteId, RouteInfo};
 use crate::repository::Repository;
 
@@ -23,7 +24,11 @@ pub trait RouteRepository: Repository {
         conn: &<Self as Repository>::Connection,
     ) -> ApplicationResult<RouteInfo>;
 
-    async fn find_all_infos(&self, conn: &Self::Connection) -> ApplicationResult<Vec<RouteInfo>>;
+    async fn search_infos(
+        &self,
+        query: RouteSearchQuery,
+        conn: &<Self as Repository>::Connection,
+    ) -> ApplicationResult<Vec<RouteInfo>>;
 
     async fn insert_info(
         &self,
@@ -72,7 +77,7 @@ mockall::mock! {
 
         async fn find_info(&self, id: &RouteId, conn: &super::MockConnection) -> ApplicationResult<RouteInfo>;
 
-        async fn find_all_infos(&self, conn: &super::MockConnection) -> ApplicationResult<Vec<RouteInfo>>;
+        async fn search_infos(&self, query: RouteSearchQuery, conn: &super::MockConnection) -> ApplicationResult<Vec<RouteInfo>>;
 
         async fn insert_info(&self, info: &RouteInfo, conn: &super::MockConnection) -> ApplicationResult<()>;
 

--- a/api/infrastructure/src/dto/route.rs
+++ b/api/infrastructure/src/dto/route.rs
@@ -1,5 +1,8 @@
 use getset::Getters;
-use route_bucket_domain::model::route::{RouteId, RouteInfo};
+use route_bucket_domain::model::{
+    route::{RouteId, RouteInfo},
+    user::UserId,
+};
 use route_bucket_utils::ApplicationResult;
 
 /// ルートのdto構造体
@@ -8,6 +11,7 @@ use route_bucket_utils::ApplicationResult;
 pub struct RouteDto {
     id: String,
     name: String,
+    owner_id: String,
     operation_pos: u32,
 }
 
@@ -16,11 +20,13 @@ impl RouteDto {
         let Self {
             id,
             name,
+            owner_id,
             operation_pos,
         } = self;
         Ok(RouteInfo::new(
             RouteId::from_string(id),
             &name,
+            UserId::from(owner_id),
             operation_pos as usize,
         ))
     }
@@ -29,6 +35,7 @@ impl RouteDto {
         Ok(RouteDto {
             id: route_info.id().to_string(),
             name: route_info.name().clone(),
+            owner_id: route_info.owner_id().to_string(),
             operation_pos: *route_info.op_num() as u32,
         })
     }

--- a/api/infrastructure/src/repository.rs
+++ b/api/infrastructure/src/repository.rs
@@ -45,7 +45,7 @@ fn serializable_to_search_query<T: Serialize>(
         serde_json::from_value(serde_json::to_value(serializable).unwrap()).unwrap();
 
     let mut query = format!("SELECT * FROM {}", table);
-    if hashmap.len() > 0 {
+    if !hashmap.is_empty() {
         let conditions = hashmap
             .into_iter()
             .map(|(key, val)| format!("`{}` = '{}'", key, val))

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -330,7 +330,7 @@ mod tests {
         model::{
             fixtures::route::{
                 CoordinateFixtures, OperationFixtures, RouteFixtures, RouteGpxFixtures,
-                RouteInfoFixtures, SegmentFixtures,
+                RouteInfoFixtures, RouteSearchQueryFixtures, SegmentFixtures,
             },
             route::{Coordinate, DrawingMode, RouteGpx, Segment},
         },
@@ -404,11 +404,31 @@ mod tests {
     #[tokio::test]
     async fn can_find_all() {
         let mut usecase = TestRouteUseCase::new();
-        usecase.expect_find_all_at_route_repository(vec![RouteInfo::route0(0)]);
+        usecase.expect_search_infos_at_route_repository(
+            RouteSearchQuery::empty(),
+            vec![RouteInfo::route0(0)],
+        );
 
         assert_eq!(
             usecase.find_all().await,
-            Ok(RouteGetAllResponse {
+            Ok(RouteSearchResponse {
+                route_infos: vec![RouteInfo::route0(0)]
+            })
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn can_search() {
+        let mut usecase = TestRouteUseCase::new();
+        usecase.expect_search_infos_at_route_repository(
+            RouteSearchQuery::search_guest(),
+            vec![RouteInfo::route0(0)],
+        );
+
+        assert_eq!(
+            usecase.search(RouteSearchQuery::search_guest()).await,
+            Ok(RouteSearchResponse {
                 route_infos: vec![RouteInfo::route0(0)]
             })
         );
@@ -660,8 +680,12 @@ mod tests {
             expect_at_repository!(self, find_info, param_id, return_info);
         }
 
-        fn expect_find_all_at_route_repository(&mut self, return_infos: Vec<RouteInfo>) {
-            expect_at_repository!(self, find_all_infos, return_infos);
+        fn expect_search_infos_at_route_repository(
+            &mut self,
+            query: RouteSearchQuery,
+            return_infos: Vec<RouteInfo>,
+        ) {
+            expect_at_repository!(self, search_infos, query, return_infos);
         }
 
         fn expect_insert_info_at_route_repository(&mut self, param_info: RouteInfo) {

--- a/api/usecase/src/route/responses.rs
+++ b/api/usecase/src/route/responses.rs
@@ -21,7 +21,7 @@ pub struct RouteGetResponse {
 
 #[derive(Debug, Serialize)]
 #[cfg_attr(test, derive(PartialEq))]
-pub struct RouteGetAllResponse {
+pub struct RouteSearchResponse {
     #[serde(rename = "routes")]
     pub route_infos: Vec<RouteInfo>,
 }

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -2,6 +2,7 @@ CREATE TABLE routes
 (
     `id`            VARCHAR(11)      NOT NULL,
     `name`          VARCHAR(50)      NOT NULL,
+    `owner_id`      VARCHAR(40)      NOT NULL,
     `operation_pos` INTEGER UNSIGNED NOT NULL,
     PRIMARY KEY (`id`)
 );


### PR DESCRIPTION
* `RouteInfo`に`owner_id`を追加
* 検索条件を表す構造体`RouteSearchQuery`を追加し、これでクエリパラメータからDBまで条件を運べるようにした
* `Route`作成時に`owner_id`を振るためには、認証が必要だが、この辺の使用を詰めていなかったので、一旦`POST /routes/`では`owner_id`がguestという固定値になるようにした（ #107 にissueを立てた）

