### PR TITLE
下り獲得標高の追加

### DIFF
--- a/api/domain/src/model/route.rs
+++ b/api/domain/src/model/route.rs
@@ -101,7 +101,7 @@ impl Route {
 
     // methods from SegmentList ( No tests for them! )
 
-    pub fn calc_elevation_gain(&self) -> Elevation {
+    pub fn calc_elevation_gain(&self) -> (Elevation, Elevation) {
         self.seg_list.calc_elevation_gain()
     }
 

--- a/api/domain/src/model/route/types.rs
+++ b/api/domain/src/model/route/types.rs
@@ -80,8 +80,7 @@ impl<const MAX_ABS: u32> TryFrom<f64> for NumericValueObject<OrderedFloat<f64>, 
                 // TODO: stringのconst genericsが追加されたら、
                 // メッセージに具体的なエイリアス名(Latitudeとか)を入れる
                 "Invalid value {} for NumericValueObject<OrderedFloat<f64>, {}>",
-                val,
-                MAX_ABS
+                val, MAX_ABS
             )))
         }
     }
@@ -99,8 +98,7 @@ impl<const MAX_ABS: u32> TryFrom<i32> for NumericValueObject<i32, MAX_ABS> {
                 // TODO: stringのconst genericsが追加されたら、
                 // メッセージに具体的なエイリアス名(Latitudeとか)を入れる
                 "Invalid value {} for NumericValueObject<i32, {}>",
-                val,
-                MAX_ABS
+                val, MAX_ABS
             )))
         }
     }

--- a/api/infrastructure/src/repository/route.rs
+++ b/api/infrastructure/src/repository/route.rs
@@ -186,7 +186,7 @@ impl RouteRepositoryMySql {
         } else {
             let seg_ids = segment_list
                 .iter()
-                .map(|seg| format!("'{}'", seg.id().to_string()))
+                .map(|seg| format!("'{}'", seg.id()))
                 .collect_vec()
                 .join(",");
             format!("id NOT IN ({})", seg_ids)


### PR DESCRIPTION
Closes #101 

`SegmentList::calc_elevation_gain`の戻り値を`(Elevation, Elevation)`とし、二個目のElevationで下り獲得標高を返すようにした。

ついでに、最新版のrustで出るようになったlintのエラーを修正した