### PR TITLE
予約語と重複するuser idの禁止

### DIFF
--- a/api/controller/src/user.rs
+++ b/api/controller/src/user.rs
@@ -1,7 +1,9 @@
 use actix_web::{web, HttpResponse, Result};
 use actix_web_httpauth::extractors::bearer::BearerAuth;
 use route_bucket_domain::model::user::UserId;
-use route_bucket_usecase::user::{UserCreateRequest, UserUpdateRequest, UserUseCase};
+use route_bucket_usecase::user::{
+    UserCreateRequest, UserUpdateRequest, UserUseCase, UserValidateRequest,
+};
 
 use crate::AddService;
 
@@ -40,6 +42,13 @@ async fn delete<U: 'static + UserUseCase>(
     Ok(HttpResponse::Ok().json(usecase.delete(&user_id, auth.token()).await?))
 }
 
+async fn post_validate<U: 'static + UserUseCase>(
+    usecase: web::Data<U>,
+    req: web::Json<UserValidateRequest>,
+) -> Result<HttpResponse> {
+    Ok(HttpResponse::Ok().json(usecase.validate(req.into_inner()).await?))
+}
+
 pub trait BuildUserService: AddService {
     fn build_user_service<U: 'static + UserUseCase>(self) -> Self {
         self.add_service(
@@ -50,7 +59,8 @@ pub trait BuildUserService: AddService {
                         .route(web::get().to(get::<U>))
                         .route(web::patch().to(patch::<U>))
                         .route(web::delete().to(delete::<U>)),
-                ),
+                )
+                .service(web::resource("/validate/").route(web::post().to(post_validate::<U>))),
         )
     }
 }

--- a/api/domain/src/external.rs
+++ b/api/domain/src/external.rs
@@ -81,6 +81,8 @@ pub trait UserAuthApi: Send + Sync {
             ))
         })
     }
+
+    async fn check_if_email_exists(&self, email: &Email) -> ApplicationResult<bool>;
 }
 
 pub trait CallUserAuthApi {

--- a/api/domain/src/external.rs
+++ b/api/domain/src/external.rs
@@ -90,3 +90,15 @@ pub trait CallUserAuthApi {
 
     fn user_auth_api(&self) -> &Self::UserAuthApi;
 }
+
+#[cfg_attr(feature = "mocking", mockall::automock)]
+#[async_trait]
+pub trait ReservedUserIdCheckerApi: Send + Sync {
+    async fn check_if_reserved(&self, id: &UserId) -> ApplicationResult<bool>;
+}
+
+pub trait CallReservedUserIdCheckerApi {
+    type ReservedUserIdCheckerApi: ReservedUserIdCheckerApi;
+
+    fn reserved_user_id_checker_api(&self) -> &Self::ReservedUserIdCheckerApi;
+}

--- a/api/domain/src/model/route/route_info.rs
+++ b/api/domain/src/model/route/route_info.rs
@@ -75,7 +75,7 @@ pub(crate) mod tests {
             RouteInfo {
                 id: RouteId::new(),
                 name: "route0".into(),
-                owner_id: UserId::guest(),
+                owner_id: UserId::doncic(),
                 op_num,
             }
         }
@@ -84,7 +84,7 @@ pub(crate) mod tests {
             RouteInfo {
                 id: RouteId::new(),
                 name: "route1".into(),
-                owner_id: UserId::guest(),
+                owner_id: UserId::doncic(),
                 op_num,
             }
         }

--- a/api/domain/src/model/route/search_query.rs
+++ b/api/domain/src/model/route/search_query.rs
@@ -24,7 +24,7 @@ pub(crate) mod tests {
     pub trait RouteSearchQueryFixtures {
         fn search_guest() -> RouteSearchQuery {
             RouteSearchQuery {
-                owner_id: Some(UserId::guest()),
+                owner_id: Some(UserId::doncic()),
             }
         }
     }

--- a/api/domain/src/model/route/search_query.rs
+++ b/api/domain/src/model/route/search_query.rs
@@ -6,7 +6,10 @@ use crate::model::user::UserId;
 #[cfg_attr(any(test, feature = "fixtures"), derive(PartialEq))]
 pub struct RouteSearchQuery {
     #[serde(skip_serializing_if = "Option::is_none")]
-    owner_id: Option<UserId>,
+    pub owner_id: Option<UserId>,
+    #[serde(default)]
+    pub page_offset: usize,
+    pub page_size: Option<usize>,
 }
 
 impl RouteSearchQuery {
@@ -25,6 +28,7 @@ pub(crate) mod tests {
         fn search_guest() -> RouteSearchQuery {
             RouteSearchQuery {
                 owner_id: Some(UserId::doncic()),
+                ..Default::default()
             }
         }
     }

--- a/api/domain/src/model/user.rs
+++ b/api/domain/src/model/user.rs
@@ -62,10 +62,6 @@ pub(crate) mod tests {
         fn porzingis() -> UserId {
             UserId::from("kporzee".to_string())
         }
-
-        fn guest() -> UserId {
-            UserId::from("guest".to_string())
-        }
     }
 
     impl UserIdFixtures for UserId {}

--- a/api/domain/src/repository/route.rs
+++ b/api/domain/src/repository/route.rs
@@ -30,6 +30,12 @@ pub trait RouteRepository: Repository {
         conn: &<Self as Repository>::Connection,
     ) -> ApplicationResult<Vec<RouteInfo>>;
 
+    async fn count_infos(
+        &self,
+        query: RouteSearchQuery,
+        conn: &<Self as Repository>::Connection,
+    ) -> ApplicationResult<usize>;
+
     async fn insert_info(
         &self,
         info: &RouteInfo,
@@ -78,6 +84,8 @@ mockall::mock! {
         async fn find_info(&self, id: &RouteId, conn: &super::MockConnection) -> ApplicationResult<RouteInfo>;
 
         async fn search_infos(&self, query: RouteSearchQuery, conn: &super::MockConnection) -> ApplicationResult<Vec<RouteInfo>>;
+
+        async fn count_infos(&self, query: RouteSearchQuery, conn: &super::MockConnection) -> ApplicationResult<usize>;
 
         async fn insert_info(&self, info: &RouteInfo, conn: &super::MockConnection) -> ApplicationResult<()>;
 

--- a/api/infrastructure/src/dto.rs
+++ b/api/infrastructure/src/dto.rs
@@ -1,4 +1,5 @@
 pub mod operation;
 pub mod route;
+pub mod search_query;
 pub mod segment;
 pub mod user;

--- a/api/infrastructure/src/dto/search_query.rs
+++ b/api/infrastructure/src/dto/search_query.rs
@@ -9,7 +9,7 @@ enum WhereCondition {
 }
 
 impl WhereCondition {
-    fn to_query(self, field_name: &'static str) -> String {
+    fn to_query(&self, field_name: &'static str) -> String {
         match self {
             Self::Eq(value) => {
                 format!("{} = \"{}\"", field_name, value)
@@ -25,7 +25,7 @@ struct OrderBy {
 }
 
 impl OrderBy {
-    fn to_query(self) -> String {
+    fn to_query(&self) -> String {
         format!(
             "`{}` {}",
             self.field_name,
@@ -44,20 +44,24 @@ pub(crate) struct SearchQuery {
 }
 
 impl SearchQuery {
-    pub fn to_sql(self) -> String {
-        let mut query = format!("SELECT * FROM {} ", self.table_name);
+    pub fn to_sql(&self, is_for_counting: bool) -> String {
+        let mut query = format!(
+            "SELECT {} FROM {} ",
+            if is_for_counting { "COUNT(*)" } else { "*" },
+            self.table_name
+        );
 
         if !self.where_conditions.is_empty() {
             query += &format!(
                 "WHERE {} ",
                 self.where_conditions
-                    .into_iter()
+                    .iter()
                     .map(|(field, cond)| cond.to_query(field))
                     .join(", "),
             );
         }
 
-        if let Some(order_by) = self.order_by {
+        if let Some(order_by) = &self.order_by {
             query += &format!("ORDER BY {} ", order_by.to_query());
         }
 

--- a/api/infrastructure/src/dto/search_query.rs
+++ b/api/infrastructure/src/dto/search_query.rs
@@ -1,0 +1,102 @@
+use std::collections::HashMap;
+
+use itertools::Itertools;
+use route_bucket_domain::model::route::RouteSearchQuery;
+
+#[derive(Clone, Debug)]
+enum WhereCondition {
+    Eq(String),
+}
+
+impl WhereCondition {
+    fn to_query(self, field_name: &'static str) -> String {
+        match self {
+            Self::Eq(value) => {
+                format!("{} = \"{}\"", field_name, value)
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct OrderBy {
+    field_name: &'static str,
+    descending: bool,
+}
+
+impl OrderBy {
+    fn to_query(self) -> String {
+        format!(
+            "`{}` {}",
+            self.field_name,
+            if self.descending { "DESC" } else { "" }
+        )
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct SearchQuery {
+    table_name: &'static str,
+    where_conditions: HashMap<&'static str, WhereCondition>,
+    order_by: Option<OrderBy>,
+    limit: Option<usize>,
+    offset: Option<usize>,
+}
+
+impl SearchQuery {
+    pub fn to_sql(self) -> String {
+        let mut query = format!("SELECT * FROM {} ", self.table_name);
+
+        if !self.where_conditions.is_empty() {
+            query += &format!(
+                "WHERE {} ",
+                self.where_conditions
+                    .into_iter()
+                    .map(|(field, cond)| cond.to_query(field))
+                    .join(", "),
+            );
+        }
+
+        if let Some(order_by) = self.order_by {
+            query += &format!("ORDER BY {} ", order_by.to_query());
+        }
+
+        if let Some(limit) = self.limit {
+            query += &format!("LIMIT {} ", limit);
+        }
+
+        if let Some(offset) = self.offset {
+            query += &format!("OFFSET {} ", offset);
+        }
+
+        query
+    }
+}
+
+impl From<RouteSearchQuery> for SearchQuery {
+    fn from(route_search_query: RouteSearchQuery) -> Self {
+        let mut search_query = SearchQuery {
+            table_name: "routes",
+            ..Default::default()
+        };
+
+        if let Some(owner_id) = route_search_query.owner_id {
+            search_query
+                .where_conditions
+                .insert("owner_id", WhereCondition::Eq(owner_id.to_string()));
+        }
+
+        // TODO: ここを指定できるようにする
+        search_query.order_by = Some(OrderBy {
+            field_name: "updated_at",
+            descending: true,
+        });
+
+        if let Some(page_size) = route_search_query.page_size {
+            search_query.limit = Some(page_size);
+            search_query.offset = Some(page_size * route_search_query.page_offset);
+        }
+
+        search_query
+    }
+}

--- a/api/infrastructure/src/external.rs
+++ b/api/infrastructure/src/external.rs
@@ -1,3 +1,4 @@
 pub mod firebase;
 pub mod osrm;
+pub mod reserved_uids_reader;
 pub mod srtm;

--- a/api/infrastructure/src/external/firebase.rs
+++ b/api/infrastructure/src/external/firebase.rs
@@ -20,7 +20,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use tokio::sync::RwLock;
 
-use self::token::verify;
+use self::token::verify_and_get_user_id;
 
 const CREDENTIAL_PATH: &str = "resources/credentials/firebase-adminsdk.json";
 const API_SCOPE: &str = "https://www.googleapis.com/auth/identitytoolkit";
@@ -95,7 +95,7 @@ impl GoogleAccessToken {
             self.token = response
                 .get("access_token")
                 .ok_or_else(|| {
-                    ApplicationError::AuthError(format!(
+                    ApplicationError::ExternalError(format!(
                         "Unable to find access_token in the response: {:?}",
                         response.clone()
                     ))
@@ -109,7 +109,7 @@ impl GoogleAccessToken {
                     response
                         .get("expires_in")
                         .ok_or_else(|| {
-                            ApplicationError::AuthError(format!(
+                            ApplicationError::ExternalError(format!(
                                 "Unable to find expires_in in the response: {:?}",
                                 response.clone()
                             ))
@@ -187,7 +187,7 @@ impl UserAuthApi for FirebaseAuthApi {
         if response.status().is_success() {
             Ok(())
         } else {
-            Err(ApplicationError::AuthError(format!(
+            Err(ApplicationError::ExternalError(format!(
                 "Failed to create account: {:?}",
                 response.json::<Value>().await
             )))
@@ -210,7 +210,7 @@ impl UserAuthApi for FirebaseAuthApi {
         if response.status().is_success() {
             Ok(())
         } else {
-            Err(ApplicationError::AuthError(format!(
+            Err(ApplicationError::ExternalError(format!(
                 "Failed to delete account: {:?}",
                 response.json::<Value>().await
             )))

--- a/api/infrastructure/src/external/firebase.rs
+++ b/api/infrastructure/src/external/firebase.rs
@@ -29,16 +29,10 @@ static API_TOKEN_EXP_OFFSET: Lazy<Duration> = Lazy::new(|| Duration::seconds(10)
 
 #[derive(Clone, Debug, Deserialize, Default)]
 struct FirebaseCredential {
-    r#type: String,
     project_id: String,
-    private_key_id: String,
     private_key: String,
     client_email: String,
-    client_id: String,
-    auth_uri: String,
     token_uri: String,
-    auth_provider_x509_cert_url: String,
-    client_x509_cert_url: String,
 }
 
 #[derive(Clone, Debug, Derivative)]

--- a/api/infrastructure/src/external/firebase.rs
+++ b/api/infrastructure/src/external/firebase.rs
@@ -217,7 +217,7 @@ impl UserAuthApi for FirebaseAuthApi {
         }
     }
 
-    async fn verify_token(&self, user_id: &UserId, token: &str) -> ApplicationResult<()> {
-        verify(user_id, token, &self.credential).await
+    async fn authenticate(&self, token: &str) -> ApplicationResult<UserId> {
+        verify_and_get_user_id(token, &self.credential).await
     }
 }

--- a/api/infrastructure/src/external/firebase/token.rs
+++ b/api/infrastructure/src/external/firebase/token.rs
@@ -52,13 +52,15 @@ pub(super) async fn verify(
     let kid = decode_header(token)
         .map(|header| header.kid)?
         .ok_or_else(|| {
-            ApplicationError::AuthError("The decoded jwt header didn't contain kid.".into())
+            ApplicationError::AuthenticationError(
+                "The decoded jwt header didn't contain kid.".into(),
+            )
         })?;
 
     // validate: kid
     let jwks_by_kid = HashMap::from(reqwest::get(JWT_URL).await?.json::<KeysResponse>().await?);
     let jwk = jwks_by_kid.get(&kid).ok_or_else(|| {
-        ApplicationError::AuthError("The decoded kid not found in jwks response".into())
+        ApplicationError::AuthenticationError("The decoded kid not found in jwks response".into())
     })?;
 
     // validate: alg, iss, aud

--- a/api/infrastructure/src/external/firebase/token.rs
+++ b/api/infrastructure/src/external/firebase/token.rs
@@ -44,11 +44,10 @@ impl From<KeysResponse> for HashMap<String, Jwk> {
     }
 }
 
-pub(super) async fn verify(
-    user_id: &UserId,
+pub(super) async fn verify_and_get_user_id(
     token: &str,
     credential: &FirebaseCredential,
-) -> ApplicationResult<()> {
+) -> ApplicationResult<UserId> {
     let kid = decode_header(token)
         .map(|header| header.kid)?
         .ok_or_else(|| {
@@ -76,11 +75,5 @@ pub(super) async fn verify(
     let decoding_key = DecodingKey::from_rsa_components(&jwk.n, &jwk.e);
     let decoded_token = jsonwebtoken::decode::<Claims>(token, &decoding_key, &validation)?;
 
-    let uid = decoded_token.claims.sub;
-    (user_id.to_string() == uid).then(|| ()).ok_or_else(|| {
-        ApplicationError::AuthError(format!(
-            "The id of the user ({}) doesn't match the id from the token ({}).",
-            user_id, uid
-        ))
-    })
+    Ok(UserId::from(decoded_token.claims.sub))
 }

--- a/api/infrastructure/src/external/reserved_uids_reader.rs
+++ b/api/infrastructure/src/external/reserved_uids_reader.rs
@@ -34,7 +34,7 @@ impl InnerReservedUidsReader {
                     TEXT_PATH, err
                 ))
             })?
-            .split("\n")
+            .split('\n')
             .map(String::from)
             .map(UserId::from)
             .collect();

--- a/api/infrastructure/src/external/reserved_uids_reader.rs
+++ b/api/infrastructure/src/external/reserved_uids_reader.rs
@@ -1,0 +1,71 @@
+use std::fs::read_to_string;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, Utc};
+use derivative::Derivative;
+use once_cell::sync::Lazy;
+use route_bucket_domain::{external::ReservedUserIdCheckerApi, model::user::UserId};
+use route_bucket_utils::{ApplicationError, ApplicationResult};
+use tokio::sync::RwLock;
+
+const TEXT_PATH: &str = "resources/reserved_uids.txt";
+static UPDATE_INTERVAL: Lazy<Duration> = Lazy::new(|| Duration::days(1));
+
+#[derive(Derivative)]
+#[derivative(Default)]
+struct InnerReservedUidsReader {
+    reserved_ids: Vec<UserId>,
+    #[derivative(Default(value = "chrono::MIN_DATETIME"))]
+    next_update_time: DateTime<Utc>,
+}
+
+impl InnerReservedUidsReader {
+    fn new() -> ApplicationResult<Self> {
+        let mut reader: Self = Default::default();
+        reader.update()?;
+        Ok(reader)
+    }
+
+    fn update(&mut self) -> ApplicationResult<()> {
+        self.reserved_ids = read_to_string(TEXT_PATH)
+            .map_err(|err| {
+                ApplicationError::ExternalError(format!(
+                    "Failed to read from {}! ({})",
+                    TEXT_PATH, err
+                ))
+            })?
+            .split("\n")
+            .map(String::from)
+            .map(UserId::from)
+            .collect();
+        self.next_update_time = Utc::now() + *UPDATE_INTERVAL;
+        Ok(())
+    }
+
+    fn contains(&self, id: &UserId) -> bool {
+        self.reserved_ids.contains(id)
+    }
+}
+
+pub struct ReservedUidsReader(RwLock<InnerReservedUidsReader>);
+
+impl ReservedUidsReader {
+    pub fn new() -> ApplicationResult<Self> {
+        InnerReservedUidsReader::new().map(RwLock::new).map(Self)
+    }
+}
+
+#[async_trait]
+impl ReservedUserIdCheckerApi for ReservedUidsReader {
+    async fn check_if_reserved(&self, id: &UserId) -> ApplicationResult<bool> {
+        // Write lock scope
+        {
+            let mut inner_reader = self.0.write().await;
+            if inner_reader.next_update_time <= Utc::now() {
+                inner_reader.update()?;
+            }
+        }
+
+        Ok(self.0.read().await.contains(id))
+    }
+}

--- a/api/infrastructure/src/external/srtm.rs
+++ b/api/infrastructure/src/external/srtm.rs
@@ -46,6 +46,7 @@ enum IfdTag {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 struct IfdEntry {
     datatype: u16,
     count: u32,

--- a/api/infrastructure/src/lib.rs
+++ b/api/infrastructure/src/lib.rs
@@ -1,5 +1,6 @@
 pub use external::firebase::FirebaseAuthApi;
 pub use external::osrm::OsrmApi;
+pub use external::reserved_uids_reader::ReservedUidsReader;
 pub use external::srtm::SrtmReader;
 pub use repository::{init_repositories, route::RouteRepositoryMySql, user::UserRepositoryMySql};
 

--- a/api/infrastructure/src/repository.rs
+++ b/api/infrastructure/src/repository.rs
@@ -1,12 +1,9 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use derive_more::Deref;
-use itertools::Itertools;
 use route_bucket_domain::repository::Connection;
 use route_bucket_utils::{ApplicationError, ApplicationResult};
-use serde::Serialize;
 use sqlx::mysql::{MySqlPoolOptions, MySqlTransactionManager};
 use sqlx::pool::PoolConnection;
 use sqlx::{MySql, TransactionManager};
@@ -35,26 +32,6 @@ pub async fn init_repositories() -> (RouteRepositoryMySql, UserRepositoryMySql) 
 
 fn gen_err_mapper(msg: &'static str) -> impl FnOnce(sqlx::Error) -> ApplicationError {
     move |err| ApplicationError::DataBaseError(format!("{} ({:?})", msg, err))
-}
-
-fn serializable_to_search_query<T: Serialize>(
-    table: &str,
-    serializable: T,
-) -> ApplicationResult<String> {
-    let hashmap: HashMap<String, String> =
-        serde_json::from_value(serde_json::to_value(serializable).unwrap()).unwrap();
-
-    let mut query = format!("SELECT * FROM {}", table);
-    if !hashmap.is_empty() {
-        let conditions = hashmap
-            .into_iter()
-            .map(|(key, val)| format!("`{}` = '{}'", key, val))
-            .join(", ");
-
-        query = format!("{} WHERE {}", query, conditions);
-    }
-
-    Ok(query)
 }
 
 #[derive(Deref)]

--- a/api/infrastructure/src/repository/route.rs
+++ b/api/infrastructure/src/repository/route.rs
@@ -312,7 +312,8 @@ impl RouteRepository for RouteRepositoryMySql {
 
         sqlx::query(
             r"
-            INSERT INTO routes VALUES (?, ?, ?, ?)
+            INSERT INTO routes (`id`, `name`, `owner_id`, `operation_pos`)
+            VALUES (?, ?, ?, ?)
             ",
         )
         .bind(dto.id())

--- a/api/infrastructure/src/repository/route.rs
+++ b/api/infrastructure/src/repository/route.rs
@@ -14,10 +14,9 @@ use route_bucket_utils::{ApplicationError, ApplicationResult};
 
 use crate::dto::operation::OperationDto;
 use crate::dto::route::RouteDto;
+use crate::dto::search_query::SearchQuery;
 use crate::dto::segment::SegmentDto;
 use crate::repository::{gen_err_mapper, RepositoryConnectionMySql};
-
-use super::serializable_to_search_query;
 
 // NOTE: MySqlPoolを共有したくなったら、Arcで囲めば良さそう
 pub struct RouteRepositoryMySql(pub(super) Arc<MySqlPool>);
@@ -293,7 +292,7 @@ impl RouteRepository for RouteRepositoryMySql {
     ) -> ApplicationResult<Vec<RouteInfo>> {
         let mut conn = conn.lock().await;
 
-        sqlx::query_as::<_, RouteDto>(&serializable_to_search_query("routes", query)?)
+        sqlx::query_as::<_, RouteDto>(&SearchQuery::from(query).to_sql())
             .fetch_all(&mut *conn)
             .await
             .map_err(gen_err_mapper("failed to find infos"))?

--- a/api/resources/reserved_uids.txt
+++ b/api/resources/reserved_uids.txt
@@ -1,0 +1,11 @@
+routes
+posts
+comments
+about
+privacy
+terms
+signin
+signup
+signout
+password_reset
+icons

--- a/api/src/bin/seed.rs
+++ b/api/src/bin/seed.rs
@@ -1,80 +1,81 @@
-use route_bucket_backend::server::Server;
-use route_bucket_domain::model::route::{Coordinate, DrawingMode};
-use route_bucket_usecase::route::RouteUseCase;
+// use route_bucket_backend::server::Server;
+// use route_bucket_domain::model::route::{Coordinate, DrawingMode};
+// use route_bucket_usecase::route::RouteUseCase;
 
-macro_rules! coord {
-    ( $lat: expr, $lon: expr ) => {
-        Coordinate::new($lat, $lon).unwrap()
-    };
-}
+// macro_rules! coord {
+//     ( $lat: expr, $lon: expr ) => {
+//         Coordinate::new($lat, $lon).unwrap()
+//     };
+// }
 
 #[actix_web::main]
 async fn main() {
-    env_logger::init();
+    todo!()
+    // env_logger::init();
 
-    let server = Server::new().await;
+    // let server = Server::new().await;
 
-    let route_id1 = server
-        .create(&String::from("sample1").into())
-        .await
-        .unwrap()
-        .id;
+    // let route_id1 = server
+    //     .create(&String::from("sample1").into())
+    //     .await
+    //     .unwrap()
+    //     .id;
 
-    let route_id2 = server
-        .create(&String::from("sample2: 皇居ラン").into())
-        .await
-        .unwrap()
-        .id;
+    // let route_id2 = server
+    //     .create(&String::from("sample2: 皇居ラン").into())
+    //     .await
+    //     .unwrap()
+    //     .id;
 
-    server
-        .add_point(
-            &route_id2,
-            0,
-            &(DrawingMode::FollowRoad, coord!(35.68136, 139.75875)).into(),
-        )
-        .await
-        .unwrap();
-    server
-        .add_point(
-            &route_id2,
-            1,
-            &(DrawingMode::FollowRoad, coord!(35.69053, 139.75681)).into(),
-        )
-        .await
-        .unwrap();
-    server
-        .add_point(
-            &route_id2,
-            2,
-            &(DrawingMode::FollowRoad, coord!(35.69510, 139.75139)).into(),
-        )
-        .await
-        .unwrap();
-    server
-        .add_point(
-            &route_id2,
-            3,
-            &(DrawingMode::FollowRoad, coord!(35.68942, 139.74547)).into(),
-        )
-        .await
-        .unwrap();
-    server
-        .add_point(
-            &route_id2,
-            4,
-            &(DrawingMode::FollowRoad, coord!(35.68418, 139.74424)).into(),
-        )
-        .await
-        .unwrap();
-    server
-        .add_point(
-            &route_id2,
-            5,
-            &(DrawingMode::FollowRoad, coord!(35.68136, 139.75875)).into(),
-        )
-        .await
-        .unwrap();
+    // server
+    //     .add_point(
+    //         &route_id2,
+    //         0,
+    //         &(DrawingMode::FollowRoad, coord!(35.68136, 139.75875)).into(),
+    //     )
+    //     .await
+    //     .unwrap();
+    // server
+    //     .add_point(
+    //         &route_id2,
+    //         1,
+    //         &(DrawingMode::FollowRoad, coord!(35.69053, 139.75681)).into(),
+    //     )
+    //     .await
+    //     .unwrap();
+    // server
+    //     .add_point(
+    //         &route_id2,
+    //         2,
+    //         &(DrawingMode::FollowRoad, coord!(35.69510, 139.75139)).into(),
+    //     )
+    //     .await
+    //     .unwrap();
+    // server
+    //     .add_point(
+    //         &route_id2,
+    //         3,
+    //         &(DrawingMode::FollowRoad, coord!(35.68942, 139.74547)).into(),
+    //     )
+    //     .await
+    //     .unwrap();
+    // server
+    //     .add_point(
+    //         &route_id2,
+    //         4,
+    //         &(DrawingMode::FollowRoad, coord!(35.68418, 139.74424)).into(),
+    //     )
+    //     .await
+    //     .unwrap();
+    // server
+    //     .add_point(
+    //         &route_id2,
+    //         5,
+    //         &(DrawingMode::FollowRoad, coord!(35.68136, 139.75875)).into(),
+    //     )
+    //     .await
+    //     .unwrap();
 
-    log::info!("Route {} added!", route_id1);
-    log::info!("Route {} added!", route_id2);
+    // log::info!("Route {} added!", route_id1);
+    // log::info!("Route {} added!", route_id2);
 }

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -1,8 +1,10 @@
-use route_bucket_domain::external::{CallElevationApi, CallRouteInterpolationApi, CallUserAuthApi};
+use route_bucket_domain::external::{
+    CallElevationApi, CallReservedUserIdCheckerApi, CallRouteInterpolationApi, CallUserAuthApi,
+};
 use route_bucket_domain::repository::{CallRouteRepository, CallUserRepository};
 use route_bucket_infrastructure::{
-    init_repositories, FirebaseAuthApi, OsrmApi, RouteRepositoryMySql, SrtmReader,
-    UserRepositoryMySql,
+    init_repositories, FirebaseAuthApi, OsrmApi, ReservedUidsReader, RouteRepositoryMySql,
+    SrtmReader, UserRepositoryMySql,
 };
 
 pub struct Server {
@@ -11,6 +13,7 @@ pub struct Server {
     srtm_reader: SrtmReader,
     osrm_api: OsrmApi,
     firebase_auth_api: FirebaseAuthApi,
+    reserved_uids_reader: ReservedUidsReader,
 }
 
 impl Server {
@@ -22,6 +25,7 @@ impl Server {
             srtm_reader: SrtmReader::new().unwrap(),
             osrm_api: OsrmApi::new(),
             firebase_auth_api: FirebaseAuthApi::new().await.unwrap(),
+            reserved_uids_reader: ReservedUidsReader::new().unwrap(),
         }
     }
 }
@@ -64,5 +68,13 @@ impl CallUserAuthApi for Server {
 
     fn user_auth_api(&self) -> &Self::UserAuthApi {
         &self.firebase_auth_api
+    }
+}
+
+impl CallReservedUserIdCheckerApi for Server {
+    type ReservedUserIdCheckerApi = ReservedUidsReader;
+
+    fn reserved_user_id_checker_api(&self) -> &Self::ReservedUserIdCheckerApi {
+        &self.reserved_uids_reader
     }
 }

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -141,14 +141,14 @@ where
                 let owner_id = self.user_auth_api().authenticate(user_access_token).await?;
                 let route_info = RouteInfo::new(RouteId::new(), &req.name, owner_id, 0);
 
-        self.route_repository()
-            .insert_info(&route_info, &conn)
-            .await?;
+                self.route_repository()
+                    .insert_info(&route_info, &conn)
+                    .await?;
 
-        Ok(RouteCreateResponse {
-            id: route_info.id().clone(),
-        })
-    }
+                Ok(RouteCreateResponse {
+                    id: route_info.id().clone(),
+                })
+            }
             .boxed()
         })
         .await
@@ -387,7 +387,7 @@ where
                     .authorize(info.owner_id(), user_access_token)
                     .await?;
 
-        self.route_repository().delete(route_id, &conn).await
+                self.route_repository().delete(route_id, &conn).await
             }
             .boxed()
         })
@@ -399,13 +399,17 @@ where
 mod tests {
     use crate::{expect_at_repository, expect_once};
     use route_bucket_domain::{
-        external::{MockElevationApi, MockRouteInterpolationApi},
+        external::{MockElevationApi, MockRouteInterpolationApi, MockUserAuthApi},
         model::{
-            fixtures::route::{
-                CoordinateFixtures, OperationFixtures, RouteFixtures, RouteGpxFixtures,
-                RouteInfoFixtures, RouteSearchQueryFixtures, SegmentFixtures,
+            fixtures::{
+                route::{
+                    CoordinateFixtures, OperationFixtures, RouteFixtures, RouteGpxFixtures,
+                    RouteInfoFixtures, RouteSearchQueryFixtures, SegmentFixtures,
+                },
+                user::UserIdFixtures,
             },
             route::{Coordinate, DrawingMode, RouteGpx, Segment},
+            user::UserId,
         },
         repository::{MockConnection, MockRouteRepository},
     };
@@ -452,6 +456,10 @@ mod tests {
 
     fn yokohama_to_tokyo_before_interpolation() -> Route {
         Route::yokohama_to_tokyo()
+    }
+
+    fn doncic_token() -> String {
+        String::from("token.for.doncic")
     }
 
     #[rstest]
@@ -531,10 +539,11 @@ mod tests {
         };
 
         let mut usecase = TestRouteUseCase::new();
+        usecase.expect_authenticate_at_auth_api(doncic_token(), UserId::doncic());
         usecase.expect_insert_info_at_route_repository(RouteInfo::route0(0));
         // NOTE: unable to check resp since RouteId is auto-generated
         // assert_eq!(usecase.create(&req).await, Ok(expected_resp));
-        assert!(matches!(usecase.create(&req).await, Ok(_)));
+        assert!(matches!(usecase.create(&doncic_token(), &req).await, Ok(_)));
     }
 
     #[rstest]
@@ -545,11 +554,12 @@ mod tests {
         };
 
         let mut usecase = TestRouteUseCase::new();
+        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_info_at_route_repository(route_id(), RouteInfo::route0(0));
         usecase.expect_update_info_at_route_repository(RouteInfo::route1(0));
 
         assert_eq!(
-            usecase.rename(&route_id(), &req).await,
+            usecase.rename(&route_id(), &doncic_token(), &req).await,
             Ok(RouteInfo::route1(0))
         );
     }
@@ -563,6 +573,7 @@ mod tests {
         };
 
         let mut usecase = TestRouteUseCase::new();
+        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_at_route_repository(
             route_id(),
             Route::yokohama_to_chiba_filled(false, false),
@@ -585,7 +596,9 @@ mod tests {
         ));
 
         assert_eq!(
-            usecase.add_point(&route_id(), 1, &req).await,
+            usecase
+                .add_point(&route_id(), &doncic_token(), 1, &req)
+                .await,
             Route::yokohama_to_chiba_via_tokyo_filled(true, true).try_into()
         );
     }
@@ -596,7 +609,9 @@ mod tests {
         let req = RemovePointRequest {
             mode: DrawingMode::FollowRoad,
         };
+
         let mut usecase = TestRouteUseCase::new();
+        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_at_route_repository(
             route_id(),
             Route::yokohama_to_chiba_via_tokyo_filled(false, false),
@@ -612,7 +627,9 @@ mod tests {
         usecase.expect_update_at_route_repository(Route::yokohama_to_chiba_filled(true, true));
 
         assert_eq!(
-            usecase.remove_point(&route_id(), 1, &req).await,
+            usecase
+                .remove_point(&route_id(), &doncic_token(), 1, &req)
+                .await,
             Route::yokohama_to_chiba_filled(true, true).try_into()
         );
     }
@@ -626,6 +643,7 @@ mod tests {
         };
 
         let mut usecase = TestRouteUseCase::new();
+        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_at_route_repository(
             route_id(),
             Route::yokohama_to_chiba_filled(false, false),
@@ -646,7 +664,9 @@ mod tests {
         usecase.expect_update_at_route_repository(Route::yokohama_to_tokyo_filled(true, true));
 
         assert_eq!(
-            usecase.move_point(&route_id(), 1, &req).await,
+            usecase
+                .move_point(&route_id(), &doncic_token(), 1, &req)
+                .await,
             Route::yokohama_to_tokyo_filled(true, true).try_into()
         );
     }
@@ -655,11 +675,12 @@ mod tests {
     #[tokio::test]
     async fn can_clear_route() {
         let mut usecase = TestRouteUseCase::new();
+        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_info_at_route_repository(route_id(), RouteInfo::route0(3));
         usecase.expect_update_at_route_repository(Route::empty());
 
         assert_eq!(
-            usecase.clear_route(&route_id()).await,
+            usecase.clear_route(&route_id(), &doncic_token()).await,
             Route::empty().try_into()
         );
     }
@@ -668,6 +689,7 @@ mod tests {
     #[tokio::test]
     async fn can_redo_operation() {
         let mut usecase = TestRouteUseCase::new();
+        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_at_route_repository(
             route_id(),
             Route::yokohama_to_chiba_filled(false, false),
@@ -685,7 +707,7 @@ mod tests {
         ));
 
         assert_eq!(
-            usecase.redo_operation(&route_id()).await,
+            usecase.redo_operation(&route_id(), &doncic_token()).await,
             Route::yokohama_to_chiba_via_tokyo_filled(true, true).try_into()
         );
     }
@@ -694,6 +716,7 @@ mod tests {
     #[tokio::test]
     async fn can_undo_operation() {
         let mut usecase = TestRouteUseCase::new();
+        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_at_route_repository(
             route_id(),
             Route::yokohama_to_chiba_via_tokyo_filled(false, false),
@@ -709,7 +732,7 @@ mod tests {
         usecase.expect_update_at_route_repository(Route::yokohama_to_chiba_filled(true, true));
 
         assert_eq!(
-            usecase.undo_operation(&route_id()).await,
+            usecase.undo_operation(&route_id(), &doncic_token()).await,
             Route::yokohama_to_chiba_filled(true, true).try_into()
         );
     }
@@ -718,14 +741,17 @@ mod tests {
     #[tokio::test]
     async fn can_delete() {
         let mut usecase = TestRouteUseCase::new();
+        usecase.expect_find_info_at_route_repository(route_id(), RouteInfo::route0(0));
+        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_delete_at_route_repository(route_id());
-        assert_eq!(usecase.delete(&route_id()).await, Ok(()));
+        assert_eq!(usecase.delete(&route_id(), &doncic_token()).await, Ok(()));
     }
 
     struct TestRouteUseCase {
         repository: MockRouteRepository,
         interpolation_api: MockRouteInterpolationApi,
         elevation_api: MockElevationApi,
+        auth_api: MockUserAuthApi,
     }
 
     // setup methods for mocking
@@ -735,6 +761,7 @@ mod tests {
                 repository: MockRouteRepository::new(),
                 interpolation_api: MockRouteInterpolationApi::new(),
                 elevation_api: MockElevationApi::new(),
+                auth_api: MockUserAuthApi::new(),
             };
             expect_at_repository!(usecase, get_connection, MockConnection {});
 
@@ -815,6 +842,14 @@ mod tests {
                 before_route => after_route
             );
         }
+
+        fn expect_authenticate_at_auth_api(&mut self, param_token: String, return_id: UserId) {
+            expect_once!(self.auth_api, authenticate, param_token, return_id);
+        }
+
+        fn expect_authorize_at_auth_api(&mut self, param_id: UserId, param_token: String) {
+            expect_once!(self.auth_api, authorize, param_id, param_token, ());
+        }
     }
 
     // impls to enable trait RouteUseCase
@@ -839,6 +874,14 @@ mod tests {
 
         fn elevation_api(&self) -> &Self::ElevationApi {
             &self.elevation_api
+        }
+    }
+
+    impl CallUserAuthApi for TestRouteUseCase {
+        type UserAuthApi = MockUserAuthApi;
+
+        fn user_auth_api(&self) -> &Self::UserAuthApi {
+            &self.auth_api
         }
     }
 }

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -142,7 +142,7 @@ where
                 let route_info = RouteInfo::new(RouteId::new(), &req.name, owner_id, 0);
 
                 self.route_repository()
-                    .insert_info(&route_info, &conn)
+                    .insert_info(&route_info, conn)
                     .await?;
 
                 Ok(RouteCreateResponse {
@@ -387,7 +387,7 @@ where
                     .authorize(info.owner_id(), user_access_token)
                     .await?;
 
-                self.route_repository().delete(route_id, &conn).await
+                self.route_repository().delete(route_id, conn).await
             }
             .boxed()
         })

--- a/api/usecase/src/route/responses.rs
+++ b/api/usecase/src/route/responses.rs
@@ -24,6 +24,7 @@ pub struct RouteGetResponse {
 pub struct RouteSearchResponse {
     #[serde(rename = "routes")]
     pub route_infos: Vec<RouteInfo>,
+    pub result_num: usize,
 }
 
 pub type RouteGetGpxResponse = RouteGpx;

--- a/api/usecase/src/user.rs
+++ b/api/usecase/src/user.rs
@@ -71,7 +71,7 @@ where
 
         conn.transaction(|conn| {
             async move {
-                self.user_auth_api().verify_token(user_id, token).await?;
+                self.user_auth_api().authorize(user_id, token).await?;
 
                 let mut user = self.user_repository().find(user_id, conn).await?;
 
@@ -95,7 +95,7 @@ where
         let conn = self.user_repository().get_connection().await?;
         conn.transaction(|conn| {
             async move {
-                self.user_auth_api().verify_token(user_id, token).await?;
+                self.user_auth_api().authorize(user_id, token).await?;
 
                 self.user_repository().delete(user_id, conn).await?;
                 self.user_auth_api().delete_account(user_id).await

--- a/api/usecase/src/user.rs
+++ b/api/usecase/src/user.rs
@@ -156,7 +156,7 @@ mod tests {
     use crate::{expect_at_repository, expect_once};
     use chrono::NaiveDate;
     use route_bucket_domain::{
-        external::MockUserAuthApi,
+        external::{MockReservedUserIdCheckerApi, MockUserAuthApi},
         model::{
             fixtures::user::{UserFixtures, UserIdFixtures},
             types::{Email, Url},
@@ -296,6 +296,7 @@ mod tests {
         });
 
         let mut usecase = TestUserUseCase::new();
+        usecase.expect_check_if_reserved_at_uid_check_api(UserId::doncic(), false);
         usecase.expect_find_at_user_repository(UserId::doncic(), User::doncic());
         usecase.expect_check_if_email_exists_at_auth_api(unknown_email(), false);
 
@@ -305,6 +306,7 @@ mod tests {
     struct TestUserUseCase {
         repository: MockUserRepository,
         auth_api: MockUserAuthApi,
+        uid_check_api: MockReservedUserIdCheckerApi,
     }
 
     // setup methods for mocking
@@ -313,6 +315,7 @@ mod tests {
             let mut usecase = TestUserUseCase {
                 repository: MockUserRepository::new(),
                 auth_api: MockUserAuthApi::new(),
+                uid_check_api: MockReservedUserIdCheckerApi::new(),
             };
             expect_at_repository!(usecase, get_connection, MockConnection {});
 
@@ -371,6 +374,14 @@ mod tests {
                 result_bool
             );
         }
+
+        fn expect_check_if_reserved_at_uid_check_api(
+            &mut self,
+            param_id: UserId,
+            result_bool: bool,
+        ) {
+            expect_once!(self.uid_check_api, check_if_reserved, param_id, result_bool);
+        }
     }
 
     // impls to enable trait RouteUseCase
@@ -387,6 +398,14 @@ mod tests {
 
         fn user_auth_api(&self) -> &Self::UserAuthApi {
             &self.auth_api
+        }
+    }
+
+    impl CallReservedUserIdCheckerApi for TestUserUseCase {
+        type ReservedUserIdCheckerApi = MockReservedUserIdCheckerApi;
+
+        fn reserved_user_id_checker_api(&self) -> &Self::ReservedUserIdCheckerApi {
+            &self.uid_check_api
         }
     }
 }

--- a/api/usecase/src/user.rs
+++ b/api/usecase/src/user.rs
@@ -135,7 +135,6 @@ mod tests {
             birthdate: NaiveDate::from_str("1999-02-28").ok(),
             icon_url: Url::try_from("https://on.nba.com/30qMUEI".to_string()).ok(),
             password: "LukaMagic#77".to_string(),
-            password_confirmation: "LukaMagic#77".to_string(),
         }
     }
 
@@ -149,7 +148,6 @@ mod tests {
             birthdate: None,
             icon_url: None,
             password: "LukaMagic#77".to_string(),
-            password_confirmation: "LukaMagic#77".to_string(),
         }
     }
 

--- a/api/usecase/src/user.rs
+++ b/api/usecase/src/user.rs
@@ -202,7 +202,7 @@ mod tests {
     #[tokio::test]
     async fn can_update() {
         let mut usecase = TestUserUseCase::new();
-        usecase.expect_verify_token_at_auth_api(UserId::porzingis(), porzingis_token());
+        usecase.expect_authorize_at_auth_api(UserId::porzingis(), porzingis_token());
         usecase.expect_find_at_user_repository(UserId::porzingis(), User::porzingis());
         usecase.expect_update_at_user_repository(User::porzingis_pretending_like_doncic());
 
@@ -222,7 +222,7 @@ mod tests {
     #[tokio::test]
     async fn can_delete() {
         let mut usecase = TestUserUseCase::new();
-        usecase.expect_verify_token_at_auth_api(UserId::doncic(), doncic_token());
+        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_delete_account_at_auth_api(UserId::doncic());
         usecase.expect_delete_at_user_repository(UserId::doncic());
 
@@ -285,8 +285,8 @@ mod tests {
             expect_once!(self.auth_api, delete_account, param_id, ());
         }
 
-        fn expect_verify_token_at_auth_api(&mut self, param_id: UserId, param_token: String) {
-            expect_once!(self.auth_api, verify_token, param_id, param_token, ());
+        fn expect_authorize_at_auth_api(&mut self, param_id: UserId, param_token: String) {
+            expect_once!(self.auth_api, authorize, param_id, param_token, ());
         }
     }
 

--- a/api/usecase/src/user/requests.rs
+++ b/api/usecase/src/user/requests.rs
@@ -27,8 +27,6 @@ pub struct UserCreateRequest {
     pub(super) icon_url: Option<Url>,
     #[validate(length(min = 6))]
     pub(super) password: String,
-    #[validate(must_match = "password")]
-    pub(super) password_confirmation: String,
 }
 
 impl UserCreateRequest {

--- a/api/usecase/src/user/requests.rs
+++ b/api/usecase/src/user/requests.rs
@@ -11,31 +11,29 @@ use route_bucket_domain::model::{
     user::{Gender, User, UserId},
 };
 
-#[derive(From, Deserialize, Validate)]
+#[derive(From, Deserialize)]
 pub struct UserCreateRequest {
-    #[validate]
     pub(super) id: UserId,
-    #[validate(length(min = 1, max = 50))]
     pub(super) name: String,
-    #[validate]
     pub(super) email: Email,
     #[serde(default)]
     pub(super) gender: Gender,
-    #[validate(custom = "UserCreateRequest::validate_birthdate")]
     pub(super) birthdate: Option<NaiveDate>,
-    #[validate]
     pub(super) icon_url: Option<Url>,
-    #[validate(length(min = 6))]
     pub(super) password: String,
 }
 
-impl UserCreateRequest {
-    fn validate_birthdate(birthdate: &NaiveDate) -> Result<(), validator::ValidationError> {
-        if *birthdate <= Utc::today().naive_utc() {
-            Ok(())
-        } else {
-            Err(validator::ValidationError::new("FUTURE_BIRTHDATE"))
+impl Validate for UserCreateRequest {
+    fn validate(&self) -> Result<(), validator::ValidationErrors> {
+        UserValidateRequest {
+            id: Some(self.id.clone()),
+            name: Some(self.name.clone()),
+            email: Some(self.email.clone()),
+            birthdate: self.birthdate,
+            icon_url: self.icon_url.clone(),
+            password: Some(self.password.clone()),
         }
+        .validate()
     }
 }
 
@@ -64,8 +62,34 @@ pub struct UserUpdateRequest {
     pub(super) name: Option<String>,
     #[serde(default)]
     pub(super) gender: Option<Gender>,
-    #[validate(custom = "UserCreateRequest::validate_birthdate")]
+    #[validate(custom = "UserValidateRequest::validate_birthdate")]
     pub(super) birthdate: Option<NaiveDate>,
     #[validate]
     pub(super) icon_url: Option<Url>,
+}
+
+#[derive(From, Deserialize, Validate)]
+pub struct UserValidateRequest {
+    #[validate]
+    pub(super) id: Option<UserId>,
+    #[validate(length(min = 1, max = 50))]
+    pub(super) name: Option<String>,
+    #[validate]
+    pub(super) email: Option<Email>,
+    #[validate(custom = "UserValidateRequest::validate_birthdate")]
+    pub(super) birthdate: Option<NaiveDate>,
+    #[validate]
+    pub(super) icon_url: Option<Url>,
+    #[validate(length(min = 6))]
+    pub(super) password: Option<String>,
+}
+
+impl UserValidateRequest {
+    fn validate_birthdate(birthdate: &NaiveDate) -> Result<(), validator::ValidationError> {
+        if *birthdate <= Utc::today().naive_utc() {
+            Ok(())
+        } else {
+            Err(validator::ValidationError::new("FUTURE_BIRTHDATE"))
+        }
+    }
 }

--- a/api/usecase/src/user/responses.rs
+++ b/api/usecase/src/user/responses.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use derive_more::From;
 use route_bucket_domain::model::user::UserId;
 use serde::Serialize;
@@ -7,3 +9,14 @@ use serde::Serialize;
 pub struct UserCreateResponse {
     pub id: UserId,
 }
+
+#[derive(Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub(super) enum ValidationErrorCode {
+    InvalidFormat,
+    AlreadyExists,
+}
+
+#[derive(Debug, Default, Serialize)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct UserValidateResponse(pub(super) HashMap<&'static str, ValidationErrorCode>);

--- a/api/usecase/src/user/responses.rs
+++ b/api/usecase/src/user/responses.rs
@@ -15,6 +15,7 @@ pub struct UserCreateResponse {
 pub(super) enum ValidationErrorCode {
     InvalidFormat,
     AlreadyExists,
+    ReservedWord,
 }
 
 #[derive(Debug, Default, Serialize)]

--- a/api/utils/src/error.rs
+++ b/api/utils/src/error.rs
@@ -10,8 +10,11 @@ pub type ApplicationResult<T> = Result<T, ApplicationError>;
 /// actix-webを用いて直接リクエストに変換できる自作エラークラス
 #[derive(Clone, Debug, Display, Error, PartialEq)]
 pub enum ApplicationError {
-    #[display(fmt = "AuthError: {}", _0)]
-    AuthError(String),
+    #[display(fmt = "AuthenticationError: {}", _0)]
+    AuthenticationError(String),
+
+    #[display(fmt = "AuthorizationError: {}", _0)]
+    AuthorizationError(String),
 
     #[display(fmt = "DataBaseError: {}", _0)]
     DataBaseError(String),
@@ -44,7 +47,8 @@ pub enum ApplicationError {
 impl ResponseError for ApplicationError {
     fn status_code(&self) -> http::StatusCode {
         match *self {
-            ApplicationError::AuthError(..) => http::StatusCode::UNAUTHORIZED,
+            ApplicationError::AuthenticationError(..) => http::StatusCode::UNAUTHORIZED,
+            ApplicationError::AuthorizationError(..) => http::StatusCode::FORBIDDEN,
             ApplicationError::InvalidOperation(..) | ApplicationError::ValidationError(..) => {
                 http::StatusCode::BAD_REQUEST
             }
@@ -65,7 +69,7 @@ impl ResponseError for ApplicationError {
 
 impl From<jsonwebtoken::errors::Error> for ApplicationError {
     fn from(err: jsonwebtoken::errors::Error) -> Self {
-        ApplicationError::AuthError(err.to_string())
+        ApplicationError::AuthenticationError(err.to_string())
     }
 }
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -4,6 +4,9 @@ CREATE TABLE routes
     `name`          VARCHAR(50)      NOT NULL,
     `owner_id`      VARCHAR(40)      NOT NULL,
     `operation_pos` INTEGER UNSIGNED NOT NULL,
+    `created_at`    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`    TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX updated_idx (`updated_at`),
     PRIMARY KEY (`id`)
 );
 


### PR DESCRIPTION
Closes #116 

* /api/resources/reserved_uids.txt`で予約語を定義
* `infrastructure::external::ReservedUidsReader`で、渡したuseridが↑の中に含まれるかどうかを判定
* ↑で含まれる場合は、`ValidationErrorCode::ReservedWord`を返すように