### PR TITLE
`Permission`の編集・削除系エンドポイントの追加

### DIFF
--- a/api/domain/src/model.rs
+++ b/api/domain/src/model.rs
@@ -6,6 +6,7 @@ pub mod user;
 #[cfg(feature = "fixtures")]
 pub mod fixtures {
     pub mod route {
+        pub use crate::model::permission::tests::PermissionFixtures;
         pub use crate::model::route::bounding_box::tests::BoundingBoxFixture;
         pub use crate::model::route::coordinate::tests::CoordinateFixtures;
         pub use crate::model::route::route_gpx::tests::RouteGpxFixtures;

--- a/api/domain/src/model/permission.rs
+++ b/api/domain/src/model/permission.rs
@@ -4,6 +4,9 @@ use serde::{Deserialize, Serialize};
 
 use super::{route::RouteId, user::UserId};
 
+#[cfg(any(test, feature = "fixtures"))]
+use derivative::Derivative;
+
 #[derive(
     Copy,
     Clone,
@@ -27,9 +30,30 @@ pub enum PermissionType {
 
 #[derive(Clone, Debug, From, Into, Getters)]
 #[get = "pub"]
-#[cfg_attr(any(test, feature = "fixtures"), derive(PartialEq))]
+#[cfg_attr(any(test, feature = "fixtures"), derive(Derivative))]
+#[cfg_attr(any(test, feature = "fixtures"), derivative(PartialEq))]
 pub struct Permission {
+    #[cfg_attr(any(test, feature = "fixtures"), derivative(PartialEq = "ignore"))]
     route_id: RouteId,
     user_id: UserId,
     permission_type: PermissionType,
+}
+
+#[cfg(any(test, feature = "fixtures"))]
+pub(crate) mod tests {
+    use crate::model::user::tests::UserIdFixtures;
+
+    use super::*;
+
+    pub trait PermissionFixtures {
+        fn porzingis_viewer_permission() -> Permission {
+            Permission {
+                route_id: RouteId::new(),
+                user_id: UserId::porzingis(),
+                permission_type: PermissionType::Viewer,
+            }
+        }
+    }
+
+    impl PermissionFixtures for Permission {}
 }

--- a/api/infrastructure/src/repository/permission.rs
+++ b/api/infrastructure/src/repository/permission.rs
@@ -49,7 +49,7 @@ impl PermissionRepository for PermissionRepositoryMySql {
 
         let sqlx_result = sqlx::query_as::<_, PermissionDto>(
             r"
-            SELECT * FROM permissions WHERE route_id = ?, user_id = ?
+            SELECT * FROM permissions WHERE `route_id` = ? AND `user_id` = ?
             ",
         )
         .bind(route_info.id().to_string())
@@ -102,7 +102,7 @@ impl PermissionRepository for PermissionRepositoryMySql {
 
         sqlx::query(
             r"
-            DELETE FROM permissions WHERE route_id = ?, user_id = ?
+            DELETE FROM permissions WHERE `route_id` = ? AND `user_id` = ?
             ",
         )
         .bind(route_id.to_string())

--- a/api/usecase/src/route/requests.rs
+++ b/api/usecase/src/route/requests.rs
@@ -1,7 +1,11 @@
 use derive_more::From;
 use serde::Deserialize;
 
-use route_bucket_domain::model::route::{Coordinate, DrawingMode};
+use route_bucket_domain::model::{
+    permission::PermissionType,
+    route::{Coordinate, DrawingMode},
+    user::UserId,
+};
 
 #[derive(From, Deserialize)]
 pub struct RouteCreateRequest {
@@ -22,4 +26,16 @@ pub struct RemovePointRequest {
 #[derive(From, Deserialize)]
 pub struct RouteRenameRequest {
     pub(super) name: String,
+}
+
+#[derive(From, Deserialize)]
+pub struct UpdatePermissionRequest {
+    pub(super) user_id: UserId,
+    #[serde(alias = "type")]
+    pub(super) permission_type: PermissionType,
+}
+
+#[derive(From, Deserialize)]
+pub struct DeletePermissionRequest {
+    pub(super) user_id: UserId,
 }


### PR DESCRIPTION
https://github.com/team-azb/route-bucket-backend/pull/127 のモデルを用いて`/routes/{id}/permissions/`に`PUT`と`DELETE`を追加した