### PR TITLE
Github ActionsのRustのバージョンを固定する

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.58.1
           components: rustfmt, clippy
       - name: Check format
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
Rustのバージョンが勝手にアップデートされるたびに、lintやformat checkが落ちるようになるのを防ぐ目的