### PR TITLE
`Route`の権限を表す`Permission`モデルの追加

### DIFF
--- a/api/domain/src/model.rs
+++ b/api/domain/src/model.rs
@@ -1,3 +1,4 @@
+pub mod permission;
 pub mod route;
 pub mod types;
 pub mod user;

--- a/api/domain/src/model/permission.rs
+++ b/api/domain/src/model/permission.rs
@@ -16,11 +16,13 @@ use super::{route::RouteId, user::UserId};
     strum::Display,
     strum::EnumString,
 )]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[strum(serialize_all = "snake_case")]
 pub enum PermissionType {
+    None,
     Viewer,
     Editor,
+    Owner,
 }
 
 #[derive(Clone, Debug, From, Into, Getters)]

--- a/api/domain/src/model/permission.rs
+++ b/api/domain/src/model/permission.rs
@@ -1,0 +1,32 @@
+use derive_more::{From, Into};
+use getset::Getters;
+use serde::{Deserialize, Serialize};
+
+use super::{route::RouteId, user::UserId};
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    PartialOrd,
+    PartialEq,
+    Eq,
+    strum::Display,
+    strum::EnumString,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum PermissionType {
+    Viewer,
+    Editor,
+}
+
+#[derive(Clone, Debug, From, Into, Getters)]
+#[get = "pub"]
+pub struct Permission {
+    route_id: RouteId,
+    user_id: UserId,
+    permission_type: PermissionType,
+}

--- a/api/domain/src/model/permission.rs
+++ b/api/domain/src/model/permission.rs
@@ -27,6 +27,7 @@ pub enum PermissionType {
 
 #[derive(Clone, Debug, From, Into, Getters)]
 #[get = "pub"]
+#[cfg_attr(any(test, feature = "fixtures"), derive(PartialEq))]
 pub struct Permission {
     route_id: RouteId,
     user_id: UserId,

--- a/api/domain/src/repository.rs
+++ b/api/domain/src/repository.rs
@@ -2,14 +2,16 @@ use async_trait::async_trait;
 use futures::future::BoxFuture;
 use route_bucket_utils::ApplicationResult;
 
+pub use permission::{CallPermissionRepository, PermissionRepository};
 pub use route::{CallRouteRepository, RouteRepository};
 pub use user::{CallUserRepository, UserRepository};
 
 #[cfg(feature = "mocking")]
-pub use route::MockRouteRepository;
-#[cfg(feature = "mocking")]
-pub use user::MockUserRepository;
+pub use self::{
+    permission::MockPermissionRepository, route::MockRouteRepository, user::MockUserRepository,
+};
 
+pub(crate) mod permission;
 pub(crate) mod route;
 pub(crate) mod user;
 

--- a/api/domain/src/repository/permission.rs
+++ b/api/domain/src/repository/permission.rs
@@ -1,0 +1,61 @@
+use async_trait::async_trait;
+use route_bucket_utils::ApplicationResult;
+
+use crate::model::{
+    permission::{Permission, PermissionType},
+    route::{RouteId, RouteInfo},
+    user::UserId,
+};
+
+use super::Repository;
+
+#[async_trait]
+pub trait PermissionRepository: Repository {
+    async fn authorize_user(
+        &self,
+        route_info: &RouteInfo,
+        user_id: &UserId,
+        target_type: PermissionType,
+        conn: &<Self as Repository>::Connection,
+    ) -> ApplicationResult<()>;
+
+    async fn insert_or_update(
+        &self,
+        permission: &Permission,
+        conn: &<Self as Repository>::Connection,
+    ) -> ApplicationResult<()>;
+
+    async fn delete(
+        &self,
+        route_id: &RouteId,
+        user_id: &UserId,
+        conn: &<Self as Repository>::Connection,
+    ) -> ApplicationResult<()>;
+}
+
+pub trait CallPermissionRepository {
+    type PermissionRepository: PermissionRepository;
+
+    fn permission_repository(&self) -> &Self::PermissionRepository;
+}
+
+#[cfg(feature = "mocking")]
+mockall::mock! {
+    pub PermissionRepository {}
+
+    #[async_trait]
+    impl Repository for PermissionRepository {
+        type Connection = super::MockConnection;
+
+        async fn get_connection(&self) -> ApplicationResult<super::MockConnection>;
+    }
+
+    #[async_trait]
+    impl PermissionRepository for PermissionRepository {
+        async fn authorize_user(&self, route_info: &RouteInfo, user_id: &UserId, target_type: PermissionType, conn: &super::MockConnection) -> ApplicationResult<()>;
+
+        async fn insert_or_update(&self, permission: &Permission, conn: &super::MockConnection) -> ApplicationResult<()>;
+
+        async fn delete(&self, route_id: &RouteId, user_id: &UserId, conn: &super::MockConnection) -> ApplicationResult<()>;
+    }
+}

--- a/api/infrastructure/src/dto.rs
+++ b/api/infrastructure/src/dto.rs
@@ -1,4 +1,5 @@
 pub mod operation;
+pub mod permission;
 pub mod route;
 pub mod search_query;
 pub mod segment;

--- a/api/infrastructure/src/dto/permission.rs
+++ b/api/infrastructure/src/dto/permission.rs
@@ -1,0 +1,47 @@
+use std::str::FromStr;
+
+use getset::Getters;
+use route_bucket_domain::model::{
+    permission::{Permission, PermissionType},
+    route::RouteId,
+    user::UserId,
+};
+use route_bucket_utils::{ApplicationError, ApplicationResult};
+
+/// ルートのdto構造体
+#[derive(sqlx::FromRow, Getters)]
+#[get = "pub"]
+pub(crate) struct PermissionDto {
+    pub(crate) route_id: String,
+    pub(crate) user_id: String,
+    pub(crate) permission_type: String,
+}
+
+impl PermissionDto {
+    pub fn into_model(self) -> ApplicationResult<Permission> {
+        let Self {
+            user_id,
+            route_id,
+            permission_type,
+        } = self;
+        Ok(Permission::from((
+            RouteId::from_string(route_id),
+            UserId::from(user_id),
+            PermissionType::from_str(&permission_type).map_err(|e| {
+                ApplicationError::DataBaseError(format!(
+                    "Failed to parse permission.permission_type ({:?})",
+                    e
+                ))
+            })?,
+        )))
+    }
+
+    pub fn from_model(permission: &Permission) -> ApplicationResult<Self> {
+        let (route_id, user_id, permission_type) = permission.clone().into();
+        Ok(Self {
+            route_id: route_id.to_string(),
+            user_id: user_id.to_string(),
+            permission_type: permission_type.to_string(),
+        })
+    }
+}

--- a/api/infrastructure/src/lib.rs
+++ b/api/infrastructure/src/lib.rs
@@ -2,7 +2,10 @@ pub use external::firebase::FirebaseAuthApi;
 pub use external::osrm::OsrmApi;
 pub use external::reserved_uids_reader::ReservedUidsReader;
 pub use external::srtm::SrtmReader;
-pub use repository::{init_repositories, route::RouteRepositoryMySql, user::UserRepositoryMySql};
+pub use repository::{
+    init_repositories, permission::PermissionRepositoryMySql, route::RouteRepositoryMySql,
+    user::UserRepositoryMySql,
+};
 
 mod dto;
 mod external;

--- a/api/infrastructure/src/repository.rs
+++ b/api/infrastructure/src/repository.rs
@@ -9,13 +9,19 @@ use sqlx::pool::PoolConnection;
 use sqlx::{MySql, TransactionManager};
 use tokio::sync::Mutex;
 
+use self::permission::PermissionRepositoryMySql;
 use self::route::RouteRepositoryMySql;
 use self::user::UserRepositoryMySql;
 
+pub mod permission;
 pub mod route;
 pub mod user;
 
-pub async fn init_repositories() -> (RouteRepositoryMySql, UserRepositoryMySql) {
+pub async fn init_repositories() -> (
+    RouteRepositoryMySql,
+    UserRepositoryMySql,
+    PermissionRepositoryMySql,
+) {
     let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL NOT FOUND");
     let pool = Arc::new(
         MySqlPoolOptions::new()
@@ -26,7 +32,8 @@ pub async fn init_repositories() -> (RouteRepositoryMySql, UserRepositoryMySql) 
     );
     (
         RouteRepositoryMySql(pool.clone()),
-        UserRepositoryMySql(pool),
+        UserRepositoryMySql(pool.clone()),
+        PermissionRepositoryMySql(pool),
     )
 }
 

--- a/api/infrastructure/src/repository/permission.rs
+++ b/api/infrastructure/src/repository/permission.rs
@@ -1,0 +1,127 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use route_bucket_domain::{
+    model::{
+        permission::{Permission, PermissionType},
+        route::{RouteId, RouteInfo},
+        user::UserId,
+    },
+    repository::{PermissionRepository, Repository},
+};
+use route_bucket_utils::{ApplicationError, ApplicationResult};
+use sqlx::MySqlPool;
+use tokio::sync::Mutex;
+
+use crate::dto::permission::PermissionDto;
+
+use super::{gen_err_mapper, RepositoryConnectionMySql};
+
+pub struct PermissionRepositoryMySql(pub(super) Arc<MySqlPool>);
+
+#[async_trait]
+impl Repository for PermissionRepositoryMySql {
+    type Connection = RepositoryConnectionMySql;
+
+    async fn get_connection(&self) -> ApplicationResult<Self::Connection> {
+        self.0
+            .acquire()
+            .await
+            .map(Mutex::new)
+            .map(RepositoryConnectionMySql)
+            .map_err(gen_err_mapper("failed to get connection"))
+    }
+}
+
+#[async_trait]
+impl PermissionRepository for PermissionRepositoryMySql {
+    async fn authorize_user(
+        &self,
+        route_info: &RouteInfo,
+        user_id: &UserId,
+        target_type: PermissionType,
+        conn: &<Self as Repository>::Connection,
+    ) -> ApplicationResult<()> {
+        if *user_id == *route_info.owner_id() {
+            return Ok(());
+        }
+
+        let mut conn = conn.lock().await;
+
+        let auth_err_closure = || {
+            ApplicationError::AuthorizationError(format!(
+                "User {} doesn't have {} permission on Route {}",
+                user_id,
+                target_type,
+                route_info.id()
+            ))
+        };
+
+        sqlx::query_as::<_, PermissionDto>(
+            r"
+            SELECT * FROM permissions WHERE route_id = ?, user_id = ?
+            ",
+        )
+        .bind(route_info.id().to_string())
+        .bind(user_id.to_string())
+        .fetch_one(&mut *conn)
+        .await
+        .map_err(|sqlx_err| match sqlx_err {
+            sqlx::Error::RowNotFound => auth_err_closure(),
+            other => gen_err_mapper("failed to find permission")(other),
+        })
+        .and_then(|dto| {
+            let permission = dto.into_model()?;
+            (target_type <= *permission.permission_type())
+                .then(|| ())
+                .ok_or_else(auth_err_closure)
+        })
+    }
+
+    async fn insert_or_update(
+        &self,
+        permission: &Permission,
+        conn: &<Self as Repository>::Connection,
+    ) -> ApplicationResult<()> {
+        let mut conn = conn.lock().await;
+        let dto = PermissionDto::from_model(permission)?;
+
+        sqlx::query(
+            r"
+            INSERT INTO permissions VALUES (?, ?, ?)
+            ON DUPLICATE KEY UPDATE `permission_type` = ?
+            ",
+        )
+        .bind(dto.route_id())
+        .bind(dto.user_id())
+        .bind(dto.permission_type())
+        .bind(dto.permission_type())
+        .execute(&mut *conn)
+        .await
+        .map_err(gen_err_mapper("failed to insert or update Permission"))?;
+
+        Ok(())
+    }
+
+    async fn delete(
+        &self,
+        route_id: &RouteId,
+        user_id: &UserId,
+        conn: &<Self as Repository>::Connection,
+    ) -> ApplicationResult<()> {
+        let mut conn = conn.lock().await;
+
+        sqlx::query(
+            r"
+            DELETE FROM permissions WHERE route_id = ?, user_id = ?
+            ",
+        )
+        .bind(route_id.to_string())
+        .bind(user_id.to_string())
+        .execute(&mut *conn)
+        .await
+        .map_err(gen_err_mapper("failed to delete Permission"))?;
+
+        Ok(())
+    }
+}

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -1,15 +1,18 @@
 use route_bucket_domain::external::{
     CallElevationApi, CallReservedUserIdCheckerApi, CallRouteInterpolationApi, CallUserAuthApi,
 };
-use route_bucket_domain::repository::{CallRouteRepository, CallUserRepository};
+use route_bucket_domain::repository::{
+    CallPermissionRepository, CallRouteRepository, CallUserRepository,
+};
 use route_bucket_infrastructure::{
-    init_repositories, FirebaseAuthApi, OsrmApi, ReservedUidsReader, RouteRepositoryMySql,
-    SrtmReader, UserRepositoryMySql,
+    init_repositories, FirebaseAuthApi, OsrmApi, PermissionRepositoryMySql, ReservedUidsReader,
+    RouteRepositoryMySql, SrtmReader, UserRepositoryMySql,
 };
 
 pub struct Server {
     route_repository: RouteRepositoryMySql,
     user_repository: UserRepositoryMySql,
+    permission_repository: PermissionRepositoryMySql,
     srtm_reader: SrtmReader,
     osrm_api: OsrmApi,
     firebase_auth_api: FirebaseAuthApi,
@@ -18,10 +21,11 @@ pub struct Server {
 
 impl Server {
     pub async fn new() -> Self {
-        let (route_repository, user_repository) = init_repositories().await;
+        let (route_repository, user_repository, permission_repository) = init_repositories().await;
         Self {
             route_repository,
             user_repository,
+            permission_repository,
             srtm_reader: SrtmReader::new().unwrap(),
             osrm_api: OsrmApi::new(),
             firebase_auth_api: FirebaseAuthApi::new().await.unwrap(),
@@ -44,6 +48,14 @@ impl CallUserRepository for Server {
 
     fn user_repository(&self) -> &Self::UserRepository {
         &self.user_repository
+    }
+}
+
+impl CallPermissionRepository for Server {
+    type PermissionRepository = PermissionRepositoryMySql;
+
+    fn permission_repository(&self) -> &Self::PermissionRepository {
+        &self.permission_repository
     }
 }
 

--- a/api/usecase/src/lib.rs
+++ b/api/usecase/src/lib.rs
@@ -67,5 +67,24 @@ mod test_macros {
                 true
             })
         };
+        ($repo_exp:expr, $method_name:ident, $in_exp0:expr, $in_exp1:expr, $out_exp:expr) => {
+            expect_at_repository!($repo_exp, $method_name, $out_exp).withf(
+                move |input0, input1, _| {
+                    assert_eq!(*input0, $in_exp0);
+                    assert_eq!(*input1, $in_exp1);
+                    true
+                },
+            )
+        };
+        ($repo_exp:expr, $method_name:ident, $in_exp0:expr, $in_exp1:expr, $in_exp2:expr, $out_exp:expr) => {
+            expect_at_repository!($repo_exp, $method_name, $out_exp).withf(
+                move |input0, input1, input2, _| {
+                    assert_eq!(*input0, $in_exp0);
+                    assert_eq!(*input1, $in_exp1);
+                    assert_eq!(*input2, $in_exp2);
+                    true
+                },
+            )
+        };
     }
 }

--- a/api/usecase/src/lib.rs
+++ b/api/usecase/src/lib.rs
@@ -58,11 +58,11 @@ mod test_macros {
 
     #[macro_export]
     macro_rules! expect_at_repository {
-        ($usecase:expr, $method_name:ident, $out_exp:expr) => {
-            crate::expect_once!($usecase.repository, $method_name).return_const(Ok($out_exp))
+        ($repo_exp:expr, $method_name:ident, $out_exp:expr) => {
+            crate::expect_once!($repo_exp, $method_name).return_const(Ok($out_exp))
         };
-        ($usecase:expr, $method_name:ident, $in_exp:expr, $out_exp:expr) => {
-            expect_at_repository!($usecase, $method_name, $out_exp).withf(move |input, _| {
+        ($repo_exp:expr, $method_name:ident, $in_exp:expr, $out_exp:expr) => {
+            expect_at_repository!($repo_exp, $method_name, $out_exp).withf(move |input, _| {
                 assert_eq!(*input, $in_exp);
                 true
             })

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -447,10 +447,11 @@ mod tests {
                 },
                 user::UserIdFixtures,
             },
+            permission::Permission,
             route::{Coordinate, DrawingMode, RouteGpx, Segment},
             user::UserId,
         },
-        repository::{MockConnection, MockRouteRepository},
+        repository::{MockConnection, MockPermissionRepository, MockRouteRepository},
     };
     use rstest::rstest;
 
@@ -596,8 +597,13 @@ mod tests {
         };
 
         let mut usecase = TestRouteUseCase::new();
-        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_info_at_route_repository(route_id(), RouteInfo::empty_route0(0));
+        usecase.expect_authenticate_at_auth_api(doncic_token(), UserId::doncic());
+        usecase.expect_authorize_user_at_permission_repository(
+            RouteInfo::empty_route0(0),
+            UserId::doncic(),
+            PermissionType::Editor,
+        );
         usecase.expect_update_info_at_route_repository(RouteInfo::empty_route1(0));
 
         assert_eq!(
@@ -615,10 +621,15 @@ mod tests {
         };
 
         let mut usecase = TestRouteUseCase::new();
-        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_at_route_repository(
             route_id(),
             Route::yokohama_to_chiba_filled(false, false),
+        );
+        usecase.expect_authenticate_at_auth_api(doncic_token(), UserId::doncic());
+        usecase.expect_authorize_user_at_permission_repository(
+            RouteInfo::empty_route0(2),
+            UserId::doncic(),
+            PermissionType::Editor,
         );
         usecase.expect_correct_coordinate_at_interpolation_api(
             tokyo_before_correction(),
@@ -653,10 +664,15 @@ mod tests {
         };
 
         let mut usecase = TestRouteUseCase::new();
-        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_at_route_repository(
             route_id(),
             Route::yokohama_to_chiba_via_tokyo_filled(false, false),
+        );
+        usecase.expect_authenticate_at_auth_api(doncic_token(), UserId::doncic());
+        usecase.expect_authorize_user_at_permission_repository(
+            RouteInfo::empty_route0(3),
+            UserId::doncic(),
+            PermissionType::Editor,
         );
         usecase.expect_interpolate_empty_segments_at_interpolation_api(
             yokohama_to_chiba_before_interpolation(false),
@@ -685,10 +701,15 @@ mod tests {
         };
 
         let mut usecase = TestRouteUseCase::new();
-        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_at_route_repository(
             route_id(),
             Route::yokohama_to_chiba_filled(false, false),
+        );
+        usecase.expect_authenticate_at_auth_api(doncic_token(), UserId::doncic());
+        usecase.expect_authorize_user_at_permission_repository(
+            RouteInfo::empty_route0(2),
+            UserId::doncic(),
+            PermissionType::Editor,
         );
         usecase.expect_correct_coordinate_at_interpolation_api(
             tokyo_before_correction(),
@@ -717,8 +738,13 @@ mod tests {
     #[tokio::test]
     async fn can_clear_route() {
         let mut usecase = TestRouteUseCase::new();
-        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_info_at_route_repository(route_id(), RouteInfo::empty_route0(3));
+        usecase.expect_authenticate_at_auth_api(doncic_token(), UserId::doncic());
+        usecase.expect_authorize_user_at_permission_repository(
+            RouteInfo::empty_route0(3),
+            UserId::doncic(),
+            PermissionType::Editor,
+        );
         usecase.expect_update_at_route_repository(Route::empty());
 
         assert_eq!(
@@ -731,10 +757,15 @@ mod tests {
     #[tokio::test]
     async fn can_redo_operation() {
         let mut usecase = TestRouteUseCase::new();
-        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_at_route_repository(
             route_id(),
             Route::yokohama_to_chiba_filled(false, false),
+        );
+        usecase.expect_authenticate_at_auth_api(doncic_token(), UserId::doncic());
+        usecase.expect_authorize_user_at_permission_repository(
+            RouteInfo::empty_route0(2),
+            UserId::doncic(),
+            PermissionType::Editor,
         );
         usecase.expect_interpolate_empty_segments_at_interpolation_api(
             yokohama_to_chiba_via_tokyo_before_interpolation(),
@@ -758,10 +789,15 @@ mod tests {
     #[tokio::test]
     async fn can_undo_operation() {
         let mut usecase = TestRouteUseCase::new();
-        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_at_route_repository(
             route_id(),
             Route::yokohama_to_chiba_via_tokyo_filled(false, false),
+        );
+        usecase.expect_authenticate_at_auth_api(doncic_token(), UserId::doncic());
+        usecase.expect_authorize_user_at_permission_repository(
+            RouteInfo::empty_route0(3),
+            UserId::doncic(),
+            PermissionType::Editor,
         );
         usecase.expect_interpolate_empty_segments_at_interpolation_api(
             yokohama_to_chiba_before_interpolation(true),
@@ -784,13 +820,19 @@ mod tests {
     async fn can_delete() {
         let mut usecase = TestRouteUseCase::new();
         usecase.expect_find_info_at_route_repository(route_id(), RouteInfo::empty_route0(0));
-        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
+        usecase.expect_authenticate_at_auth_api(doncic_token(), UserId::doncic());
+        usecase.expect_authorize_user_at_permission_repository(
+            RouteInfo::empty_route0(0),
+            UserId::doncic(),
+            PermissionType::Editor,
+        );
         usecase.expect_delete_at_route_repository(route_id());
         assert_eq!(usecase.delete(&route_id(), &doncic_token()).await, Ok(()));
     }
 
     struct TestRouteUseCase {
-        repository: MockRouteRepository,
+        route_repository: MockRouteRepository,
+        permission_repository: MockPermissionRepository,
         interpolation_api: MockRouteInterpolationApi,
         elevation_api: MockElevationApi,
         auth_api: MockUserAuthApi,
@@ -800,7 +842,8 @@ mod tests {
     impl TestRouteUseCase {
         fn new() -> Self {
             let mut usecase = TestRouteUseCase {
-                repository: MockRouteRepository::new(),
+                route_repository: MockRouteRepository::new(),
+                permission_repository: MockPermissionRepository::new(),
                 interpolation_api: MockRouteInterpolationApi::new(),
                 elevation_api: MockElevationApi::new(),
                 auth_api: MockUserAuthApi::new(),
@@ -854,6 +897,79 @@ mod tests {
             expect_at_repository!(self.route_repository, delete, param_id, ());
         }
 
+        #[allow(dead_code)]
+        fn expect_get_connection_at_permission_repository(&mut self) {
+            expect_at_repository!(
+                self.permission_repository,
+                get_connection,
+                MockConnection {}
+            );
+        }
+
+        #[allow(dead_code)]
+        fn expect_find_type_at_permission_repository(
+            &mut self,
+            param_info: RouteInfo,
+            param_user_id: UserId,
+            return_permission_type: PermissionType,
+        ) {
+            self.expect_get_connection_at_permission_repository();
+            expect_at_repository!(
+                self.permission_repository,
+                find_type,
+                param_info,
+                param_user_id,
+                return_permission_type
+            );
+        }
+
+        fn expect_authorize_user_at_permission_repository(
+            &mut self,
+            param_info: RouteInfo,
+            param_user_id: UserId,
+            param_permission_type: PermissionType,
+        ) {
+            self.expect_get_connection_at_permission_repository();
+            expect_at_repository!(
+                self.permission_repository,
+                authorize_user,
+                param_info,
+                param_user_id,
+                param_permission_type,
+                ()
+            );
+        }
+
+        #[allow(dead_code)]
+        fn expect_insert_or_update_at_permission_repository(
+            &mut self,
+            param_permission: Permission,
+        ) {
+            self.expect_get_connection_at_permission_repository();
+            expect_at_repository!(
+                self.permission_repository,
+                insert_or_update,
+                param_permission,
+                ()
+            );
+        }
+
+        #[allow(dead_code)]
+        fn expect_delete_at_permission_repository(
+            &mut self,
+            param_route_id: RouteId,
+            param_user_id: UserId,
+        ) {
+            self.expect_get_connection_at_permission_repository();
+            expect_at_repository!(
+                self.permission_repository,
+                delete,
+                param_route_id,
+                param_user_id,
+                ()
+            );
+        }
+
         fn expect_correct_coordinate_at_interpolation_api(
             &mut self,
             param_coord: Coordinate,
@@ -896,10 +1012,6 @@ mod tests {
         fn expect_authenticate_at_auth_api(&mut self, param_token: String, return_id: UserId) {
             expect_once!(self.auth_api, authenticate, param_token, return_id);
         }
-
-        fn expect_authorize_at_auth_api(&mut self, param_id: UserId, param_token: String) {
-            expect_once!(self.auth_api, authorize, param_id, param_token, ());
-        }
     }
 
     // impls to enable trait RouteUseCase
@@ -907,7 +1019,15 @@ mod tests {
         type RouteRepository = MockRouteRepository;
 
         fn route_repository(&self) -> &Self::RouteRepository {
-            &self.repository
+            &self.route_repository
+        }
+    }
+
+    impl CallPermissionRepository for TestRouteUseCase {
+        type PermissionRepository = MockPermissionRepository;
+
+        fn permission_repository(&self) -> &Self::PermissionRepository {
+            &self.permission_repository
         }
     }
 

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -805,13 +805,13 @@ mod tests {
                 elevation_api: MockElevationApi::new(),
                 auth_api: MockUserAuthApi::new(),
             };
-            expect_at_repository!(usecase, get_connection, MockConnection {});
+            expect_at_repository!(usecase.route_repository, get_connection, MockConnection {});
 
             usecase
         }
 
         fn expect_find_at_route_repository(&mut self, param_id: RouteId, return_route: Route) {
-            expect_at_repository!(self, find, param_id, return_route);
+            expect_at_repository!(self.route_repository, find, param_id, return_route);
         }
 
         fn expect_find_info_at_route_repository(
@@ -819,7 +819,7 @@ mod tests {
             param_id: RouteId,
             return_info: RouteInfo,
         ) {
-            expect_at_repository!(self, find_info, param_id, return_info);
+            expect_at_repository!(self.route_repository, find_info, param_id, return_info);
         }
 
         fn expect_search_infos_at_route_repository(
@@ -827,7 +827,7 @@ mod tests {
             query: RouteSearchQuery,
             return_infos: Vec<RouteInfo>,
         ) {
-            expect_at_repository!(self, search_infos, query, return_infos);
+            expect_at_repository!(self.route_repository, search_infos, query, return_infos);
         }
 
         fn expect_count_infos_at_route_repository(
@@ -835,23 +835,23 @@ mod tests {
             query: RouteSearchQuery,
             return_count: usize,
         ) {
-            expect_at_repository!(self, count_infos, query, return_count);
+            expect_at_repository!(self.route_repository, count_infos, query, return_count);
         }
 
         fn expect_insert_info_at_route_repository(&mut self, param_info: RouteInfo) {
-            expect_at_repository!(self, insert_info, param_info, ());
+            expect_at_repository!(self.route_repository, insert_info, param_info, ());
         }
 
         fn expect_update_at_route_repository(&mut self, param_route: Route) {
-            expect_at_repository!(self, update, param_route, ());
+            expect_at_repository!(self.route_repository, update, param_route, ());
         }
 
         fn expect_update_info_at_route_repository(&mut self, param_info: RouteInfo) {
-            expect_at_repository!(self, update_info, param_info, ());
+            expect_at_repository!(self.route_repository, update_info, param_info, ());
         }
 
         fn expect_delete_at_route_repository(&mut self, param_id: RouteId) {
-            expect_at_repository!(self, delete, param_id, ());
+            expect_at_repository!(self.route_repository, delete, param_id, ());
         }
 
         fn expect_correct_coordinate_at_interpolation_api(

--- a/api/usecase/src/user.rs
+++ b/api/usecase/src/user.rs
@@ -317,25 +317,25 @@ mod tests {
                 auth_api: MockUserAuthApi::new(),
                 uid_check_api: MockReservedUserIdCheckerApi::new(),
             };
-            expect_at_repository!(usecase, get_connection, MockConnection {});
+            expect_at_repository!(usecase.repository, get_connection, MockConnection {});
 
             usecase
         }
 
         fn expect_find_at_user_repository(&mut self, param_id: UserId, return_user: User) {
-            expect_at_repository!(self, find, param_id, return_user);
+            expect_at_repository!(self.repository, find, param_id, return_user);
         }
 
         fn expect_insert_at_user_repository(&mut self, param_user: User) {
-            expect_at_repository!(self, insert, param_user, ());
+            expect_at_repository!(self.repository, insert, param_user, ());
         }
 
         fn expect_update_at_user_repository(&mut self, param_user: User) {
-            expect_at_repository!(self, update, param_user, ());
+            expect_at_repository!(self.repository, update, param_user, ());
         }
 
         fn expect_delete_at_user_repository(&mut self, param_id: UserId) {
-            expect_at_repository!(self, delete, param_id, ());
+            expect_at_repository!(self.repository, delete, param_id, ());
         }
 
         fn expect_create_account_at_auth_api(

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -46,3 +46,11 @@ CREATE TABLE users
     `icon_url`  VARCHAR(100)             ,
     PRIMARY KEY (`id`)
 );
+
+CREATE TABLE permissions
+(
+    `route_id`        VARCHAR(11) NOT NULL,
+    `user_id`         VARCHAR(40) NOT NULL,
+    `permission_type` VARCHAR(6)  NOT NULL,
+    PRIMARY KEY (`user_id`, `route_id`)
+);


### PR DESCRIPTION
Closes #110 

今回は、`UserAuthApi::authorize`を`PermissionRepository::authorize_user`で置き換えるのみで、`Permission`を追加するエンドポイントの作成は行わなかった。（なので、DBの`permissions`テーブルは空のはず）

**Commits**
Domain: c7289828db809458dcfcd158ddf830cb77db99ec
Infra: 2b7aa51b3e83e879de07db8db29251c50059404c
UseCase: 0cb5582da79dbdff2421e25f6ec070582aab7b39