### PR TITLE
/routes に認証を追加

### DIFF
--- a/api/domain/src/model/route/route_info.rs
+++ b/api/domain/src/model/route/route_info.rs
@@ -75,7 +75,7 @@ pub(crate) mod tests {
             RouteInfo {
                 id: RouteId::new(),
                 name: "route0".into(),
-                owner_id: UserId::guest(),
+                owner_id: UserId::doncic(),
                 op_num,
             }
         }
@@ -84,7 +84,7 @@ pub(crate) mod tests {
             RouteInfo {
                 id: RouteId::new(),
                 name: "route1".into(),
-                owner_id: UserId::guest(),
+                owner_id: UserId::doncic(),
                 op_num,
             }
         }

--- a/api/domain/src/model/route/search_query.rs
+++ b/api/domain/src/model/route/search_query.rs
@@ -24,7 +24,7 @@ pub(crate) mod tests {
     pub trait RouteSearchQueryFixtures {
         fn search_guest() -> RouteSearchQuery {
             RouteSearchQuery {
-                owner_id: Some(UserId::guest()),
+                owner_id: Some(UserId::doncic()),
             }
         }
     }

--- a/api/domain/src/model/user.rs
+++ b/api/domain/src/model/user.rs
@@ -62,10 +62,6 @@ pub(crate) mod tests {
         fn porzingis() -> UserId {
             UserId::from("kporzee".to_string())
         }
-
-        fn guest() -> UserId {
-            UserId::from("guest".to_string())
-        }
     }
 
     impl UserIdFixtures for UserId {}

--- a/api/infrastructure/src/external/firebase.rs
+++ b/api/infrastructure/src/external/firebase.rs
@@ -20,7 +20,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use tokio::sync::RwLock;
 
-use self::token::verify;
+use self::token::verify_and_get_user_id;
 
 const CREDENTIAL_PATH: &str = "resources/credentials/firebase-adminsdk.json";
 const API_SCOPE: &str = "https://www.googleapis.com/auth/identitytoolkit";
@@ -95,7 +95,7 @@ impl GoogleAccessToken {
             self.token = response
                 .get("access_token")
                 .ok_or_else(|| {
-                    ApplicationError::AuthError(format!(
+                    ApplicationError::ExternalError(format!(
                         "Unable to find access_token in the response: {:?}",
                         response.clone()
                     ))
@@ -109,7 +109,7 @@ impl GoogleAccessToken {
                     response
                         .get("expires_in")
                         .ok_or_else(|| {
-                            ApplicationError::AuthError(format!(
+                            ApplicationError::ExternalError(format!(
                                 "Unable to find expires_in in the response: {:?}",
                                 response.clone()
                             ))
@@ -187,7 +187,7 @@ impl UserAuthApi for FirebaseAuthApi {
         if response.status().is_success() {
             Ok(())
         } else {
-            Err(ApplicationError::AuthError(format!(
+            Err(ApplicationError::ExternalError(format!(
                 "Failed to create account: {:?}",
                 response.json::<Value>().await
             )))
@@ -210,7 +210,7 @@ impl UserAuthApi for FirebaseAuthApi {
         if response.status().is_success() {
             Ok(())
         } else {
-            Err(ApplicationError::AuthError(format!(
+            Err(ApplicationError::ExternalError(format!(
                 "Failed to delete account: {:?}",
                 response.json::<Value>().await
             )))

--- a/api/infrastructure/src/external/firebase.rs
+++ b/api/infrastructure/src/external/firebase.rs
@@ -217,7 +217,7 @@ impl UserAuthApi for FirebaseAuthApi {
         }
     }
 
-    async fn verify_token(&self, user_id: &UserId, token: &str) -> ApplicationResult<()> {
-        verify(user_id, token, &self.credential).await
+    async fn authenticate(&self, token: &str) -> ApplicationResult<UserId> {
+        verify_and_get_user_id(token, &self.credential).await
     }
 }

--- a/api/infrastructure/src/external/firebase/token.rs
+++ b/api/infrastructure/src/external/firebase/token.rs
@@ -52,13 +52,15 @@ pub(super) async fn verify(
     let kid = decode_header(token)
         .map(|header| header.kid)?
         .ok_or_else(|| {
-            ApplicationError::AuthError("The decoded jwt header didn't contain kid.".into())
+            ApplicationError::AuthenticationError(
+                "The decoded jwt header didn't contain kid.".into(),
+            )
         })?;
 
     // validate: kid
     let jwks_by_kid = HashMap::from(reqwest::get(JWT_URL).await?.json::<KeysResponse>().await?);
     let jwk = jwks_by_kid.get(&kid).ok_or_else(|| {
-        ApplicationError::AuthError("The decoded kid not found in jwks response".into())
+        ApplicationError::AuthenticationError("The decoded kid not found in jwks response".into())
     })?;
 
     // validate: alg, iss, aud

--- a/api/infrastructure/src/external/firebase/token.rs
+++ b/api/infrastructure/src/external/firebase/token.rs
@@ -44,11 +44,10 @@ impl From<KeysResponse> for HashMap<String, Jwk> {
     }
 }
 
-pub(super) async fn verify(
-    user_id: &UserId,
+pub(super) async fn verify_and_get_user_id(
     token: &str,
     credential: &FirebaseCredential,
-) -> ApplicationResult<()> {
+) -> ApplicationResult<UserId> {
     let kid = decode_header(token)
         .map(|header| header.kid)?
         .ok_or_else(|| {
@@ -76,11 +75,5 @@ pub(super) async fn verify(
     let decoding_key = DecodingKey::from_rsa_components(&jwk.n, &jwk.e);
     let decoded_token = jsonwebtoken::decode::<Claims>(token, &decoding_key, &validation)?;
 
-    let uid = decoded_token.claims.sub;
-    (user_id.to_string() == uid).then(|| ()).ok_or_else(|| {
-        ApplicationError::AuthError(format!(
-            "The id of the user ({}) doesn't match the id from the token ({}).",
-            user_id, uid
-        ))
-    })
+    Ok(UserId::from(decoded_token.claims.sub))
 }

--- a/api/src/bin/seed.rs
+++ b/api/src/bin/seed.rs
@@ -1,80 +1,81 @@
-use route_bucket_backend::server::Server;
-use route_bucket_domain::model::route::{Coordinate, DrawingMode};
-use route_bucket_usecase::route::RouteUseCase;
+// use route_bucket_backend::server::Server;
+// use route_bucket_domain::model::route::{Coordinate, DrawingMode};
+// use route_bucket_usecase::route::RouteUseCase;
 
-macro_rules! coord {
-    ( $lat: expr, $lon: expr ) => {
-        Coordinate::new($lat, $lon).unwrap()
-    };
-}
+// macro_rules! coord {
+//     ( $lat: expr, $lon: expr ) => {
+//         Coordinate::new($lat, $lon).unwrap()
+//     };
+// }
 
 #[actix_web::main]
 async fn main() {
-    env_logger::init();
+    todo!()
+    // env_logger::init();
 
-    let server = Server::new().await;
+    // let server = Server::new().await;
 
-    let route_id1 = server
-        .create(&String::from("sample1").into())
-        .await
-        .unwrap()
-        .id;
+    // let route_id1 = server
+    //     .create(&String::from("sample1").into())
+    //     .await
+    //     .unwrap()
+    //     .id;
 
-    let route_id2 = server
-        .create(&String::from("sample2: 皇居ラン").into())
-        .await
-        .unwrap()
-        .id;
+    // let route_id2 = server
+    //     .create(&String::from("sample2: 皇居ラン").into())
+    //     .await
+    //     .unwrap()
+    //     .id;
 
-    server
-        .add_point(
-            &route_id2,
-            0,
-            &(DrawingMode::FollowRoad, coord!(35.68136, 139.75875)).into(),
-        )
-        .await
-        .unwrap();
-    server
-        .add_point(
-            &route_id2,
-            1,
-            &(DrawingMode::FollowRoad, coord!(35.69053, 139.75681)).into(),
-        )
-        .await
-        .unwrap();
-    server
-        .add_point(
-            &route_id2,
-            2,
-            &(DrawingMode::FollowRoad, coord!(35.69510, 139.75139)).into(),
-        )
-        .await
-        .unwrap();
-    server
-        .add_point(
-            &route_id2,
-            3,
-            &(DrawingMode::FollowRoad, coord!(35.68942, 139.74547)).into(),
-        )
-        .await
-        .unwrap();
-    server
-        .add_point(
-            &route_id2,
-            4,
-            &(DrawingMode::FollowRoad, coord!(35.68418, 139.74424)).into(),
-        )
-        .await
-        .unwrap();
-    server
-        .add_point(
-            &route_id2,
-            5,
-            &(DrawingMode::FollowRoad, coord!(35.68136, 139.75875)).into(),
-        )
-        .await
-        .unwrap();
+    // server
+    //     .add_point(
+    //         &route_id2,
+    //         0,
+    //         &(DrawingMode::FollowRoad, coord!(35.68136, 139.75875)).into(),
+    //     )
+    //     .await
+    //     .unwrap();
+    // server
+    //     .add_point(
+    //         &route_id2,
+    //         1,
+    //         &(DrawingMode::FollowRoad, coord!(35.69053, 139.75681)).into(),
+    //     )
+    //     .await
+    //     .unwrap();
+    // server
+    //     .add_point(
+    //         &route_id2,
+    //         2,
+    //         &(DrawingMode::FollowRoad, coord!(35.69510, 139.75139)).into(),
+    //     )
+    //     .await
+    //     .unwrap();
+    // server
+    //     .add_point(
+    //         &route_id2,
+    //         3,
+    //         &(DrawingMode::FollowRoad, coord!(35.68942, 139.74547)).into(),
+    //     )
+    //     .await
+    //     .unwrap();
+    // server
+    //     .add_point(
+    //         &route_id2,
+    //         4,
+    //         &(DrawingMode::FollowRoad, coord!(35.68418, 139.74424)).into(),
+    //     )
+    //     .await
+    //     .unwrap();
+    // server
+    //     .add_point(
+    //         &route_id2,
+    //         5,
+    //         &(DrawingMode::FollowRoad, coord!(35.68136, 139.75875)).into(),
+    //     )
+    //     .await
+    //     .unwrap();
 
-    log::info!("Route {} added!", route_id1);
-    log::info!("Route {} added!", route_id2);
+    // log::info!("Route {} added!", route_id1);
+    // log::info!("Route {} added!", route_id2);
 }

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -141,14 +141,14 @@ where
                 let owner_id = self.user_auth_api().authenticate(user_access_token).await?;
                 let route_info = RouteInfo::new(RouteId::new(), &req.name, owner_id, 0);
 
-        self.route_repository()
-            .insert_info(&route_info, &conn)
-            .await?;
+                self.route_repository()
+                    .insert_info(&route_info, &conn)
+                    .await?;
 
-        Ok(RouteCreateResponse {
-            id: route_info.id().clone(),
-        })
-    }
+                Ok(RouteCreateResponse {
+                    id: route_info.id().clone(),
+                })
+            }
             .boxed()
         })
         .await
@@ -387,7 +387,7 @@ where
                     .authorize(info.owner_id(), user_access_token)
                     .await?;
 
-        self.route_repository().delete(route_id, &conn).await
+                self.route_repository().delete(route_id, &conn).await
             }
             .boxed()
         })
@@ -399,13 +399,17 @@ where
 mod tests {
     use crate::{expect_at_repository, expect_once};
     use route_bucket_domain::{
-        external::{MockElevationApi, MockRouteInterpolationApi},
+        external::{MockElevationApi, MockRouteInterpolationApi, MockUserAuthApi},
         model::{
-            fixtures::route::{
-                CoordinateFixtures, OperationFixtures, RouteFixtures, RouteGpxFixtures,
-                RouteInfoFixtures, RouteSearchQueryFixtures, SegmentFixtures,
+            fixtures::{
+                route::{
+                    CoordinateFixtures, OperationFixtures, RouteFixtures, RouteGpxFixtures,
+                    RouteInfoFixtures, RouteSearchQueryFixtures, SegmentFixtures,
+                },
+                user::UserIdFixtures,
             },
             route::{Coordinate, DrawingMode, RouteGpx, Segment},
+            user::UserId,
         },
         repository::{MockConnection, MockRouteRepository},
     };
@@ -452,6 +456,10 @@ mod tests {
 
     fn yokohama_to_tokyo_before_interpolation() -> Route {
         Route::yokohama_to_tokyo()
+    }
+
+    fn doncic_token() -> String {
+        String::from("token.for.doncic")
     }
 
     #[rstest]
@@ -531,10 +539,11 @@ mod tests {
         };
 
         let mut usecase = TestRouteUseCase::new();
+        usecase.expect_authenticate_at_auth_api(doncic_token(), UserId::doncic());
         usecase.expect_insert_info_at_route_repository(RouteInfo::route0(0));
         // NOTE: unable to check resp since RouteId is auto-generated
         // assert_eq!(usecase.create(&req).await, Ok(expected_resp));
-        assert!(matches!(usecase.create(&req).await, Ok(_)));
+        assert!(matches!(usecase.create(&doncic_token(), &req).await, Ok(_)));
     }
 
     #[rstest]
@@ -545,11 +554,12 @@ mod tests {
         };
 
         let mut usecase = TestRouteUseCase::new();
+        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_info_at_route_repository(route_id(), RouteInfo::route0(0));
         usecase.expect_update_info_at_route_repository(RouteInfo::route1(0));
 
         assert_eq!(
-            usecase.rename(&route_id(), &req).await,
+            usecase.rename(&route_id(), &doncic_token(), &req).await,
             Ok(RouteInfo::route1(0))
         );
     }
@@ -563,6 +573,7 @@ mod tests {
         };
 
         let mut usecase = TestRouteUseCase::new();
+        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_at_route_repository(
             route_id(),
             Route::yokohama_to_chiba_filled(false, false),
@@ -585,7 +596,9 @@ mod tests {
         ));
 
         assert_eq!(
-            usecase.add_point(&route_id(), 1, &req).await,
+            usecase
+                .add_point(&route_id(), &doncic_token(), 1, &req)
+                .await,
             Route::yokohama_to_chiba_via_tokyo_filled(true, true).try_into()
         );
     }
@@ -596,7 +609,9 @@ mod tests {
         let req = RemovePointRequest {
             mode: DrawingMode::FollowRoad,
         };
+
         let mut usecase = TestRouteUseCase::new();
+        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_at_route_repository(
             route_id(),
             Route::yokohama_to_chiba_via_tokyo_filled(false, false),
@@ -612,7 +627,9 @@ mod tests {
         usecase.expect_update_at_route_repository(Route::yokohama_to_chiba_filled(true, true));
 
         assert_eq!(
-            usecase.remove_point(&route_id(), 1, &req).await,
+            usecase
+                .remove_point(&route_id(), &doncic_token(), 1, &req)
+                .await,
             Route::yokohama_to_chiba_filled(true, true).try_into()
         );
     }
@@ -626,6 +643,7 @@ mod tests {
         };
 
         let mut usecase = TestRouteUseCase::new();
+        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_at_route_repository(
             route_id(),
             Route::yokohama_to_chiba_filled(false, false),
@@ -646,7 +664,9 @@ mod tests {
         usecase.expect_update_at_route_repository(Route::yokohama_to_tokyo_filled(true, true));
 
         assert_eq!(
-            usecase.move_point(&route_id(), 1, &req).await,
+            usecase
+                .move_point(&route_id(), &doncic_token(), 1, &req)
+                .await,
             Route::yokohama_to_tokyo_filled(true, true).try_into()
         );
     }
@@ -655,11 +675,12 @@ mod tests {
     #[tokio::test]
     async fn can_clear_route() {
         let mut usecase = TestRouteUseCase::new();
+        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_info_at_route_repository(route_id(), RouteInfo::route0(3));
         usecase.expect_update_at_route_repository(Route::empty());
 
         assert_eq!(
-            usecase.clear_route(&route_id()).await,
+            usecase.clear_route(&route_id(), &doncic_token()).await,
             Route::empty().try_into()
         );
     }
@@ -668,6 +689,7 @@ mod tests {
     #[tokio::test]
     async fn can_redo_operation() {
         let mut usecase = TestRouteUseCase::new();
+        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_at_route_repository(
             route_id(),
             Route::yokohama_to_chiba_filled(false, false),
@@ -685,7 +707,7 @@ mod tests {
         ));
 
         assert_eq!(
-            usecase.redo_operation(&route_id()).await,
+            usecase.redo_operation(&route_id(), &doncic_token()).await,
             Route::yokohama_to_chiba_via_tokyo_filled(true, true).try_into()
         );
     }
@@ -694,6 +716,7 @@ mod tests {
     #[tokio::test]
     async fn can_undo_operation() {
         let mut usecase = TestRouteUseCase::new();
+        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_at_route_repository(
             route_id(),
             Route::yokohama_to_chiba_via_tokyo_filled(false, false),
@@ -709,7 +732,7 @@ mod tests {
         usecase.expect_update_at_route_repository(Route::yokohama_to_chiba_filled(true, true));
 
         assert_eq!(
-            usecase.undo_operation(&route_id()).await,
+            usecase.undo_operation(&route_id(), &doncic_token()).await,
             Route::yokohama_to_chiba_filled(true, true).try_into()
         );
     }
@@ -718,14 +741,17 @@ mod tests {
     #[tokio::test]
     async fn can_delete() {
         let mut usecase = TestRouteUseCase::new();
+        usecase.expect_find_info_at_route_repository(route_id(), RouteInfo::route0(0));
+        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_delete_at_route_repository(route_id());
-        assert_eq!(usecase.delete(&route_id()).await, Ok(()));
+        assert_eq!(usecase.delete(&route_id(), &doncic_token()).await, Ok(()));
     }
 
     struct TestRouteUseCase {
         repository: MockRouteRepository,
         interpolation_api: MockRouteInterpolationApi,
         elevation_api: MockElevationApi,
+        auth_api: MockUserAuthApi,
     }
 
     // setup methods for mocking
@@ -735,6 +761,7 @@ mod tests {
                 repository: MockRouteRepository::new(),
                 interpolation_api: MockRouteInterpolationApi::new(),
                 elevation_api: MockElevationApi::new(),
+                auth_api: MockUserAuthApi::new(),
             };
             expect_at_repository!(usecase, get_connection, MockConnection {});
 
@@ -815,6 +842,14 @@ mod tests {
                 before_route => after_route
             );
         }
+
+        fn expect_authenticate_at_auth_api(&mut self, param_token: String, return_id: UserId) {
+            expect_once!(self.auth_api, authenticate, param_token, return_id);
+        }
+
+        fn expect_authorize_at_auth_api(&mut self, param_id: UserId, param_token: String) {
+            expect_once!(self.auth_api, authorize, param_id, param_token, ());
+        }
     }
 
     // impls to enable trait RouteUseCase
@@ -839,6 +874,14 @@ mod tests {
 
         fn elevation_api(&self) -> &Self::ElevationApi {
             &self.elevation_api
+        }
+    }
+
+    impl CallUserAuthApi for TestRouteUseCase {
+        type UserAuthApi = MockUserAuthApi;
+
+        fn user_auth_api(&self) -> &Self::UserAuthApi {
+            &self.auth_api
         }
     }
 }

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -142,7 +142,7 @@ where
                 let route_info = RouteInfo::new(RouteId::new(), &req.name, owner_id, 0);
 
                 self.route_repository()
-                    .insert_info(&route_info, &conn)
+                    .insert_info(&route_info, conn)
                     .await?;
 
                 Ok(RouteCreateResponse {
@@ -387,7 +387,7 @@ where
                     .authorize(info.owner_id(), user_access_token)
                     .await?;
 
-                self.route_repository().delete(route_id, &conn).await
+                self.route_repository().delete(route_id, conn).await
             }
             .boxed()
         })

--- a/api/usecase/src/user.rs
+++ b/api/usecase/src/user.rs
@@ -71,7 +71,7 @@ where
 
         conn.transaction(|conn| {
             async move {
-                self.user_auth_api().verify_token(user_id, token).await?;
+                self.user_auth_api().authorize(user_id, token).await?;
 
                 let mut user = self.user_repository().find(user_id, conn).await?;
 
@@ -95,7 +95,7 @@ where
         let conn = self.user_repository().get_connection().await?;
         conn.transaction(|conn| {
             async move {
-                self.user_auth_api().verify_token(user_id, token).await?;
+                self.user_auth_api().authorize(user_id, token).await?;
 
                 self.user_repository().delete(user_id, conn).await?;
                 self.user_auth_api().delete_account(user_id).await

--- a/api/usecase/src/user.rs
+++ b/api/usecase/src/user.rs
@@ -202,7 +202,7 @@ mod tests {
     #[tokio::test]
     async fn can_update() {
         let mut usecase = TestUserUseCase::new();
-        usecase.expect_verify_token_at_auth_api(UserId::porzingis(), porzingis_token());
+        usecase.expect_authorize_at_auth_api(UserId::porzingis(), porzingis_token());
         usecase.expect_find_at_user_repository(UserId::porzingis(), User::porzingis());
         usecase.expect_update_at_user_repository(User::porzingis_pretending_like_doncic());
 
@@ -222,7 +222,7 @@ mod tests {
     #[tokio::test]
     async fn can_delete() {
         let mut usecase = TestUserUseCase::new();
-        usecase.expect_verify_token_at_auth_api(UserId::doncic(), doncic_token());
+        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_delete_account_at_auth_api(UserId::doncic());
         usecase.expect_delete_at_user_repository(UserId::doncic());
 
@@ -285,8 +285,8 @@ mod tests {
             expect_once!(self.auth_api, delete_account, param_id, ());
         }
 
-        fn expect_verify_token_at_auth_api(&mut self, param_id: UserId, param_token: String) {
-            expect_once!(self.auth_api, verify_token, param_id, param_token, ());
+        fn expect_authorize_at_auth_api(&mut self, param_id: UserId, param_token: String) {
+            expect_once!(self.auth_api, authorize, param_id, param_token, ());
         }
     }
 

--- a/api/utils/src/error.rs
+++ b/api/utils/src/error.rs
@@ -10,8 +10,11 @@ pub type ApplicationResult<T> = Result<T, ApplicationError>;
 /// actix-webを用いて直接リクエストに変換できる自作エラークラス
 #[derive(Clone, Debug, Display, Error, PartialEq)]
 pub enum ApplicationError {
-    #[display(fmt = "AuthError: {}", _0)]
-    AuthError(String),
+    #[display(fmt = "AuthenticationError: {}", _0)]
+    AuthenticationError(String),
+
+    #[display(fmt = "AuthorizationError: {}", _0)]
+    AuthorizationError(String),
 
     #[display(fmt = "DataBaseError: {}", _0)]
     DataBaseError(String),
@@ -44,7 +47,8 @@ pub enum ApplicationError {
 impl ResponseError for ApplicationError {
     fn status_code(&self) -> http::StatusCode {
         match *self {
-            ApplicationError::AuthError(..) => http::StatusCode::UNAUTHORIZED,
+            ApplicationError::AuthenticationError(..) => http::StatusCode::UNAUTHORIZED,
+            ApplicationError::AuthorizationError(..) => http::StatusCode::FORBIDDEN,
             ApplicationError::InvalidOperation(..) | ApplicationError::ValidationError(..) => {
                 http::StatusCode::BAD_REQUEST
             }
@@ -65,7 +69,7 @@ impl ResponseError for ApplicationError {
 
 impl From<jsonwebtoken::errors::Error> for ApplicationError {
     fn from(err: jsonwebtoken::errors::Error) -> Self {
-        ApplicationError::AuthError(err.to_string())
+        ApplicationError::AuthenticationError(err.to_string())
     }
 }
 


### PR DESCRIPTION
Closes #107 

Routeの閲覧以外の各APIで認証を要するようにした
seed.rsでは、フロントで現状取っているaccess_tokenを取る必要があり、実装しづらくなってしまったので、一旦comment out としている