### PR TITLE
GitHub actionsのRust versionのdefaultのオーバーライド

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           toolchain: 1.58.1
           components: rustfmt, clippy
+          default: true
+          override: true
       - name: Check format
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
https://github.com/team-azb/route-bucket-backend/pull/133 でGitHub actionsのrust version由来のエラーは回避できたと思っていたが、この変更が正しく実行時に反映されていなかった。