### PR TITLE
icon_urlの長さ制限の緩和

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -37,6 +37,6 @@ CREATE TABLE users
     `name`      VARCHAR(50)      NOT NULL,
     `gender`    VARCHAR(6)       NOT NULL,
     `birthdate` DATE                     ,
-    `icon_url`  VARCHAR(100)             ,
+    `icon_url`  TEXT                     ,
     PRIMARY KEY (`id`)
 );


### PR DESCRIPTION
Closes #120 

dbにおいて、`routes.icon_url`の型を`TEXT`に変えることで、最大65536文字まで入れられるようになった