### PR TITLE
Routeに公開/非公開の概念を追加

### DIFF
--- a/api/domain/src/model/route/route_info.rs
+++ b/api/domain/src/model/route/route_info.rs
@@ -124,6 +124,13 @@ pub(crate) mod tests {
         fn yokohama_to_tokyo() -> RouteInfo {
             RouteInfo::filled_route0(3, 0, 26936.42633640023, 3)
         }
+
+        fn public_route0() -> RouteInfo {
+            RouteInfo {
+                is_public: true,
+                ..Self::empty_route0(0)
+            }
+        }
     }
 
     impl RouteInfoFixtures for RouteInfo {}

--- a/api/domain/src/model/route/route_info.rs
+++ b/api/domain/src/model/route/route_info.rs
@@ -24,6 +24,7 @@ pub struct RouteInfo {
     pub(super) ascent_elevation_gain: Elevation,
     pub(super) descent_elevation_gain: Elevation,
     pub(super) total_distance: Distance,
+    pub(super) is_public: bool,
     #[derivative(Default(value = "chrono::MIN_DATETIME"))]
     pub(super) created_at: DateTime<Utc>,
     #[derivative(Default(value = "chrono::MIN_DATETIME"))]
@@ -31,10 +32,11 @@ pub struct RouteInfo {
 }
 
 impl RouteInfo {
-    pub fn new(name: &str, owner_id: UserId) -> RouteInfo {
+    pub fn new(name: &str, owner_id: UserId, is_public: bool) -> RouteInfo {
         RouteInfo {
             name: name.to_string(),
             owner_id,
+            is_public,
             ..Default::default()
         }
     }

--- a/api/infrastructure/src/dto/route.rs
+++ b/api/infrastructure/src/dto/route.rs
@@ -19,6 +19,7 @@ pub struct RouteDto {
     ascent_elevation_gain: u32,
     descent_elevation_gain: u32,
     total_distance: f64,
+    is_public: bool,
     created_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
 }
@@ -33,6 +34,7 @@ impl RouteDto {
             ascent_elevation_gain,
             descent_elevation_gain,
             total_distance,
+            is_public,
             created_at,
             updated_at,
         } = self;
@@ -44,6 +46,7 @@ impl RouteDto {
             Elevation::try_from(ascent_elevation_gain as i32)?,
             Elevation::try_from(descent_elevation_gain as i32)?,
             Distance::try_from(total_distance)?,
+            is_public,
             created_at,
             updated_at,
         )))
@@ -58,6 +61,7 @@ impl RouteDto {
             ascent_elevation_gain: route_info.ascent_elevation_gain().value() as u32,
             descent_elevation_gain: route_info.descent_elevation_gain().value() as u32,
             total_distance: route_info.total_distance().value(),
+            is_public: *route_info.is_public(),
             created_at: *route_info.created_at(),
             updated_at: *route_info.updated_at(),
         })

--- a/api/infrastructure/src/repository/permission.rs
+++ b/api/infrastructure/src/repository/permission.rs
@@ -62,7 +62,13 @@ impl PermissionRepository for PermissionRepositoryMySql {
                 let permission = dto.into_model()?;
                 Ok(*permission.permission_type())
             }
-            Err(sqlx::Error::RowNotFound) => Ok(PermissionType::None),
+            Err(sqlx::Error::RowNotFound) => {
+                if *route_info.is_public() {
+                    Ok(PermissionType::Viewer)
+                } else {
+                    Ok(PermissionType::None)
+                }
+            }
             Err(other_sqlx_err) => Err(gen_err_mapper("failed to find permission")(other_sqlx_err)),
         }
     }

--- a/api/infrastructure/src/repository/route.rs
+++ b/api/infrastructure/src/repository/route.rs
@@ -327,9 +327,9 @@ impl RouteRepository for RouteRepositoryMySql {
             r"
             INSERT INTO routes (
                 `id`, `name`, `owner_id`, `operation_pos`, `ascent_elevation_gain`, 
-                `descent_elevation_gain`, `total_distance`       
+                `descent_elevation_gain`, `total_distance`, `is_public`
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             ",
         )
         .bind(dto.id())
@@ -339,6 +339,7 @@ impl RouteRepository for RouteRepositoryMySql {
         .bind(dto.ascent_elevation_gain())
         .bind(dto.descent_elevation_gain())
         .bind(dto.total_distance())
+        .bind(dto.is_public())
         .execute(&mut *conn)
         .await
         .map_err(gen_err_mapper("failed to insert RouteInfo"))?;

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -168,7 +168,7 @@ where
         conn.transaction(|conn| {
             async move {
                 let owner_id = self.user_auth_api().authenticate(user_access_token).await?;
-                let route_info = RouteInfo::new(&req.name, owner_id);
+                let route_info = RouteInfo::new(&req.name, owner_id, req.is_public);
 
                 self.route_repository()
                     .insert_info(&route_info, conn)

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -638,6 +638,7 @@ mod tests {
     async fn can_create() {
         let req = RouteCreateRequest {
             name: "route0".into(),
+            is_public: false,
         };
 
         let mut usecase = TestRouteUseCase::new();

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -459,7 +459,7 @@ where
 
         let perm_conn = self.permission_repository().get_connection().await?;
         self.permission_repository()
-            .authorize_user(&route_info, &user_id, PermissionType::Editor, &perm_conn)
+            .authorize_user(&route_info, &user_id, PermissionType::Owner, &perm_conn)
             .await?;
         self.permission_repository()
             .insert_or_update(
@@ -485,7 +485,7 @@ where
 
         let perm_conn = self.permission_repository().get_connection().await?;
         self.permission_repository()
-            .authorize_user(&route_info, &user_id, PermissionType::Editor, &perm_conn)
+            .authorize_user(&route_info, &user_id, PermissionType::Owner, &perm_conn)
             .await?;
         self.permission_repository()
             .delete(route_info.id(), &req.user_id, &perm_conn)

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -459,7 +459,7 @@ where
 
         let perm_conn = self.permission_repository().get_connection().await?;
         self.permission_repository()
-            .authorize_user(&route_info, &user_id, PermissionType::Editor, &perm_conn)
+            .authorize_user(&route_info, &user_id, PermissionType::Owner, &perm_conn)
             .await?;
         self.permission_repository()
             .insert_or_update(
@@ -485,7 +485,7 @@ where
 
         let perm_conn = self.permission_repository().get_connection().await?;
         self.permission_repository()
-            .authorize_user(&route_info, &user_id, PermissionType::Editor, &perm_conn)
+            .authorize_user(&route_info, &user_id, PermissionType::Owner, &perm_conn)
             .await?;
         self.permission_repository()
             .delete(route_info.id(), &req.user_id, &perm_conn)
@@ -904,7 +904,7 @@ mod tests {
         usecase.expect_authorize_user_at_permission_repository(
             RouteInfo::empty_route0(0),
             UserId::doncic(),
-            PermissionType::Editor,
+            PermissionType::Owner,
         );
         usecase.expect_insert_or_update_at_permission_repository(
             Permission::porzingis_viewer_permission(),
@@ -932,7 +932,7 @@ mod tests {
         usecase.expect_authorize_user_at_permission_repository(
             info.clone(),
             UserId::doncic(),
-            PermissionType::Editor,
+            PermissionType::Owner,
         );
         usecase.expect_delete_at_permission_repository(id.clone(), UserId::porzingis());
         assert_eq!(

--- a/api/usecase/src/route/requests.rs
+++ b/api/usecase/src/route/requests.rs
@@ -10,6 +10,7 @@ use route_bucket_domain::model::{
 #[derive(From, Deserialize)]
 pub struct RouteCreateRequest {
     pub(super) name: String,
+    pub(super) is_public: bool,
 }
 
 #[derive(From, Deserialize)]

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -7,6 +7,7 @@ CREATE TABLE routes
     `ascent_elevation_gain`  INTEGER UNSIGNED NOT NULL,
     `descent_elevation_gain` INTEGER UNSIGNED NOT NULL,
     `total_distance`         DOUBLE           NOT NULL,
+    `is_public`              TINYINT(1)       NOT NULL,
     `created_at`    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     `updated_at`    TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     INDEX updated_idx (`updated_at`),


### PR DESCRIPTION
`RouteInfo`に`is_public`というフィールドを追加し、`POST /routes/`でも`is_public`の指定を要求するようにした