### PR TITLE
検索結果のページング

### DIFF
--- a/api/domain/src/model/route/search_query.rs
+++ b/api/domain/src/model/route/search_query.rs
@@ -6,7 +6,10 @@ use crate::model::user::UserId;
 #[cfg_attr(any(test, feature = "fixtures"), derive(PartialEq))]
 pub struct RouteSearchQuery {
     #[serde(skip_serializing_if = "Option::is_none")]
-    owner_id: Option<UserId>,
+    pub owner_id: Option<UserId>,
+    #[serde(default)]
+    pub page_offset: usize,
+    pub page_size: Option<usize>,
 }
 
 impl RouteSearchQuery {
@@ -25,6 +28,7 @@ pub(crate) mod tests {
         fn search_guest() -> RouteSearchQuery {
             RouteSearchQuery {
                 owner_id: Some(UserId::doncic()),
+                ..Default::default()
             }
         }
     }

--- a/api/domain/src/repository/route.rs
+++ b/api/domain/src/repository/route.rs
@@ -30,6 +30,12 @@ pub trait RouteRepository: Repository {
         conn: &<Self as Repository>::Connection,
     ) -> ApplicationResult<Vec<RouteInfo>>;
 
+    async fn count_infos(
+        &self,
+        query: RouteSearchQuery,
+        conn: &<Self as Repository>::Connection,
+    ) -> ApplicationResult<usize>;
+
     async fn insert_info(
         &self,
         info: &RouteInfo,
@@ -78,6 +84,8 @@ mockall::mock! {
         async fn find_info(&self, id: &RouteId, conn: &super::MockConnection) -> ApplicationResult<RouteInfo>;
 
         async fn search_infos(&self, query: RouteSearchQuery, conn: &super::MockConnection) -> ApplicationResult<Vec<RouteInfo>>;
+
+        async fn count_infos(&self, query: RouteSearchQuery, conn: &super::MockConnection) -> ApplicationResult<usize>;
 
         async fn insert_info(&self, info: &RouteInfo, conn: &super::MockConnection) -> ApplicationResult<()>;
 

--- a/api/infrastructure/src/dto.rs
+++ b/api/infrastructure/src/dto.rs
@@ -1,4 +1,5 @@
 pub mod operation;
 pub mod route;
+pub mod search_query;
 pub mod segment;
 pub mod user;

--- a/api/infrastructure/src/dto/search_query.rs
+++ b/api/infrastructure/src/dto/search_query.rs
@@ -9,7 +9,7 @@ enum WhereCondition {
 }
 
 impl WhereCondition {
-    fn to_query(self, field_name: &'static str) -> String {
+    fn to_query(&self, field_name: &'static str) -> String {
         match self {
             Self::Eq(value) => {
                 format!("{} = \"{}\"", field_name, value)
@@ -25,7 +25,7 @@ struct OrderBy {
 }
 
 impl OrderBy {
-    fn to_query(self) -> String {
+    fn to_query(&self) -> String {
         format!(
             "`{}` {}",
             self.field_name,
@@ -44,20 +44,24 @@ pub(crate) struct SearchQuery {
 }
 
 impl SearchQuery {
-    pub fn to_sql(self) -> String {
-        let mut query = format!("SELECT * FROM {} ", self.table_name);
+    pub fn to_sql(&self, is_for_counting: bool) -> String {
+        let mut query = format!(
+            "SELECT {} FROM {} ",
+            if is_for_counting { "COUNT(*)" } else { "*" },
+            self.table_name
+        );
 
         if !self.where_conditions.is_empty() {
             query += &format!(
                 "WHERE {} ",
                 self.where_conditions
-                    .into_iter()
+                    .iter()
                     .map(|(field, cond)| cond.to_query(field))
                     .join(", "),
             );
         }
 
-        if let Some(order_by) = self.order_by {
+        if let Some(order_by) = &self.order_by {
             query += &format!("ORDER BY {} ", order_by.to_query());
         }
 

--- a/api/infrastructure/src/dto/search_query.rs
+++ b/api/infrastructure/src/dto/search_query.rs
@@ -1,0 +1,102 @@
+use std::collections::HashMap;
+
+use itertools::Itertools;
+use route_bucket_domain::model::route::RouteSearchQuery;
+
+#[derive(Clone, Debug)]
+enum WhereCondition {
+    Eq(String),
+}
+
+impl WhereCondition {
+    fn to_query(self, field_name: &'static str) -> String {
+        match self {
+            Self::Eq(value) => {
+                format!("{} = \"{}\"", field_name, value)
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct OrderBy {
+    field_name: &'static str,
+    descending: bool,
+}
+
+impl OrderBy {
+    fn to_query(self) -> String {
+        format!(
+            "`{}` {}",
+            self.field_name,
+            if self.descending { "DESC" } else { "" }
+        )
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct SearchQuery {
+    table_name: &'static str,
+    where_conditions: HashMap<&'static str, WhereCondition>,
+    order_by: Option<OrderBy>,
+    limit: Option<usize>,
+    offset: Option<usize>,
+}
+
+impl SearchQuery {
+    pub fn to_sql(self) -> String {
+        let mut query = format!("SELECT * FROM {} ", self.table_name);
+
+        if !self.where_conditions.is_empty() {
+            query += &format!(
+                "WHERE {} ",
+                self.where_conditions
+                    .into_iter()
+                    .map(|(field, cond)| cond.to_query(field))
+                    .join(", "),
+            );
+        }
+
+        if let Some(order_by) = self.order_by {
+            query += &format!("ORDER BY {} ", order_by.to_query());
+        }
+
+        if let Some(limit) = self.limit {
+            query += &format!("LIMIT {} ", limit);
+        }
+
+        if let Some(offset) = self.offset {
+            query += &format!("OFFSET {} ", offset);
+        }
+
+        query
+    }
+}
+
+impl From<RouteSearchQuery> for SearchQuery {
+    fn from(route_search_query: RouteSearchQuery) -> Self {
+        let mut search_query = SearchQuery {
+            table_name: "routes",
+            ..Default::default()
+        };
+
+        if let Some(owner_id) = route_search_query.owner_id {
+            search_query
+                .where_conditions
+                .insert("owner_id", WhereCondition::Eq(owner_id.to_string()));
+        }
+
+        // TODO: ここを指定できるようにする
+        search_query.order_by = Some(OrderBy {
+            field_name: "updated_at",
+            descending: true,
+        });
+
+        if let Some(page_size) = route_search_query.page_size {
+            search_query.limit = Some(page_size);
+            search_query.offset = Some(page_size * route_search_query.page_offset);
+        }
+
+        search_query
+    }
+}

--- a/api/infrastructure/src/dto/search_query.rs
+++ b/api/infrastructure/src/dto/search_query.rs
@@ -61,16 +61,18 @@ impl SearchQuery {
             );
         }
 
-        if let Some(order_by) = &self.order_by {
-            query += &format!("ORDER BY {} ", order_by.to_query());
-        }
+        if !is_for_counting {
+            if let Some(order_by) = &self.order_by {
+                query += &format!("ORDER BY {} ", order_by.to_query());
+            }
 
-        if let Some(limit) = self.limit {
-            query += &format!("LIMIT {} ", limit);
-        }
+            if let Some(limit) = self.limit {
+                query += &format!("LIMIT {} ", limit);
+            }
 
-        if let Some(offset) = self.offset {
-            query += &format!("OFFSET {} ", offset);
+            if let Some(offset) = self.offset {
+                query += &format!("OFFSET {} ", offset);
+            }
         }
 
         query

--- a/api/infrastructure/src/repository.rs
+++ b/api/infrastructure/src/repository.rs
@@ -1,12 +1,9 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use derive_more::Deref;
-use itertools::Itertools;
 use route_bucket_domain::repository::Connection;
 use route_bucket_utils::{ApplicationError, ApplicationResult};
-use serde::Serialize;
 use sqlx::mysql::{MySqlPoolOptions, MySqlTransactionManager};
 use sqlx::pool::PoolConnection;
 use sqlx::{MySql, TransactionManager};
@@ -35,26 +32,6 @@ pub async fn init_repositories() -> (RouteRepositoryMySql, UserRepositoryMySql) 
 
 fn gen_err_mapper(msg: &'static str) -> impl FnOnce(sqlx::Error) -> ApplicationError {
     move |err| ApplicationError::DataBaseError(format!("{} ({:?})", msg, err))
-}
-
-fn serializable_to_search_query<T: Serialize>(
-    table: &str,
-    serializable: T,
-) -> ApplicationResult<String> {
-    let hashmap: HashMap<String, String> =
-        serde_json::from_value(serde_json::to_value(serializable).unwrap()).unwrap();
-
-    let mut query = format!("SELECT * FROM {}", table);
-    if !hashmap.is_empty() {
-        let conditions = hashmap
-            .into_iter()
-            .map(|(key, val)| format!("`{}` = '{}'", key, val))
-            .join(", ");
-
-        query = format!("{} WHERE {}", query, conditions);
-    }
-
-    Ok(query)
 }
 
 #[derive(Deref)]

--- a/api/infrastructure/src/repository/route.rs
+++ b/api/infrastructure/src/repository/route.rs
@@ -312,7 +312,8 @@ impl RouteRepository for RouteRepositoryMySql {
 
         sqlx::query(
             r"
-            INSERT INTO routes VALUES (?, ?, ?, ?)
+            INSERT INTO routes (`id`, `name`, `owner_id`, `operation_pos`)
+            VALUES (?, ?, ?, ?)
             ",
         )
         .bind(dto.id())

--- a/api/infrastructure/src/repository/route.rs
+++ b/api/infrastructure/src/repository/route.rs
@@ -14,10 +14,9 @@ use route_bucket_utils::{ApplicationError, ApplicationResult};
 
 use crate::dto::operation::OperationDto;
 use crate::dto::route::RouteDto;
+use crate::dto::search_query::SearchQuery;
 use crate::dto::segment::SegmentDto;
 use crate::repository::{gen_err_mapper, RepositoryConnectionMySql};
-
-use super::serializable_to_search_query;
 
 // NOTE: MySqlPoolを共有したくなったら、Arcで囲めば良さそう
 pub struct RouteRepositoryMySql(pub(super) Arc<MySqlPool>);
@@ -293,7 +292,7 @@ impl RouteRepository for RouteRepositoryMySql {
     ) -> ApplicationResult<Vec<RouteInfo>> {
         let mut conn = conn.lock().await;
 
-        sqlx::query_as::<_, RouteDto>(&serializable_to_search_query("routes", query)?)
+        sqlx::query_as::<_, RouteDto>(&SearchQuery::from(query).to_sql())
             .fetch_all(&mut *conn)
             .await
             .map_err(gen_err_mapper("failed to find infos"))?

--- a/api/usecase/src/route/responses.rs
+++ b/api/usecase/src/route/responses.rs
@@ -24,6 +24,7 @@ pub struct RouteGetResponse {
 pub struct RouteSearchResponse {
     #[serde(rename = "routes")]
     pub route_infos: Vec<RouteInfo>,
+    pub result_num: usize,
 }
 
 pub type RouteGetGpxResponse = RouteGpx;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -4,6 +4,9 @@ CREATE TABLE routes
     `name`          VARCHAR(50)      NOT NULL,
     `owner_id`      VARCHAR(40)      NOT NULL,
     `operation_pos` INTEGER UNSIGNED NOT NULL,
+    `created_at`    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`    TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX updated_idx (`updated_at`),
     PRIMARY KEY (`id`)
 );
 


### PR DESCRIPTION
* フロント側でのページングを実現するために、`GET /routes/search`で`page_offset`と`page_size`を指定できるようにした
* 検索回りをリファクタして、infraのオブジェクトとして`SearchQuery`を定義した
* DBのroutesに`created_at`,`updated_at`を追加し、`updated_at`で検索結果をソートする仕様とした