### PR TITLE
`RouteInfo`に詳細表示用フィールドを追加

### DIFF
--- a/api/domain/Cargo.toml
+++ b/api/domain/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 async-trait = "0.1.50"
 chrono = "0.4.19"
-derivative = { version = "2.2.0", optional = true }
+derivative = "2.2.0"
 derive_more = "0.99.16"
 futures = "0.3.16"
 geo = "0.17.1"
@@ -33,10 +33,9 @@ strum = { version = "0.22.0", features = ["derive"] }
 validator = { version = "0.14.0", features = ["derive"] }
 
 [dev-dependencies]
-derivative = "2.2.0"
 rstest = "0.11.0"
 
 [features]
-fixtures = ["derivative", "rstest"]
+fixtures = ["rstest"]
 mocking = ["mockall"]
 testing = ["fixtures", "mocking"]

--- a/api/domain/src/model/route.rs
+++ b/api/domain/src/model/route.rs
@@ -110,16 +110,8 @@ impl Route {
         Ok(())
     }
 
-    pub fn gather_waypoints(&self) -> Vec<Coordinate> {
-        self.seg_list.gather_waypoints()
-    }
-
     pub fn iter_seg_mut(&mut self) -> IterMut<Segment> {
         self.seg_list.iter_mut()
-    }
-
-    pub fn into_segments_in_between(self) -> Vec<Segment> {
-        self.seg_list.into_segments_in_between()
     }
 }
 

--- a/api/domain/src/model/route.rs
+++ b/api/domain/src/model/route.rs
@@ -99,18 +99,16 @@ impl Route {
         Ok(())
     }
 
-    // methods from SegmentList ( No tests for them! )
-
-    pub fn calc_elevation_gain(&self) -> (Elevation, Elevation) {
-        self.seg_list.calc_elevation_gain()
+    pub fn reflect_update_on_seg_list_to_info(&mut self) -> ApplicationResult<()> {
+        let (asc_gain, desc_gain) = self.seg_list.calc_elevation_gain();
+        self.info.ascent_elevation_gain = asc_gain;
+        self.info.descent_elevation_gain = desc_gain;
+        self.info.total_distance = self.seg_list.get_total_distance()?;
+        Ok(())
     }
 
     pub fn attach_distance_from_start(&mut self) {
         self.seg_list.attach_distance_from_start()
-    }
-
-    pub fn get_total_distance(&self) -> ApplicationResult<Distance> {
-        self.seg_list.get_total_distance()
     }
 
     pub fn gather_waypoints(&self) -> Vec<Coordinate> {

--- a/api/domain/src/model/route.rs
+++ b/api/domain/src/model/route.rs
@@ -99,16 +99,15 @@ impl Route {
         Ok(())
     }
 
-    pub fn reflect_update_on_seg_list_to_info(&mut self) -> ApplicationResult<()> {
+    pub fn calc_route_features_from_seg_list(&mut self) -> ApplicationResult<()> {
+        self.seg_list.attach_distance_from_start();
+
         let (asc_gain, desc_gain) = self.seg_list.calc_elevation_gain();
         self.info.ascent_elevation_gain = asc_gain;
         self.info.descent_elevation_gain = desc_gain;
         self.info.total_distance = self.seg_list.get_total_distance()?;
-        Ok(())
-    }
 
-    pub fn attach_distance_from_start(&mut self) {
-        self.seg_list.attach_distance_from_start()
+        Ok(())
     }
 
     pub fn gather_waypoints(&self) -> Vec<Coordinate> {
@@ -143,6 +142,19 @@ pub(crate) mod tests {
     #[fixture]
     fn full_route() -> Route {
         Route::yokohama_to_chiba_via_tokyo()
+    }
+
+    #[fixture]
+    fn full_route_filled() -> Route {
+        Route {
+            info: RouteInfo::yokohama_to_chiba_via_tokyo(),
+            ..Route::yokohama_to_chiba_via_tokyo_filled(true, true)
+        }
+    }
+
+    #[fixture]
+    fn full_route_filled_but_yet_to_calc_features() -> Route {
+        Route::yokohama_to_chiba_via_tokyo_filled(true, false)
     }
 
     #[fixture]
@@ -236,10 +248,19 @@ pub(crate) mod tests {
         ))
     }
 
-    macro_rules! init_route {
+    #[rstest]
+    fn can_calc_route_features_from_seg_list(
+        #[from(full_route_filled_but_yet_to_calc_features)] mut route: Route,
+        #[from(full_route_filled)] expected: Route,
+    ) {
+        route.calc_route_features_from_seg_list().unwrap();
+        assert_eq!(route, expected)
+    }
+
+    macro_rules! init_empty_route {
         ($op_num:expr, $op_list_name:ident, $seg_list_name:ident) => {
             Route {
-                info: RouteInfo::route0($op_num),
+                info: RouteInfo::empty_route0($op_num),
                 op_list: Operation::$op_list_name(),
                 seg_list: SegmentList::$seg_list_name(false, false, true),
             }
@@ -249,57 +270,69 @@ pub(crate) mod tests {
     pub trait RouteFixtures {
         fn empty() -> Route {
             Route {
-                info: RouteInfo::route0(0),
+                info: RouteInfo::empty_route0(0),
                 op_list: Vec::new(),
                 seg_list: SegmentList::empty(),
             }
         }
 
         fn yokohama() -> Route {
-            init_route!(1, after_add_yokohama_op_list, yokohama)
+            init_empty_route!(1, after_add_yokohama_op_list, yokohama)
         }
 
         fn yokohama_to_chiba() -> Route {
-            init_route!(2, after_add_chiba_op_list, yokohama_to_chiba)
+            init_empty_route!(2, after_add_chiba_op_list, yokohama_to_chiba)
         }
 
         fn yokohama_to_chiba_via_tokyo() -> Route {
-            init_route!(3, after_add_tokyo_op_list, yokohama_to_chiba_via_tokyo)
+            init_empty_route!(3, after_add_tokyo_op_list, yokohama_to_chiba_via_tokyo)
         }
 
         fn yokohama_to_chiba_after_remove() -> Route {
-            init_route!(4, after_remove_tokyo_op_list, yokohama_to_chiba)
+            init_empty_route!(4, after_remove_tokyo_op_list, yokohama_to_chiba)
         }
 
         fn yokohama_to_chiba_after_undo() -> Route {
-            init_route!(2, after_add_tokyo_op_list, yokohama_to_chiba)
+            init_empty_route!(2, after_add_tokyo_op_list, yokohama_to_chiba)
         }
 
         fn yokohama_to_tokyo() -> Route {
-            init_route!(3, after_move_chiba_op_list, yokohama_to_tokyo)
+            init_empty_route!(3, after_move_chiba_op_list, yokohama_to_tokyo)
         }
 
-        fn yokohama_to_chiba_filled(set_ele: bool, set_dist: bool) -> Route {
+        fn yokohama_to_chiba_filled(set_ele: bool, set_features: bool) -> Route {
             Route::new(
-                RouteInfo::route0(2),
+                if set_features {
+                    RouteInfo::yokohama_to_chiba()
+                } else {
+                    RouteInfo::empty_route0(2)
+                },
                 Operation::after_add_tokyo_op_list(),
-                SegmentList::yokohama_to_chiba(set_ele, set_dist, false),
+                SegmentList::yokohama_to_chiba(set_ele, set_features, false),
             )
         }
 
-        fn yokohama_to_chiba_via_tokyo_filled(set_ele: bool, set_dist: bool) -> Route {
+        fn yokohama_to_chiba_via_tokyo_filled(set_ele: bool, set_features: bool) -> Route {
             Route::new(
-                RouteInfo::route0(3),
+                if set_features {
+                    RouteInfo::yokohama_to_chiba_via_tokyo()
+                } else {
+                    RouteInfo::empty_route0(3)
+                },
                 Operation::after_add_tokyo_op_list(),
-                SegmentList::yokohama_to_chiba_via_tokyo(set_ele, set_dist, false),
+                SegmentList::yokohama_to_chiba_via_tokyo(set_ele, set_features, false),
             )
         }
 
-        fn yokohama_to_tokyo_filled(set_ele: bool, set_dist: bool) -> Route {
+        fn yokohama_to_tokyo_filled(set_ele: bool, set_features: bool) -> Route {
             Route::new(
-                RouteInfo::route0(3),
+                if set_features {
+                    RouteInfo::yokohama_to_tokyo()
+                } else {
+                    RouteInfo::empty_route0(3)
+                },
                 Operation::after_move_chiba_op_list(),
-                SegmentList::yokohama_to_tokyo(set_ele, set_dist, false),
+                SegmentList::yokohama_to_tokyo(set_ele, set_features, false),
             )
         }
     }

--- a/api/domain/src/model/route/route_gpx.rs
+++ b/api/domain/src/model/route/route_gpx.rs
@@ -160,20 +160,13 @@ impl TryFrom<Route> for RouteGpx {
 pub(crate) mod tests {
     use rstest::{fixture, rstest};
 
-    use crate::model::route::route_info::tests::RouteInfoFixtures;
-    use crate::model::route::segment_list::tests::OperationFixtures;
-    use crate::model::route::segment_list::tests::SegmentListFixture;
-    use crate::model::route::segment_list::Operation;
+    use crate::model::route::tests::RouteFixtures;
 
     use super::*;
 
     #[fixture]
     fn route0() -> Route {
-        Route {
-            info: RouteInfo::route0(3),
-            op_list: Operation::after_add_tokyo_op_list(),
-            seg_list: SegmentList::yokohama_to_chiba_via_tokyo(true, true, false),
-        }
+        Route::yokohama_to_chiba_via_tokyo_filled(true, true)
     }
 
     #[fixture]

--- a/api/domain/src/model/route/route_info.rs
+++ b/api/domain/src/model/route/route_info.rs
@@ -1,33 +1,64 @@
+use chrono::{DateTime, Utc};
+use derivative::Derivative;
 use getset::Getters;
 use serde::{Deserialize, Serialize};
 
-#[cfg(any(test, feature = "fixtures"))]
-use derivative::Derivative;
-
 use crate::model::user::UserId;
 
-use super::RouteId;
+use super::{Distance, Elevation, RouteId};
 
-#[derive(Clone, Debug, Getters, Deserialize, Serialize)]
+#[derive(Clone, Debug, Getters, Derivative, Deserialize, Serialize)]
 #[get = "pub"]
-#[cfg_attr(any(test, feature = "fixtures"), derive(Derivative))]
+#[derivative(Default)]
 #[cfg_attr(any(test, feature = "fixtures"), derivative(PartialEq))]
 pub struct RouteInfo {
+    #[derivative(Default(value = "RouteId::new()"))]
     #[cfg_attr(any(test, feature = "fixtures"), derivative(PartialEq = "ignore"))]
     pub(super) id: RouteId,
     pub(super) name: String,
+    #[derivative(Default(value = "UserId::from(\"\".to_string())"))]
     pub(super) owner_id: UserId,
     #[serde(skip_serializing)]
     pub(super) op_num: usize,
+    pub(super) ascent_elevation_gain: Elevation,
+    pub(super) descent_elevation_gain: Elevation,
+    pub(super) total_distance: Distance,
+    #[derivative(Default(value = "Utc::now()"))]
+    pub(super) created_at: DateTime<Utc>,
+    #[derivative(Default(value = "Utc::now()"))]
+    pub(super) updated_at: DateTime<Utc>,
 }
 
 impl RouteInfo {
-    pub fn new(id: RouteId, name: &str, owner_id: UserId, op_num: usize) -> RouteInfo {
+    pub fn new(name: &str, owner_id: UserId) -> RouteInfo {
+        RouteInfo {
+            name: name.to_string(),
+            owner_id,
+            ..Default::default()
+        }
+    }
+
+    pub fn with_details(
+        id: RouteId,
+        name: &str,
+        owner_id: UserId,
+        op_num: usize,
+        ascent_elevation_gain: Elevation,
+        descent_elevation_gain: Elevation,
+        total_distance: Distance,
+        created_at: DateTime<Utc>,
+        updated_at: DateTime<Utc>,
+    ) -> RouteInfo {
         RouteInfo {
             id,
             name: name.to_string(),
             owner_id,
             op_num,
+            ascent_elevation_gain,
+            descent_elevation_gain,
+            total_distance,
+            created_at,
+            updated_at,
         }
     }
 

--- a/api/domain/src/model/route/route_info.rs
+++ b/api/domain/src/model/route/route_info.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use derivative::Derivative;
+use derive_more::From;
 use getset::Getters;
 use serde::{Deserialize, Serialize};
 
@@ -7,7 +8,7 @@ use crate::model::user::UserId;
 
 use super::{Distance, Elevation, RouteId};
 
-#[derive(Clone, Debug, Getters, Derivative, Deserialize, Serialize)]
+#[derive(Clone, Debug, From, Getters, Derivative, Deserialize, Serialize)]
 #[get = "pub"]
 #[derivative(Default)]
 #[cfg_attr(any(test, feature = "fixtures"), derivative(PartialEq))]
@@ -35,30 +36,6 @@ impl RouteInfo {
             name: name.to_string(),
             owner_id,
             ..Default::default()
-        }
-    }
-
-    pub fn with_details(
-        id: RouteId,
-        name: &str,
-        owner_id: UserId,
-        op_num: usize,
-        ascent_elevation_gain: Elevation,
-        descent_elevation_gain: Elevation,
-        total_distance: Distance,
-        created_at: DateTime<Utc>,
-        updated_at: DateTime<Utc>,
-    ) -> RouteInfo {
-        RouteInfo {
-            id,
-            name: name.to_string(),
-            owner_id,
-            op_num,
-            ascent_elevation_gain,
-            descent_elevation_gain,
-            total_distance,
-            created_at,
-            updated_at,
         }
     }
 

--- a/api/domain/src/model/route/route_info.rs
+++ b/api/domain/src/model/route/route_info.rs
@@ -23,9 +23,9 @@ pub struct RouteInfo {
     pub(super) ascent_elevation_gain: Elevation,
     pub(super) descent_elevation_gain: Elevation,
     pub(super) total_distance: Distance,
-    #[derivative(Default(value = "Utc::now()"))]
+    #[derivative(Default(value = "chrono::MIN_DATETIME"))]
     pub(super) created_at: DateTime<Utc>,
-    #[derivative(Default(value = "Utc::now()"))]
+    #[derivative(Default(value = "chrono::MIN_DATETIME"))]
     pub(super) updated_at: DateTime<Utc>,
 }
 
@@ -74,6 +74,7 @@ impl RouteInfo {
 #[cfg(any(test, feature = "fixtures"))]
 pub(crate) mod tests {
     use rstest::{fixture, rstest};
+    use std::convert::TryFrom;
 
     use crate::model::user::tests::UserIdFixtures;
 
@@ -81,12 +82,12 @@ pub(crate) mod tests {
 
     #[fixture]
     fn route0_without_op() -> RouteInfo {
-        RouteInfo::route0(0)
+        RouteInfo::empty_route0(0)
     }
 
     #[fixture]
     fn route0_op2() -> RouteInfo {
-        RouteInfo::route0(2)
+        RouteInfo::empty_route0(2)
     }
 
     #[rstest]
@@ -102,22 +103,47 @@ pub(crate) mod tests {
     }
 
     pub trait RouteInfoFixtures {
-        fn route0(op_num: usize) -> RouteInfo {
+        fn empty_route0(op_num: usize) -> RouteInfo {
             RouteInfo {
                 id: RouteId::new(),
                 name: "route0".into(),
                 owner_id: UserId::doncic(),
                 op_num,
+                ..Default::default()
             }
         }
 
-        fn route1(op_num: usize) -> RouteInfo {
+        fn filled_route0(
+            asc_gain: i32,
+            desc_gain: i32,
+            total_dist: f64,
+            op_num: usize,
+        ) -> RouteInfo {
             RouteInfo {
-                id: RouteId::new(),
-                name: "route1".into(),
-                owner_id: UserId::doncic(),
-                op_num,
+                ascent_elevation_gain: Elevation::try_from(asc_gain).unwrap(),
+                descent_elevation_gain: Elevation::try_from(desc_gain).unwrap(),
+                total_distance: Distance::try_from(total_dist).unwrap(),
+                ..Self::empty_route0(op_num)
             }
+        }
+
+        fn empty_route1(op_num: usize) -> RouteInfo {
+            RouteInfo {
+                name: "route1".into(),
+                ..Self::empty_route0(op_num)
+            }
+        }
+
+        fn yokohama_to_chiba() -> RouteInfo {
+            RouteInfo::filled_route0(10, 0, 46779.709825324135, 2)
+        }
+
+        fn yokohama_to_chiba_via_tokyo() -> RouteInfo {
+            RouteInfo::filled_route0(10, 0, 58759.973932514884, 3)
+        }
+
+        fn yokohama_to_tokyo() -> RouteInfo {
+            RouteInfo::filled_route0(3, 0, 26936.42633640023, 3)
         }
     }
 

--- a/api/domain/src/model/route/types.rs
+++ b/api/domain/src/model/route/types.rs
@@ -25,6 +25,7 @@ pub type Distance = NumericValueObject<OrderedFloat<f64>, 0>;
 
 /// Value Object for BigDecimal type
 #[derive(
+    Default,
     Add,
     AddAssign,
     Sub,
@@ -39,7 +40,7 @@ pub type Distance = NumericValueObject<OrderedFloat<f64>, 0>;
     Serialize,
     Deserialize,
 )]
-pub struct NumericValueObject<T, const MAX_ABS: u32>(T);
+pub struct NumericValueObject<T: Default, const MAX_ABS: u32>(T);
 
 impl<const MAX_ABS: u32> NumericValueObject<i32, MAX_ABS> {
     pub fn value(&self) -> i32 {
@@ -53,7 +54,9 @@ impl<const MAX_ABS: u32> NumericValueObject<OrderedFloat<f64>, MAX_ABS> {
     }
 }
 
-impl<T: Copy + FromPrimitive + Bounded, const MAX_ABS: u32> NumericValueObject<T, MAX_ABS> {
+impl<T: Copy + Default + FromPrimitive + Bounded, const MAX_ABS: u32>
+    NumericValueObject<T, MAX_ABS>
+{
     pub fn max_value() -> Self {
         Self(if MAX_ABS == 0 {
             T::max_value()

--- a/api/infrastructure/src/dto/route.rs
+++ b/api/infrastructure/src/dto/route.rs
@@ -1,6 +1,9 @@
+use std::convert::TryFrom;
+
+use chrono::{DateTime, Utc};
 use getset::Getters;
 use route_bucket_domain::model::{
-    route::{RouteId, RouteInfo},
+    route::{Distance, Elevation, RouteId, RouteInfo},
     user::UserId,
 };
 use route_bucket_utils::ApplicationResult;
@@ -13,6 +16,11 @@ pub struct RouteDto {
     name: String,
     owner_id: String,
     operation_pos: u32,
+    ascent_elevation_gain: u32,
+    descent_elevation_gain: u32,
+    total_distance: f64,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
 }
 
 impl RouteDto {
@@ -22,12 +30,22 @@ impl RouteDto {
             name,
             owner_id,
             operation_pos,
+            ascent_elevation_gain,
+            descent_elevation_gain,
+            total_distance,
+            created_at,
+            updated_at,
         } = self;
-        Ok(RouteInfo::new(
+        Ok(RouteInfo::with_details(
             RouteId::from_string(id),
             &name,
             UserId::from(owner_id),
             operation_pos as usize,
+            Elevation::try_from(ascent_elevation_gain as i32)?,
+            Elevation::try_from(descent_elevation_gain as i32)?,
+            Distance::try_from(total_distance)?,
+            created_at,
+            updated_at,
         ))
     }
 
@@ -37,6 +55,11 @@ impl RouteDto {
             name: route_info.name().clone(),
             owner_id: route_info.owner_id().to_string(),
             operation_pos: *route_info.op_num() as u32,
+            ascent_elevation_gain: route_info.ascent_elevation_gain().value() as u32,
+            descent_elevation_gain: route_info.descent_elevation_gain().value() as u32,
+            total_distance: route_info.total_distance().value(),
+            created_at: route_info.created_at().clone(),
+            updated_at: route_info.updated_at().clone(),
         })
     }
 }

--- a/api/infrastructure/src/dto/route.rs
+++ b/api/infrastructure/src/dto/route.rs
@@ -36,9 +36,9 @@ impl RouteDto {
             created_at,
             updated_at,
         } = self;
-        Ok(RouteInfo::with_details(
+        Ok(RouteInfo::from((
             RouteId::from_string(id),
-            &name,
+            name,
             UserId::from(owner_id),
             operation_pos as usize,
             Elevation::try_from(ascent_elevation_gain as i32)?,
@@ -46,7 +46,7 @@ impl RouteDto {
             Distance::try_from(total_distance)?,
             created_at,
             updated_at,
-        ))
+        )))
     }
 
     pub fn from_model(route_info: &RouteInfo) -> ApplicationResult<RouteDto> {
@@ -58,8 +58,8 @@ impl RouteDto {
             ascent_elevation_gain: route_info.ascent_elevation_gain().value() as u32,
             descent_elevation_gain: route_info.descent_elevation_gain().value() as u32,
             total_distance: route_info.total_distance().value(),
-            created_at: route_info.created_at().clone(),
-            updated_at: route_info.updated_at().clone(),
+            created_at: *route_info.created_at(),
+            updated_at: *route_info.updated_at(),
         })
     }
 }

--- a/api/infrastructure/src/repository/route.rs
+++ b/api/infrastructure/src/repository/route.rs
@@ -325,14 +325,20 @@ impl RouteRepository for RouteRepositoryMySql {
 
         sqlx::query(
             r"
-            INSERT INTO routes (`id`, `name`, `owner_id`, `operation_pos`)
-            VALUES (?, ?, ?, ?)
+            INSERT INTO routes (
+                `id`, `name`, `owner_id`, `operation_pos`, `ascent_elevation_gain`, 
+                `descent_elevation_gain`, `total_distance`       
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
             ",
         )
         .bind(dto.id())
         .bind(dto.name())
         .bind(dto.owner_id())
         .bind(dto.operation_pos())
+        .bind(dto.ascent_elevation_gain())
+        .bind(dto.descent_elevation_gain())
+        .bind(dto.total_distance())
         .execute(&mut *conn)
         .await
         .map_err(gen_err_mapper("failed to insert RouteInfo"))?;
@@ -350,13 +356,18 @@ impl RouteRepository for RouteRepositoryMySql {
         sqlx::query(
             r"
             UPDATE routes
-            SET name = ?, owner_id = ?, operation_pos = ?
+            SET 
+                name = ?, owner_id = ?, operation_pos = ?, ascent_elevation_gain = ?,
+                descent_elevation_gain = ?, total_distance = ?
             WHERE id = ?
             ",
         )
         .bind(dto.name())
         .bind(dto.owner_id())
         .bind(dto.operation_pos())
+        .bind(dto.ascent_elevation_gain())
+        .bind(dto.descent_elevation_gain())
+        .bind(dto.total_distance())
         .bind(dto.id())
         .execute(&mut *conn)
         .await

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -147,7 +147,7 @@ where
         conn.transaction(|conn| {
             async move {
                 let owner_id = self.user_auth_api().authenticate(user_access_token).await?;
-                let route_info = RouteInfo::new(RouteId::new(), &req.name, owner_id, 0);
+                let route_info = RouteInfo::new(&req.name, owner_id);
 
                 self.route_repository()
                     .insert_info(&route_info, conn)

--- a/api/usecase/src/route/responses.rs
+++ b/api/usecase/src/route/responses.rs
@@ -46,8 +46,7 @@ pub struct RouteOperationResponse {
 impl TryFrom<Route> for RouteGetResponse {
     type Error = ApplicationError;
 
-    fn try_from(mut route: Route) -> Result<Self, Self::Error> {
-        route.reflect_update_on_seg_list_to_info()?;
+    fn try_from(route: Route) -> Result<Self, Self::Error> {
         let (info, _, seg_list) = route.into();
         Ok(RouteGetResponse {
             route_info: info,
@@ -63,8 +62,7 @@ impl TryFrom<Route> for RouteGetResponse {
 impl TryFrom<Route> for RouteOperationResponse {
     type Error = ApplicationError;
 
-    fn try_from(mut route: Route) -> Result<Self, Self::Error> {
-        route.reflect_update_on_seg_list_to_info()?;
+    fn try_from(route: Route) -> Result<Self, Self::Error> {
         let (info, _, seg_list) = route.into();
         Ok(RouteOperationResponse {
             waypoints: seg_list.gather_waypoints(),
@@ -89,11 +87,8 @@ mod tests {
 
     fn empty_route_get_resp() -> RouteGetResponse {
         RouteGetResponse {
-            route_info: RouteInfo::route0(0),
+            route_info: RouteInfo::empty_route0(0),
             waypoints: Vec::new(),
-            ascent_elevation_gain: Elevation::zero(),
-            descent_elevation_gain: Elevation::zero(),
-            total_distance: Distance::zero(),
             segments: Vec::new(),
             bounding_box: None,
         }
@@ -102,11 +97,8 @@ mod tests {
     fn full_route_get_resp() -> RouteGetResponse {
         let dist = 26936.42633640023;
         RouteGetResponse {
-            route_info: RouteInfo::route0(3),
+            route_info: RouteInfo::filled_route0(10, 0, 58759.973932514884, 3),
             waypoints: Coordinate::yokohama_to_chiba_via_tokyo_coords(false, None),
-            ascent_elevation_gain: 10.try_into().unwrap(),
-            descent_elevation_gain: 0.try_into().unwrap(),
-            total_distance: 58759.973932514884.try_into().unwrap(),
             segments: vec![
                 Segment::yokohama_to_tokyo(true, Some(0.), false, DrawingMode::Freehand),
                 Segment::tokyo_to_chiba(true, Some(dist), false, DrawingMode::Freehand),

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,9 +1,12 @@
 CREATE TABLE routes
 (
-    `id`            VARCHAR(11)      NOT NULL,
-    `name`          VARCHAR(50)      NOT NULL,
-    `owner_id`      VARCHAR(40)      NOT NULL,
-    `operation_pos` INTEGER UNSIGNED NOT NULL,
+    `id`                     VARCHAR(11)      NOT NULL,
+    `name`                   VARCHAR(50)      NOT NULL,
+    `owner_id`               VARCHAR(40)      NOT NULL,
+    `operation_pos`          INTEGER UNSIGNED NOT NULL,
+    `ascent_elevation_gain`  INTEGER UNSIGNED NOT NULL,
+    `descent_elevation_gain` INTEGER UNSIGNED NOT NULL,
+    `total_distance`         DOUBLE           NOT NULL,
     `created_at`    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     `updated_at`    TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     INDEX updated_idx (`updated_at`),


### PR DESCRIPTION
Closes #109 

検索画面用に、`RouteInfo`に獲得標高、総距離、作成/更新時間のフィールドを追加した。