### PR TITLE
ユーザのフォーム入力のバリデーション

### DIFF
--- a/api/controller/src/user.rs
+++ b/api/controller/src/user.rs
@@ -1,7 +1,9 @@
 use actix_web::{web, HttpResponse, Result};
 use actix_web_httpauth::extractors::bearer::BearerAuth;
 use route_bucket_domain::model::user::UserId;
-use route_bucket_usecase::user::{UserCreateRequest, UserUpdateRequest, UserUseCase};
+use route_bucket_usecase::user::{
+    UserCreateRequest, UserUpdateRequest, UserUseCase, UserValidateRequest,
+};
 
 use crate::AddService;
 
@@ -40,6 +42,13 @@ async fn delete<U: 'static + UserUseCase>(
     Ok(HttpResponse::Ok().json(usecase.delete(&user_id, auth.token()).await?))
 }
 
+async fn post_validate<U: 'static + UserUseCase>(
+    usecase: web::Data<U>,
+    req: web::Json<UserValidateRequest>,
+) -> Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(usecase.validate(req.into_inner()).await?))
+}
+
 pub trait BuildUserService: AddService {
     fn build_user_service<U: 'static + UserUseCase>(self) -> Self {
         self.add_service(
@@ -50,7 +59,8 @@ pub trait BuildUserService: AddService {
                         .route(web::get().to(get::<U>))
                         .route(web::patch().to(patch::<U>))
                         .route(web::delete().to(delete::<U>)),
-                ),
+                )
+                .service(web::resource("/validate/").route(web::post().to(post_validate::<U>))),
         )
     }
 }

--- a/api/domain/src/external.rs
+++ b/api/domain/src/external.rs
@@ -81,6 +81,8 @@ pub trait UserAuthApi: Send + Sync {
             ))
         })
     }
+
+    async fn check_if_email_exists(&self, email: &Email) -> ApplicationResult<bool>;
 }
 
 pub trait CallUserAuthApi {

--- a/api/infrastructure/src/external/firebase.rs
+++ b/api/infrastructure/src/external/firebase.rs
@@ -29,16 +29,10 @@ static API_TOKEN_EXP_OFFSET: Lazy<Duration> = Lazy::new(|| Duration::seconds(10)
 
 #[derive(Clone, Debug, Deserialize, Default)]
 struct FirebaseCredential {
-    r#type: String,
     project_id: String,
-    private_key_id: String,
     private_key: String,
     client_email: String,
-    client_id: String,
-    auth_uri: String,
     token_uri: String,
-    auth_provider_x509_cert_url: String,
-    client_x509_cert_url: String,
 }
 
 #[derive(Clone, Debug, Derivative)]

--- a/api/infrastructure/src/external/srtm.rs
+++ b/api/infrastructure/src/external/srtm.rs
@@ -46,6 +46,7 @@ enum IfdTag {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 struct IfdEntry {
     datatype: u16,
     count: u32,

--- a/api/usecase/src/user.rs
+++ b/api/usecase/src/user.rs
@@ -135,7 +135,6 @@ mod tests {
             birthdate: NaiveDate::from_str("1999-02-28").ok(),
             icon_url: Url::try_from("https://on.nba.com/30qMUEI".to_string()).ok(),
             password: "LukaMagic#77".to_string(),
-            password_confirmation: "LukaMagic#77".to_string(),
         }
     }
 
@@ -149,7 +148,6 @@ mod tests {
             birthdate: None,
             icon_url: None,
             password: "LukaMagic#77".to_string(),
-            password_confirmation: "LukaMagic#77".to_string(),
         }
     }
 

--- a/api/usecase/src/user/requests.rs
+++ b/api/usecase/src/user/requests.rs
@@ -27,8 +27,6 @@ pub struct UserCreateRequest {
     pub(super) icon_url: Option<Url>,
     #[validate(length(min = 6))]
     pub(super) password: String,
-    #[validate(must_match = "password")]
-    pub(super) password_confirmation: String,
 }
 
 impl UserCreateRequest {

--- a/api/usecase/src/user/requests.rs
+++ b/api/usecase/src/user/requests.rs
@@ -11,31 +11,29 @@ use route_bucket_domain::model::{
     user::{Gender, User, UserId},
 };
 
-#[derive(From, Deserialize, Validate)]
+#[derive(From, Deserialize)]
 pub struct UserCreateRequest {
-    #[validate]
     pub(super) id: UserId,
-    #[validate(length(min = 1, max = 50))]
     pub(super) name: String,
-    #[validate]
     pub(super) email: Email,
     #[serde(default)]
     pub(super) gender: Gender,
-    #[validate(custom = "UserCreateRequest::validate_birthdate")]
     pub(super) birthdate: Option<NaiveDate>,
-    #[validate]
     pub(super) icon_url: Option<Url>,
-    #[validate(length(min = 6))]
     pub(super) password: String,
 }
 
-impl UserCreateRequest {
-    fn validate_birthdate(birthdate: &NaiveDate) -> Result<(), validator::ValidationError> {
-        if *birthdate <= Utc::today().naive_utc() {
-            Ok(())
-        } else {
-            Err(validator::ValidationError::new("FUTURE_BIRTHDATE"))
+impl Validate for UserCreateRequest {
+    fn validate(&self) -> Result<(), validator::ValidationErrors> {
+        UserValidateRequest {
+            id: Some(self.id.clone()),
+            name: Some(self.name.clone()),
+            email: Some(self.email.clone()),
+            birthdate: self.birthdate,
+            icon_url: self.icon_url.clone(),
+            password: Some(self.password.clone()),
         }
+        .validate()
     }
 }
 
@@ -64,8 +62,34 @@ pub struct UserUpdateRequest {
     pub(super) name: Option<String>,
     #[serde(default)]
     pub(super) gender: Option<Gender>,
-    #[validate(custom = "UserCreateRequest::validate_birthdate")]
+    #[validate(custom = "UserValidateRequest::validate_birthdate")]
     pub(super) birthdate: Option<NaiveDate>,
     #[validate]
     pub(super) icon_url: Option<Url>,
+}
+
+#[derive(From, Deserialize, Validate)]
+pub struct UserValidateRequest {
+    #[validate]
+    pub(super) id: Option<UserId>,
+    #[validate(length(min = 1, max = 50))]
+    pub(super) name: Option<String>,
+    #[validate]
+    pub(super) email: Option<Email>,
+    #[validate(custom = "UserValidateRequest::validate_birthdate")]
+    pub(super) birthdate: Option<NaiveDate>,
+    #[validate]
+    pub(super) icon_url: Option<Url>,
+    #[validate(length(min = 6))]
+    pub(super) password: Option<String>,
+}
+
+impl UserValidateRequest {
+    fn validate_birthdate(birthdate: &NaiveDate) -> Result<(), validator::ValidationError> {
+        if *birthdate <= Utc::today().naive_utc() {
+            Ok(())
+        } else {
+            Err(validator::ValidationError::new("FUTURE_BIRTHDATE"))
+        }
+    }
 }

--- a/api/usecase/src/user/responses.rs
+++ b/api/usecase/src/user/responses.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use derive_more::From;
 use route_bucket_domain::model::user::UserId;
 use serde::Serialize;
@@ -7,3 +9,14 @@ use serde::Serialize;
 pub struct UserCreateResponse {
     pub id: UserId,
 }
+
+#[derive(Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub(super) enum ValidationErrorCode {
+    InvalidFormat,
+    AlreadyExists,
+}
+
+#[derive(Debug, Default, Serialize)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct UserValidateResponse(pub(super) HashMap<&'static str, ValidationErrorCode>);


### PR DESCRIPTION
Closes #102 
Closes #112 

* `POST /users/`で、firebase APIを叩いた時のエラーのうち、ユーザのエラーに起因するもの（idやemailの被りなど）が出たときは、400を返すようにした（今までは500が帰ってきていた)
*  `POST /users/`で`password_confirmation`を無くした（フロントに任せることにした）
* フォームの入力内容を、保存することなくバリデーションするためのエンドポイント`POST /users/validate/`を追加した