### PR TITLE
`Operation`を`SegmentList`のサブモデルに

### DIFF
--- a/api/domain/src/model.rs
+++ b/api/domain/src/model.rs
@@ -7,11 +7,12 @@ pub mod fixtures {
     pub mod route {
         pub use crate::model::route::bounding_box::tests::BoundingBoxFixture;
         pub use crate::model::route::coordinate::tests::CoordinateFixtures;
-        pub use crate::model::route::operation::tests::OperationFixtures;
         pub use crate::model::route::route_gpx::tests::RouteGpxFixtures;
         pub use crate::model::route::route_info::tests::RouteInfoFixtures;
         pub use crate::model::route::search_query::tests::RouteSearchQueryFixtures;
-        pub use crate::model::route::segment_list::tests::{SegmentFixtures, SegmentListFixture};
+        pub use crate::model::route::segment_list::tests::{
+            OperationFixtures, SegmentFixtures, SegmentListFixture,
+        };
         pub use crate::model::route::tests::RouteFixtures;
     }
 

--- a/api/domain/src/model/route.rs
+++ b/api/domain/src/model/route.rs
@@ -7,18 +7,18 @@ use route_bucket_utils::{ApplicationError, ApplicationResult};
 
 pub use self::bounding_box::BoundingBox;
 pub use self::coordinate::Coordinate;
-pub use self::operation::{Operation, OperationId, OperationType, SegmentTemplate};
 pub use self::route_gpx::RouteGpx;
 pub use self::route_info::RouteInfo;
 pub use self::search_query::RouteSearchQuery;
-pub use self::segment_list::{DrawingMode, Segment, SegmentList};
+pub use self::segment_list::{
+    DrawingMode, Operation, OperationId, OperationType, Segment, SegmentList, SegmentTemplate,
+};
 pub use self::types::{Distance, Elevation, Latitude, Longitude, Polyline};
 
 use super::types::NanoId;
 
 pub(crate) mod bounding_box;
 pub(crate) mod coordinate;
-pub(crate) mod operation;
 pub(crate) mod route_gpx;
 pub(crate) mod route_info;
 pub(crate) mod search_query;
@@ -131,7 +131,7 @@ pub(crate) mod tests {
     use rstest::{fixture, rstest};
 
     use crate::model::route::{
-        operation::tests::OperationFixtures, route_info::tests::RouteInfoFixtures,
+        route_info::tests::RouteInfoFixtures, segment_list::tests::OperationFixtures,
         segment_list::tests::SegmentListFixture,
     };
 

--- a/api/domain/src/model/route.rs
+++ b/api/domain/src/model/route.rs
@@ -105,7 +105,7 @@ impl Route {
         self.seg_list.calc_elevation_gain()
     }
 
-    pub fn attach_distance_from_start(&mut self) -> ApplicationResult<()> {
+    pub fn attach_distance_from_start(&mut self) {
         self.seg_list.attach_distance_from_start()
     }
 

--- a/api/domain/src/model/route.rs
+++ b/api/domain/src/model/route.rs
@@ -94,7 +94,7 @@ impl Route {
             self.info.op_num += 1;
         };
 
-        op.apply(&mut self.seg_list)?;
+        self.seg_list.apply_operation(op)?;
 
         Ok(())
     }

--- a/api/domain/src/model/route/route_gpx.rs
+++ b/api/domain/src/model/route/route_gpx.rs
@@ -160,10 +160,10 @@ impl TryFrom<Route> for RouteGpx {
 pub(crate) mod tests {
     use rstest::{fixture, rstest};
 
-    use crate::model::route::operation::tests::OperationFixtures;
-    use crate::model::route::operation::Operation;
     use crate::model::route::route_info::tests::RouteInfoFixtures;
+    use crate::model::route::segment_list::tests::OperationFixtures;
     use crate::model::route::segment_list::tests::SegmentListFixture;
+    use crate::model::route::segment_list::Operation;
 
     use super::*;
 

--- a/api/domain/src/model/route/segment_list.rs
+++ b/api/domain/src/model/route/segment_list.rs
@@ -13,8 +13,10 @@ use super::bounding_box::BoundingBox;
 use super::coordinate::Coordinate;
 use super::types::{Distance, Elevation};
 
+pub use self::operation::{Operation, OperationId, OperationType, SegmentTemplate};
 pub use self::segment::{DrawingMode, Segment};
 
+mod operation;
 mod segment;
 
 #[derive(Clone, Debug, Serialize, Getters)]
@@ -185,6 +187,7 @@ pub(crate) mod tests {
     use crate::model::route::bounding_box::tests::BoundingBoxFixture;
     #[cfg(test)]
     use crate::model::route::coordinate::tests::CoordinateFixtures;
+    pub use crate::model::route::segment_list::operation::tests::OperationFixtures;
     pub use crate::model::route::segment_list::segment::tests::SegmentFixtures;
 
     use super::*;

--- a/api/domain/src/model/route/segment_list/operation.rs
+++ b/api/domain/src/model/route/segment_list/operation.rs
@@ -8,8 +8,8 @@ use route_bucket_utils::{ApplicationError, ApplicationResult};
 
 use crate::model::types::NanoId;
 
-use super::coordinate::Coordinate;
-use super::segment_list::{DrawingMode, Segment, SegmentList};
+use super::super::coordinate::Coordinate;
+use super::{DrawingMode, Segment, SegmentList};
 
 #[cfg(any(test, feature = "fixtures"))]
 use derivative::Derivative;
@@ -69,12 +69,12 @@ impl From<SegmentTemplate> for Segment {
 #[cfg_attr(any(test, feature = "fixtures"), derivative(PartialEq))]
 pub struct Operation {
     #[cfg_attr(any(test, feature = "fixtures"), derivative(PartialEq = "ignore"))]
-    id: OperationId,
+    pub(super) id: OperationId,
     // NOTE: typeはロジック的には不要だが、デバッグ用に残している
-    op_type: OperationType,
-    pos: usize,
-    org_seg_templates: Vec<SegmentTemplate>,
-    new_seg_templates: Vec<SegmentTemplate>,
+    pub(super) op_type: OperationType,
+    pub(super) pos: usize,
+    pub(super) org_seg_templates: Vec<SegmentTemplate>,
+    pub(super) new_seg_templates: Vec<SegmentTemplate>,
 }
 
 impl Operation {

--- a/api/domain/src/model/route/segment_list/operation.rs
+++ b/api/domain/src/model/route/segment_list/operation.rs
@@ -210,17 +210,6 @@ impl Operation {
         ))
     }
 
-    pub fn apply(&self, seg_list: &mut SegmentList) -> ApplicationResult<()> {
-        seg_list.splice(
-            self.pos..self.pos + self.org_seg_templates.len(),
-            self.new_seg_templates
-                .iter()
-                .map(Clone::clone)
-                .map(Segment::from),
-        );
-        Ok(())
-    }
-
     pub fn reverse(&mut self) {
         self.op_type = self.op_type.reverse();
         swap(&mut self.org_seg_templates, &mut self.new_seg_templates);
@@ -325,31 +314,6 @@ pub(crate) mod tests {
     fn can_reverse_to_inverse_operation(#[case] mut op: Operation, #[case] op_inv: Operation) {
         op.reverse();
         assert_eq!(op, op_inv)
-    }
-
-    #[rstest]
-    #[case::add(
-        add_tokyo(),
-        SegmentList::yokohama_to_chiba(false, false, true),
-        SegmentList::yokohama_to_chiba_via_tokyo(false, false, true)
-    )]
-    #[case::remove(
-        remove_tokyo(),
-        SegmentList::yokohama_to_chiba_via_tokyo(false, false, true),
-        SegmentList::yokohama_to_chiba(false, false, true)
-    )]
-    #[case::move_(
-        move_chiba_to_tokyo(),
-        SegmentList::yokohama_to_chiba(false, false, true),
-        SegmentList::yokohama_to_tokyo(false, false, true)
-    )]
-    fn can_apply_to_seg_list(
-        #[case] op: Operation,
-        #[case] mut seg_list: SegmentList,
-        #[case] expected: SegmentList,
-    ) {
-        op.apply(&mut seg_list).unwrap();
-        assert_eq!(seg_list, expected)
     }
 
     macro_rules! concat_op_list {

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -95,7 +95,7 @@ where
         let conn = self.route_repository().get_connection().await?;
 
         let mut route = self.route_repository().find(route_id, &conn).await?;
-        route.attach_distance_from_start()?;
+        route.attach_distance_from_start();
         self.elevation_api().attach_elevations(&mut route)?;
 
         route.try_into()
@@ -132,7 +132,7 @@ where
         let conn = self.route_repository().get_connection().await?;
 
         let mut route = self.route_repository().find(route_id, &conn).await?;
-        route.attach_distance_from_start()?;
+        route.attach_distance_from_start();
         self.elevation_api().attach_elevations(&mut route)?;
 
         route.try_into()
@@ -217,7 +217,7 @@ where
                     .interpolate_empty_segments(&mut route)
                     .await?;
                 self.elevation_api().attach_elevations(&mut route)?;
-                route.attach_distance_from_start()?;
+                route.attach_distance_from_start();
 
                 self.route_repository().update(&route, conn).await?;
 
@@ -250,7 +250,7 @@ where
                     .interpolate_empty_segments(&mut route)
                     .await?;
                 self.elevation_api().attach_elevations(&mut route)?;
-                route.attach_distance_from_start()?;
+                route.attach_distance_from_start();
 
                 self.route_repository().update(&route, conn).await?;
 
@@ -290,7 +290,7 @@ where
                     .interpolate_empty_segments(&mut route)
                     .await?;
                 self.elevation_api().attach_elevations(&mut route)?;
-                route.attach_distance_from_start()?;
+                route.attach_distance_from_start();
 
                 self.route_repository().update(&route, conn).await?;
 
@@ -345,7 +345,7 @@ where
                     .interpolate_empty_segments(&mut route)
                     .await?;
                 self.elevation_api().attach_elevations(&mut route)?;
-                route.attach_distance_from_start()?;
+                route.attach_distance_from_start();
 
                 self.route_repository().update(&route, conn).await?;
 
@@ -375,7 +375,7 @@ where
                     .interpolate_empty_segments(&mut route)
                     .await?;
                 self.elevation_api().attach_elevations(&mut route)?;
-                route.attach_distance_from_start()?;
+                route.attach_distance_from_start();
 
                 self.route_repository().update(&route, conn).await?;
 


### PR DESCRIPTION
* `operation.rs`を`models/route/segment_list/`以下に移動した
  * `Operation`は`SemgmentList`に対する操作を表し、それ以外の文脈で登場しないので
* これに加え、`Operation::apply`を`SegmentList::apply_operation`として書き直した
  * 変更されるのは`SegmentList`であり、このメンバ関数とした方が自然に思えるので
