### PR TITLE
リソースが見つからない場合に、404を返すようにする

### DIFF
--- a/api/infrastructure/src/repository.rs
+++ b/api/infrastructure/src/repository.rs
@@ -31,7 +31,13 @@ pub async fn init_repositories() -> (RouteRepositoryMySql, UserRepositoryMySql) 
 }
 
 fn gen_err_mapper(msg: &'static str) -> impl FnOnce(sqlx::Error) -> ApplicationError {
-    move |err| ApplicationError::DataBaseError(format!("{} ({:?})", msg, err))
+    move |err| {
+        let err_str = format!("{} ({:?})", msg, err);
+        match err {
+            sqlx::Error::RowNotFound => ApplicationError::ResourceNotFound(err_str),
+            _ => ApplicationError::DataBaseError(err_str),
+        }
+    }
 }
 
 #[derive(Deref)]

--- a/api/utils/src/error.rs
+++ b/api/utils/src/error.rs
@@ -28,11 +28,8 @@ pub enum ApplicationError {
     #[display(fmt = "InvalidOperation: {}", _0)]
     InvalidOperation(&'static str),
 
-    #[display(fmt = "ResourceNotFound: {} {} not found", resource_name, id)]
-    ResourceNotFound {
-        resource_name: &'static str,
-        id: String,
-    },
+    #[display(fmt = "ResourceNotFound: {}", _0)]
+    ResourceNotFound(String),
 
     #[display(fmt = "UseCaseError: {}", _0)]
     UseCaseError(String),


### PR DESCRIPTION
Closes #130 

`gen_err_mapper`を使ったエラー処理のリファクタ時から、リソースが見つからない系のエラーでも500がかえるようになっていたところを修正した