### PR TITLE
`actix_web_validator`を用いたバリデーションの自動化

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           toolchain: 1.58.1
           components: rustfmt, clippy
+          default: true
+          override: true
       - name: Check format
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.58.1
           components: rustfmt, clippy
       - name: Check format
         uses: actions-rs/cargo@v1

--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -212,6 +212,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-web-validator"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9699f456ec129158193c11b0f26ce24f6c91c30dd383c5f7d0d33dc069be0c"
+dependencies = [
+ "actix-http",
+ "actix-router",
+ "actix-web",
+ "bytes",
+ "derive_more",
+ "futures",
+ "futures-util",
+ "log",
+ "mime",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "serde_urlencoded",
+ "validator",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,9 +463,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "bytestring"
@@ -2164,6 +2186,7 @@ dependencies = [
  "actix-service",
  "actix-web",
  "actix-web-httpauth",
+ "actix-web-validator",
  "derive_more",
  "route-bucket-domain",
  "route-bucket-usecase",
@@ -2424,6 +2447,19 @@ dependencies = [
  "itoa 0.4.7",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfafda9a9479d9ac6188b6fc1f84b850cd3f3b5faff6d13e6e45d1296e92ee8"
+dependencies = [
+ "actix-web",
+ "futures",
+ "percent-encoding",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -4,15 +4,16 @@ version = 3
 
 [[package]]
 name = "actix-codec"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d5dbeb2d9e51344cb83ca7cc170f1217f9fe25bfc50160e6e200b5c31c1019a"
+checksum = "57a7559404a7f3573127aab53c08ce37a6c6a315c374a31070f3c91cd1b4a7fe"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-core",
  "futures-sink",
  "log",
+ "memchr",
  "pin-project-lite",
  "tokio",
  "tokio-util",
@@ -20,11 +21,11 @@ dependencies = [
 
 [[package]]
 name = "actix-cors"
-version = "0.6.0-beta.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa59d36d7ad063401d94ada05264a303791796ad5222d0954cc21f2e1052e99b"
+checksum = "414360eed71ba2d5435b185ba43ecbe281dfab5df3898286d6b7be8074372c92"
 dependencies = [
- "actix-service",
+ "actix-utils",
  "actix-web",
  "derive_more",
  "futures-util",
@@ -35,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.0.0-beta.12"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afaeb3d3fcb06b775ac62f05d580aae4afe5a149513333a73f688fdf26c06639"
+checksum = "a5885cb81a0d4d0d322864bea1bb6c2a8144626b4fdc625d4c51eba197e7797a"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -46,28 +47,26 @@ dependencies = [
  "ahash",
  "base64 0.13.0",
  "bitflags",
- "brotli2",
+ "brotli",
  "bytes",
  "bytestring",
  "derive_more",
  "encoding_rs",
  "flate2",
  "futures-core",
- "futures-util",
  "h2",
  "http",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 1.0.1",
  "language-tags",
  "local-channel",
  "log",
  "mime",
  "percent-encoding",
- "pin-project",
  "pin-project-lite",
  "rand 0.8.4",
- "sha-1",
+ "sha-1 0.10.0",
  "smallvec",
  "zstd",
 ]
@@ -84,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "actix-router"
-version = "0.5.0-beta.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b95ce0d76d1aa2f98b681702807475ade0f99bd4552546a6843a966d42ea3d"
+checksum = "eb60846b52c118f2f04a56cc90880a274271c489b2498623d58176f8ca21fa80"
 dependencies = [
  "bytestring",
  "firestorm",
@@ -98,38 +97,37 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "2.4.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0c218d0a17c120f10ee0c69c9f0c45d87319e8f66b1f065e8412b612fc3e24"
+checksum = "7ea16c295198e958ef31930a6ef37d0fb64e9ca3b6116e6b93a8bdae96ee1000"
 dependencies = [
- "actix-macros",
  "futures-core",
  "tokio",
 ]
 
 [[package]]
 name = "actix-server"
-version = "2.0.0-beta.9"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411dd3296dd317ff5eff50baa13f31923ea40ec855dd7f2d3ed8639948f0195f"
+checksum = "0da34f8e659ea1b077bb4637948b815cd3768ad5a188fdcd74ff4d84240cd824"
 dependencies = [
  "actix-rt",
  "actix-service",
  "actix-utils",
  "futures-core",
  "futures-util",
- "log",
- "mio",
+ "mio 0.8.2",
  "num_cpus",
  "socket2",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "actix-service"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f5f9d66a8730d0fae62c26f3424f5751e5518086628a40b7ab6fca4a705034"
+checksum = "3b894941f818cfdc7ccc4b9e60fa7e53b5042a2e8567270f9147d5591893373a"
 dependencies = [
  "futures-core",
  "paste",
@@ -148,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.0.0-beta.11"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e85aa9bb018d83a0db70f557ba0cde9c6170a5d1de4fede02e377f68c1ac5aa9"
+checksum = "f4e5ebffd51d50df56a3ae0de0e59487340ca456f05dd0b90c0a7a6dd6a74d31"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -163,20 +161,19 @@ dependencies = [
  "actix-web-codegen",
  "ahash",
  "bytes",
+ "bytestring",
  "cfg-if",
  "cookie",
  "derive_more",
- "either",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "itoa",
+ "itoa 1.0.1",
  "language-tags",
  "log",
  "mime",
  "once_cell",
- "paste",
- "pin-project",
+ "pin-project-lite",
  "regex",
  "serde",
  "serde_json",
@@ -189,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web-codegen"
-version = "0.5.0-beta.5"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe80a8828fa88a0420dc8fdd4c16b8207326c917f17701881b063eadc2a8d3b"
+checksum = "7525bedf54704abb1d469e88d7e7e9226df73778798a69cea5022d53b2ae91bc"
 dependencies = [
  "actix-router",
  "proc-macro2",
@@ -201,14 +198,17 @@ dependencies = [
 
 [[package]]
 name = "actix-web-httpauth"
-version = "0.6.0-beta.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85705b8146a8953eef97369255ac225b239c1a689699e258510b426ed8939c44"
+checksum = "08c25a48b4684f90520183cd1a688e5f4f7e9905835fa75d02c0fe4f60fcdbe6"
 dependencies = [
  "actix-service",
+ "actix-utils",
  "actix-web",
  "base64 0.13.0",
+ "futures-core",
  "futures-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -244,6 +244,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ef4730490ad1c4eae5c4325b2a95f521d023e5c885853ff7aca0a6a1631db3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -338,12 +353,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base-x"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
-
-[[package]]
 name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,23 +392,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "brotli-sys"
-version = "0.3.2"
+name = "block-buffer"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4445dea95f4c2b41cde57cc9fee236ae4dbae88d8fcbdb4750fc1bb5d86aaecd"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
- "cc",
- "libc",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
-name = "brotli2"
-version = "0.3.2"
+name = "brotli"
+version = "3.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb036c3eade309815c15ddbacec5b22c4d1f3983a774ab2eac2e3e9ea85568e"
+checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
 dependencies = [
- "brotli-sys",
- "libc",
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -484,12 +503,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92cfa0fd5690b3cf8c1ef2cabbd9b7ef22fa53cf5e1f92b05103f6d5d1cf6e7"
-
-[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,12 +510,12 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cookie"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f1c7727e460397e56abc4bddc1d49e07a1ad78fc98eb2e1c8f032a58a2f80d"
+checksum = "94d4706de1b0fa5b132270cddffa8585166037822e260a944fe161acd137ca05"
 dependencies = [
  "percent-encoding",
- "time 0.2.27",
+ "time 0.3.5",
  "version_check",
 ]
 
@@ -527,6 +540,15 @@ name = "cpufeatures"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
 ]
@@ -604,6 +626,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4600d695eb3f6ce1cd44e6e291adceb2cc3ab12f20a33777ecd0bf6eba34e06"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,10 +674,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "discard"
-version = "1.0.4"
+name = "digest"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+checksum = "8cb780dce4f9a8f5c087362b3a4595936b2019e7c8b30f2c3e9a7e94e6ae9837"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
+]
 
 [[package]]
 name = "dotenv"
@@ -699,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "firestorm"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31586bda1b136406162e381a3185a506cdfc1631708dd40cba2f6628d8634499"
+checksum = "4d3d6188b8804df28032815ea256b6955c9625c24da7525f387a7af02fbb8f01"
 
 [[package]]
 name = "flate2"
@@ -945,7 +980,7 @@ checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -981,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.3"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
+checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
 dependencies = [
  "bytes",
  "fnv",
@@ -1075,7 +1110,7 @@ checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 0.4.7",
 ]
 
 [[package]]
@@ -1122,7 +1157,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 0.4.7",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1200,6 +1235,12 @@ name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "jobserver"
@@ -1362,6 +1403,20 @@ dependencies = [
  "log",
  "miow",
  "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -1687,30 +1742,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "pin-utils"
@@ -2228,7 +2263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ef841a26fc5d040ced0417c6c6a64ee851f42489df11cdf0218e545b6f8d28"
 dependencies = [
  "byteorder",
- "digest",
+ "digest 0.9.0",
  "lazy_static",
  "num-bigint-dig",
  "num-integer",
@@ -2271,15 +2306,6 @@ name = "rustc-demangle"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
-
-[[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
 
 [[package]]
 name = "rustc_version"
@@ -2346,20 +2372,11 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser 0.7.0",
-]
-
-[[package]]
-name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser 0.10.2",
+ "semver-parser",
 ]
 
 [[package]]
@@ -2367,12 +2384,6 @@ name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
@@ -2410,7 +2421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "indexmap",
- "itoa",
+ "itoa 0.4.7",
  "ryu",
  "serde",
 ]
@@ -2422,7 +2433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 0.4.7",
  "ryu",
  "serde",
 ]
@@ -2433,18 +2444,23 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c4cfa741c5832d0ef7fab46cabed29c2aae926db0b11bb2069edd8db5e64e16"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.1.5",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
 [[package]]
-name = "sha1"
-version = "0.6.0"
+name = "sha-1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.2",
+ "digest 0.10.2",
+]
 
 [[package]]
 name = "sha2"
@@ -2452,10 +2468,10 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.1.5",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
@@ -2559,7 +2575,7 @@ dependencies = [
  "crossbeam-channel",
  "crossbeam-queue",
  "crossbeam-utils",
- "digest",
+ "digest 0.9.0",
  "either",
  "futures-channel",
  "futures-core",
@@ -2567,7 +2583,7 @@ dependencies = [
  "generic-array 0.14.4",
  "hashlink",
  "hex",
- "itoa",
+ "itoa 0.4.7",
  "libc",
  "log",
  "memchr",
@@ -2579,7 +2595,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha-1",
+ "sha-1 0.9.6",
  "sha2",
  "smallvec",
  "sqlformat",
@@ -2631,68 +2647,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
-name = "standback"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version 0.2.3",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "stringprep"
@@ -2815,51 +2773,20 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
-dependencies = [
- "const_fn",
- "libc",
- "standback",
- "stdweb",
- "time-macros",
- "version_check",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
 dependencies = [
- "itoa",
+ "itoa 0.4.7",
  "libc",
+ "time-macros",
 ]
 
 [[package]]
 name = "time-macros"
-version = "0.1.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
-dependencies = [
- "proc-macro-hack",
- "time-macros-impl",
-]
-
-[[package]]
-name = "time-macros-impl"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "standback",
- "syn",
-]
+checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
 
 [[package]]
 name = "tinyvec"
@@ -2878,15 +2805,14 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.8.1"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
+checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
 dependencies = [
- "autocfg 1.0.1",
  "bytes",
  "libc",
  "memchr",
- "mio",
+ "mio 0.7.13",
  "num_cpus",
  "once_cell",
  "parking_lot",
@@ -2898,9 +2824,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.4.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154794c8f499c2619acd19e839294703e9e32e7630ef5f46ea80d4ef0fbee5eb"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2930,16 +2856,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.7"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
+checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "log",
  "pin-project-lite",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2950,20 +2876,33 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.26"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
+checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
-name = "tracing-core"
-version = "0.1.18"
+name = "tracing-attributes"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90442985ee2f57c9e1b548ee72ae842f4a9a20e3f417cc38dbc5dc684d9bb4ee"
 dependencies = [
  "lazy_static",
 ]
@@ -3116,6 +3055,12 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -3278,18 +3223,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.7.0+zstd.1.4.9"
+version = "0.10.0+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9428752481d8372e15b1bf779ea518a179ad6c771cca2d2c60e4fbff3cc2cd52"
+checksum = "3b1365becbe415f3f0fcd024e2f7b45bacfb5bdd055f0dc113571394114e7bdd"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "3.1.0+zstd.1.4.9"
+version = "4.1.4+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa1926623ad7fe406e090555387daf73db555b948134b4d73eac5eb08fb666d"
+checksum = "2f7cd17c9af1a4d6c24beb1cc54b17e2ef7b593dc92f19e9d9acad8b182bbaee"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -3297,9 +3242,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.5.0+zstd.1.4.9"
+version = "1.6.3+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e6c094340240369025fc6b731b054ee2a834328fa584310ac96aa4baebdc465"
+checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
 dependencies = [
  "cc",
  "libc",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -16,8 +16,8 @@ members = [
 ]
 
 [dependencies]
-actix-cors = "0.6.0-beta.3"
-actix-web = "4.0.0-beta.10"
+actix-cors = "0.6.1"
+actix-web = "4.0.1"
 env_logger = "0.9.0"
 log = "0.4.14"
 route-bucket-controller = { path = "./controller" }

--- a/api/controller/Cargo.toml
+++ b/api/controller/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-service = "2.0.0"
-actix-web = "4.0.0-beta.10"
-actix-web-httpauth = "0.6.0-beta.3"
+actix-service = "2.0.1"
+actix-web = "4.0.1"
+actix-web-httpauth = "0.6.0"
 derive_more = "0.99.16"
 route-bucket-domain = { path = "../domain" }
 route-bucket-usecase = { path = "../usecase" }

--- a/api/controller/Cargo.toml
+++ b/api/controller/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 actix-service = "2.0.1"
 actix-web = "4.0.1"
 actix-web-httpauth = "0.6.0"
+actix-web-validator = "3.0.0"
 derive_more = "0.99.16"
 route-bucket-domain = { path = "../domain" }
 route-bucket-usecase = { path = "../usecase" }

--- a/api/controller/src/lib.rs
+++ b/api/controller/src/lib.rs
@@ -16,7 +16,7 @@ pub trait AddService: Sized {
         F: HttpServiceFactory + 'static;
 }
 
-impl<T, B> AddService for App<T, B>
+impl<T, B> AddService for App<T>
 where
     B: MessageBody,
     T: ServiceFactory<

--- a/api/controller/src/route.rs
+++ b/api/controller/src/route.rs
@@ -12,8 +12,13 @@ use crate::AddService;
 async fn get<U: 'static + RouteUseCase>(
     usecase: web::Data<U>,
     id: web::Path<RouteId>,
+    auth: Option<BearerAuth>,
 ) -> Result<HttpResponse> {
-    Ok(HttpResponse::Ok().json(usecase.find(id.as_ref()).await?))
+    Ok(HttpResponse::Ok().json(
+        usecase
+            .find(id.as_ref(), auth.map(|auth| auth.token().to_string()))
+            .await?,
+    ))
 }
 
 async fn get_all<U: 'static + RouteUseCase>(usecase: web::Data<U>) -> Result<HttpResponse> {

--- a/api/controller/src/route.rs
+++ b/api/controller/src/route.rs
@@ -27,9 +27,17 @@ async fn get_all<U: 'static + RouteUseCase>(usecase: web::Data<U>) -> Result<Htt
 
 async fn get_search<U: 'static + RouteUseCase>(
     usecase: web::Data<U>,
+    auth: Option<BearerAuth>,
     query: web::Query<RouteSearchQuery>,
 ) -> Result<HttpResponse> {
-    Ok(HttpResponse::Ok().json(usecase.search(query.into_inner()).await?))
+    Ok(HttpResponse::Ok().json(
+        usecase
+            .search(
+                query.into_inner(),
+                auth.map(|auth| auth.token().to_string()),
+            )
+            .await?,
+    ))
 }
 
 async fn get_gpx<U: 'static + RouteUseCase>(

--- a/api/controller/src/route.rs
+++ b/api/controller/src/route.rs
@@ -1,4 +1,4 @@
-use actix_web::{dev, http, web, HttpResponse, Result};
+use actix_web::{http, web, HttpResponse, Result};
 
 use actix_web_httpauth::extractors::bearer::BearerAuth;
 use route_bucket_domain::model::route::{RouteId, RouteSearchQuery};
@@ -52,7 +52,7 @@ async fn get_gpx<U: 'static + RouteUseCase>(
             format!("attachment;filename=\"{}.gpx\"", gpx_resp.name()),
         ))
         .content_type("application/gpx+xml")
-        .body(dev::Body::from_slice(gpx_resp.as_slice())))
+        .body(gpx_resp.into_data()))
 }
 
 async fn post<U: 'static + RouteUseCase>(

--- a/api/domain/Cargo.toml
+++ b/api/domain/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 async-trait = "0.1.50"
 chrono = "0.4.19"
-derivative = { version = "2.2.0", optional = true }
+derivative = "2.2.0"
 derive_more = "0.99.16"
 futures = "0.3.16"
 geo = "0.17.1"
@@ -33,10 +33,9 @@ strum = { version = "0.22.0", features = ["derive"] }
 validator = { version = "0.14.0", features = ["derive"] }
 
 [dev-dependencies]
-derivative = "2.2.0"
 rstest = "0.11.0"
 
 [features]
-fixtures = ["derivative", "rstest"]
+fixtures = ["rstest"]
 mocking = ["mockall"]
 testing = ["fixtures", "mocking"]

--- a/api/domain/src/model.rs
+++ b/api/domain/src/model.rs
@@ -1,3 +1,4 @@
+pub mod permission;
 pub mod route;
 pub mod types;
 pub mod user;

--- a/api/domain/src/model.rs
+++ b/api/domain/src/model.rs
@@ -6,6 +6,7 @@ pub mod user;
 #[cfg(feature = "fixtures")]
 pub mod fixtures {
     pub mod route {
+        pub use crate::model::permission::tests::PermissionFixtures;
         pub use crate::model::route::bounding_box::tests::BoundingBoxFixture;
         pub use crate::model::route::coordinate::tests::CoordinateFixtures;
         pub use crate::model::route::route_gpx::tests::RouteGpxFixtures;

--- a/api/domain/src/model/permission.rs
+++ b/api/domain/src/model/permission.rs
@@ -16,11 +16,13 @@ use super::{route::RouteId, user::UserId};
     strum::Display,
     strum::EnumString,
 )]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[strum(serialize_all = "snake_case")]
 pub enum PermissionType {
+    None,
     Viewer,
     Editor,
+    Owner,
 }
 
 #[derive(Clone, Debug, From, Into, Getters)]

--- a/api/domain/src/model/permission.rs
+++ b/api/domain/src/model/permission.rs
@@ -4,6 +4,9 @@ use serde::{Deserialize, Serialize};
 
 use super::{route::RouteId, user::UserId};
 
+#[cfg(any(test, feature = "fixtures"))]
+use derivative::Derivative;
+
 #[derive(
     Copy,
     Clone,
@@ -27,9 +30,30 @@ pub enum PermissionType {
 
 #[derive(Clone, Debug, From, Into, Getters)]
 #[get = "pub"]
-#[cfg_attr(any(test, feature = "fixtures"), derive(PartialEq))]
+#[cfg_attr(any(test, feature = "fixtures"), derive(Derivative))]
+#[cfg_attr(any(test, feature = "fixtures"), derivative(PartialEq))]
 pub struct Permission {
+    #[cfg_attr(any(test, feature = "fixtures"), derivative(PartialEq = "ignore"))]
     route_id: RouteId,
     user_id: UserId,
     permission_type: PermissionType,
+}
+
+#[cfg(any(test, feature = "fixtures"))]
+pub(crate) mod tests {
+    use crate::model::user::tests::UserIdFixtures;
+
+    use super::*;
+
+    pub trait PermissionFixtures {
+        fn porzingis_viewer_permission() -> Permission {
+            Permission {
+                route_id: RouteId::new(),
+                user_id: UserId::porzingis(),
+                permission_type: PermissionType::Viewer,
+            }
+        }
+    }
+
+    impl PermissionFixtures for Permission {}
 }

--- a/api/domain/src/model/permission.rs
+++ b/api/domain/src/model/permission.rs
@@ -46,6 +46,22 @@ pub(crate) mod tests {
     use super::*;
 
     pub trait PermissionFixtures {
+        fn doncic_owner_permission() -> Permission {
+            Permission {
+                route_id: RouteId::new(),
+                user_id: UserId::doncic(),
+                permission_type: PermissionType::Owner,
+            }
+        }
+
+        fn doncic_viewer_permission() -> Permission {
+            Permission {
+                route_id: RouteId::new(),
+                user_id: UserId::doncic(),
+                permission_type: PermissionType::Viewer,
+            }
+        }
+
         fn porzingis_viewer_permission() -> Permission {
             Permission {
                 route_id: RouteId::new(),

--- a/api/domain/src/model/permission.rs
+++ b/api/domain/src/model/permission.rs
@@ -1,0 +1,32 @@
+use derive_more::{From, Into};
+use getset::Getters;
+use serde::{Deserialize, Serialize};
+
+use super::{route::RouteId, user::UserId};
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    PartialOrd,
+    PartialEq,
+    Eq,
+    strum::Display,
+    strum::EnumString,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum PermissionType {
+    Viewer,
+    Editor,
+}
+
+#[derive(Clone, Debug, From, Into, Getters)]
+#[get = "pub"]
+pub struct Permission {
+    route_id: RouteId,
+    user_id: UserId,
+    permission_type: PermissionType,
+}

--- a/api/domain/src/model/permission.rs
+++ b/api/domain/src/model/permission.rs
@@ -27,6 +27,7 @@ pub enum PermissionType {
 
 #[derive(Clone, Debug, From, Into, Getters)]
 #[get = "pub"]
+#[cfg_attr(any(test, feature = "fixtures"), derive(PartialEq))]
 pub struct Permission {
     route_id: RouteId,
     user_id: UserId,

--- a/api/domain/src/model/route.rs
+++ b/api/domain/src/model/route.rs
@@ -99,18 +99,16 @@ impl Route {
         Ok(())
     }
 
-    // methods from SegmentList ( No tests for them! )
-
-    pub fn calc_elevation_gain(&self) -> (Elevation, Elevation) {
-        self.seg_list.calc_elevation_gain()
+    pub fn reflect_update_on_seg_list_to_info(&mut self) -> ApplicationResult<()> {
+        let (asc_gain, desc_gain) = self.seg_list.calc_elevation_gain();
+        self.info.ascent_elevation_gain = asc_gain;
+        self.info.descent_elevation_gain = desc_gain;
+        self.info.total_distance = self.seg_list.get_total_distance()?;
+        Ok(())
     }
 
     pub fn attach_distance_from_start(&mut self) {
         self.seg_list.attach_distance_from_start()
-    }
-
-    pub fn get_total_distance(&self) -> ApplicationResult<Distance> {
-        self.seg_list.get_total_distance()
     }
 
     pub fn gather_waypoints(&self) -> Vec<Coordinate> {

--- a/api/domain/src/model/route.rs
+++ b/api/domain/src/model/route.rs
@@ -105,7 +105,7 @@ impl Route {
         self.seg_list.calc_elevation_gain()
     }
 
-    pub fn attach_distance_from_start(&mut self) -> ApplicationResult<()> {
+    pub fn attach_distance_from_start(&mut self) {
         self.seg_list.attach_distance_from_start()
     }
 

--- a/api/domain/src/model/route.rs
+++ b/api/domain/src/model/route.rs
@@ -99,16 +99,15 @@ impl Route {
         Ok(())
     }
 
-    pub fn reflect_update_on_seg_list_to_info(&mut self) -> ApplicationResult<()> {
+    pub fn calc_route_features_from_seg_list(&mut self) -> ApplicationResult<()> {
+        self.seg_list.attach_distance_from_start();
+
         let (asc_gain, desc_gain) = self.seg_list.calc_elevation_gain();
         self.info.ascent_elevation_gain = asc_gain;
         self.info.descent_elevation_gain = desc_gain;
         self.info.total_distance = self.seg_list.get_total_distance()?;
-        Ok(())
-    }
 
-    pub fn attach_distance_from_start(&mut self) {
-        self.seg_list.attach_distance_from_start()
+        Ok(())
     }
 
     pub fn gather_waypoints(&self) -> Vec<Coordinate> {
@@ -143,6 +142,19 @@ pub(crate) mod tests {
     #[fixture]
     fn full_route() -> Route {
         Route::yokohama_to_chiba_via_tokyo()
+    }
+
+    #[fixture]
+    fn full_route_filled() -> Route {
+        Route {
+            info: RouteInfo::yokohama_to_chiba_via_tokyo(),
+            ..Route::yokohama_to_chiba_via_tokyo_filled(true, true)
+        }
+    }
+
+    #[fixture]
+    fn full_route_filled_but_yet_to_calc_features() -> Route {
+        Route::yokohama_to_chiba_via_tokyo_filled(true, false)
     }
 
     #[fixture]
@@ -236,10 +248,19 @@ pub(crate) mod tests {
         ))
     }
 
-    macro_rules! init_route {
+    #[rstest]
+    fn can_calc_route_features_from_seg_list(
+        #[from(full_route_filled_but_yet_to_calc_features)] mut route: Route,
+        #[from(full_route_filled)] expected: Route,
+    ) {
+        route.calc_route_features_from_seg_list().unwrap();
+        assert_eq!(route, expected)
+    }
+
+    macro_rules! init_empty_route {
         ($op_num:expr, $op_list_name:ident, $seg_list_name:ident) => {
             Route {
-                info: RouteInfo::route0($op_num),
+                info: RouteInfo::empty_route0($op_num),
                 op_list: Operation::$op_list_name(),
                 seg_list: SegmentList::$seg_list_name(false, false, true),
             }
@@ -249,57 +270,69 @@ pub(crate) mod tests {
     pub trait RouteFixtures {
         fn empty() -> Route {
             Route {
-                info: RouteInfo::route0(0),
+                info: RouteInfo::empty_route0(0),
                 op_list: Vec::new(),
                 seg_list: SegmentList::empty(),
             }
         }
 
         fn yokohama() -> Route {
-            init_route!(1, after_add_yokohama_op_list, yokohama)
+            init_empty_route!(1, after_add_yokohama_op_list, yokohama)
         }
 
         fn yokohama_to_chiba() -> Route {
-            init_route!(2, after_add_chiba_op_list, yokohama_to_chiba)
+            init_empty_route!(2, after_add_chiba_op_list, yokohama_to_chiba)
         }
 
         fn yokohama_to_chiba_via_tokyo() -> Route {
-            init_route!(3, after_add_tokyo_op_list, yokohama_to_chiba_via_tokyo)
+            init_empty_route!(3, after_add_tokyo_op_list, yokohama_to_chiba_via_tokyo)
         }
 
         fn yokohama_to_chiba_after_remove() -> Route {
-            init_route!(4, after_remove_tokyo_op_list, yokohama_to_chiba)
+            init_empty_route!(4, after_remove_tokyo_op_list, yokohama_to_chiba)
         }
 
         fn yokohama_to_chiba_after_undo() -> Route {
-            init_route!(2, after_add_tokyo_op_list, yokohama_to_chiba)
+            init_empty_route!(2, after_add_tokyo_op_list, yokohama_to_chiba)
         }
 
         fn yokohama_to_tokyo() -> Route {
-            init_route!(3, after_move_chiba_op_list, yokohama_to_tokyo)
+            init_empty_route!(3, after_move_chiba_op_list, yokohama_to_tokyo)
         }
 
-        fn yokohama_to_chiba_filled(set_ele: bool, set_dist: bool) -> Route {
+        fn yokohama_to_chiba_filled(set_ele: bool, set_features: bool) -> Route {
             Route::new(
-                RouteInfo::route0(2),
+                if set_features {
+                    RouteInfo::yokohama_to_chiba()
+                } else {
+                    RouteInfo::empty_route0(2)
+                },
                 Operation::after_add_tokyo_op_list(),
-                SegmentList::yokohama_to_chiba(set_ele, set_dist, false),
+                SegmentList::yokohama_to_chiba(set_ele, set_features, false),
             )
         }
 
-        fn yokohama_to_chiba_via_tokyo_filled(set_ele: bool, set_dist: bool) -> Route {
+        fn yokohama_to_chiba_via_tokyo_filled(set_ele: bool, set_features: bool) -> Route {
             Route::new(
-                RouteInfo::route0(3),
+                if set_features {
+                    RouteInfo::yokohama_to_chiba_via_tokyo()
+                } else {
+                    RouteInfo::empty_route0(3)
+                },
                 Operation::after_add_tokyo_op_list(),
-                SegmentList::yokohama_to_chiba_via_tokyo(set_ele, set_dist, false),
+                SegmentList::yokohama_to_chiba_via_tokyo(set_ele, set_features, false),
             )
         }
 
-        fn yokohama_to_tokyo_filled(set_ele: bool, set_dist: bool) -> Route {
+        fn yokohama_to_tokyo_filled(set_ele: bool, set_features: bool) -> Route {
             Route::new(
-                RouteInfo::route0(3),
+                if set_features {
+                    RouteInfo::yokohama_to_tokyo()
+                } else {
+                    RouteInfo::empty_route0(3)
+                },
                 Operation::after_move_chiba_op_list(),
-                SegmentList::yokohama_to_tokyo(set_ele, set_dist, false),
+                SegmentList::yokohama_to_tokyo(set_ele, set_features, false),
             )
         }
     }

--- a/api/domain/src/model/route/route_gpx.rs
+++ b/api/domain/src/model/route/route_gpx.rs
@@ -160,20 +160,13 @@ impl TryFrom<Route> for RouteGpx {
 pub(crate) mod tests {
     use rstest::{fixture, rstest};
 
-    use crate::model::route::route_info::tests::RouteInfoFixtures;
-    use crate::model::route::segment_list::tests::OperationFixtures;
-    use crate::model::route::segment_list::tests::SegmentListFixture;
-    use crate::model::route::segment_list::Operation;
+    use crate::model::route::tests::RouteFixtures;
 
     use super::*;
 
     #[fixture]
     fn route0() -> Route {
-        Route {
-            info: RouteInfo::route0(3),
-            op_list: Operation::after_add_tokyo_op_list(),
-            seg_list: SegmentList::yokohama_to_chiba_via_tokyo(true, true, false),
-        }
+        Route::yokohama_to_chiba_via_tokyo_filled(true, true)
     }
 
     #[fixture]

--- a/api/domain/src/model/route/route_gpx.rs
+++ b/api/domain/src/model/route/route_gpx.rs
@@ -89,8 +89,8 @@ impl RouteGpx {
         &self.name
     }
 
-    pub fn as_slice(&self) -> &[u8] {
-        self.data.as_slice()
+    pub fn into_data(self) -> Vec<u8> {
+        self.data
     }
 }
 

--- a/api/domain/src/model/route/route_info.rs
+++ b/api/domain/src/model/route/route_info.rs
@@ -124,6 +124,13 @@ pub(crate) mod tests {
         fn yokohama_to_tokyo() -> RouteInfo {
             RouteInfo::filled_route0(3, 0, 26936.42633640023, 3)
         }
+
+        fn public_route0() -> RouteInfo {
+            RouteInfo {
+                is_public: true,
+                ..Self::empty_route0(0)
+            }
+        }
     }
 
     impl RouteInfoFixtures for RouteInfo {}

--- a/api/domain/src/model/route/route_info.rs
+++ b/api/domain/src/model/route/route_info.rs
@@ -1,33 +1,64 @@
+use chrono::{DateTime, Utc};
+use derivative::Derivative;
 use getset::Getters;
 use serde::{Deserialize, Serialize};
 
-#[cfg(any(test, feature = "fixtures"))]
-use derivative::Derivative;
-
 use crate::model::user::UserId;
 
-use super::RouteId;
+use super::{Distance, Elevation, RouteId};
 
-#[derive(Clone, Debug, Getters, Deserialize, Serialize)]
+#[derive(Clone, Debug, Getters, Derivative, Deserialize, Serialize)]
 #[get = "pub"]
-#[cfg_attr(any(test, feature = "fixtures"), derive(Derivative))]
+#[derivative(Default)]
 #[cfg_attr(any(test, feature = "fixtures"), derivative(PartialEq))]
 pub struct RouteInfo {
+    #[derivative(Default(value = "RouteId::new()"))]
     #[cfg_attr(any(test, feature = "fixtures"), derivative(PartialEq = "ignore"))]
     pub(super) id: RouteId,
     pub(super) name: String,
+    #[derivative(Default(value = "UserId::from(\"\".to_string())"))]
     pub(super) owner_id: UserId,
     #[serde(skip_serializing)]
     pub(super) op_num: usize,
+    pub(super) ascent_elevation_gain: Elevation,
+    pub(super) descent_elevation_gain: Elevation,
+    pub(super) total_distance: Distance,
+    #[derivative(Default(value = "Utc::now()"))]
+    pub(super) created_at: DateTime<Utc>,
+    #[derivative(Default(value = "Utc::now()"))]
+    pub(super) updated_at: DateTime<Utc>,
 }
 
 impl RouteInfo {
-    pub fn new(id: RouteId, name: &str, owner_id: UserId, op_num: usize) -> RouteInfo {
+    pub fn new(name: &str, owner_id: UserId) -> RouteInfo {
+        RouteInfo {
+            name: name.to_string(),
+            owner_id,
+            ..Default::default()
+        }
+    }
+
+    pub fn with_details(
+        id: RouteId,
+        name: &str,
+        owner_id: UserId,
+        op_num: usize,
+        ascent_elevation_gain: Elevation,
+        descent_elevation_gain: Elevation,
+        total_distance: Distance,
+        created_at: DateTime<Utc>,
+        updated_at: DateTime<Utc>,
+    ) -> RouteInfo {
         RouteInfo {
             id,
             name: name.to_string(),
             owner_id,
             op_num,
+            ascent_elevation_gain,
+            descent_elevation_gain,
+            total_distance,
+            created_at,
+            updated_at,
         }
     }
 

--- a/api/domain/src/model/route/route_info.rs
+++ b/api/domain/src/model/route/route_info.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use derivative::Derivative;
+use derive_more::From;
 use getset::Getters;
 use serde::{Deserialize, Serialize};
 
@@ -7,7 +8,7 @@ use crate::model::user::UserId;
 
 use super::{Distance, Elevation, RouteId};
 
-#[derive(Clone, Debug, Getters, Derivative, Deserialize, Serialize)]
+#[derive(Clone, Debug, From, Getters, Derivative, Deserialize, Serialize)]
 #[get = "pub"]
 #[derivative(Default)]
 #[cfg_attr(any(test, feature = "fixtures"), derivative(PartialEq))]
@@ -35,30 +36,6 @@ impl RouteInfo {
             name: name.to_string(),
             owner_id,
             ..Default::default()
-        }
-    }
-
-    pub fn with_details(
-        id: RouteId,
-        name: &str,
-        owner_id: UserId,
-        op_num: usize,
-        ascent_elevation_gain: Elevation,
-        descent_elevation_gain: Elevation,
-        total_distance: Distance,
-        created_at: DateTime<Utc>,
-        updated_at: DateTime<Utc>,
-    ) -> RouteInfo {
-        RouteInfo {
-            id,
-            name: name.to_string(),
-            owner_id,
-            op_num,
-            ascent_elevation_gain,
-            descent_elevation_gain,
-            total_distance,
-            created_at,
-            updated_at,
         }
     }
 

--- a/api/domain/src/model/route/route_info.rs
+++ b/api/domain/src/model/route/route_info.rs
@@ -24,6 +24,7 @@ pub struct RouteInfo {
     pub(super) ascent_elevation_gain: Elevation,
     pub(super) descent_elevation_gain: Elevation,
     pub(super) total_distance: Distance,
+    pub(super) is_public: bool,
     #[derivative(Default(value = "chrono::MIN_DATETIME"))]
     pub(super) created_at: DateTime<Utc>,
     #[derivative(Default(value = "chrono::MIN_DATETIME"))]
@@ -31,10 +32,11 @@ pub struct RouteInfo {
 }
 
 impl RouteInfo {
-    pub fn new(name: &str, owner_id: UserId) -> RouteInfo {
+    pub fn new(name: &str, owner_id: UserId, is_public: bool) -> RouteInfo {
         RouteInfo {
             name: name.to_string(),
             owner_id,
+            is_public,
             ..Default::default()
         }
     }

--- a/api/domain/src/model/route/route_info.rs
+++ b/api/domain/src/model/route/route_info.rs
@@ -23,9 +23,9 @@ pub struct RouteInfo {
     pub(super) ascent_elevation_gain: Elevation,
     pub(super) descent_elevation_gain: Elevation,
     pub(super) total_distance: Distance,
-    #[derivative(Default(value = "Utc::now()"))]
+    #[derivative(Default(value = "chrono::MIN_DATETIME"))]
     pub(super) created_at: DateTime<Utc>,
-    #[derivative(Default(value = "Utc::now()"))]
+    #[derivative(Default(value = "chrono::MIN_DATETIME"))]
     pub(super) updated_at: DateTime<Utc>,
 }
 
@@ -74,6 +74,7 @@ impl RouteInfo {
 #[cfg(any(test, feature = "fixtures"))]
 pub(crate) mod tests {
     use rstest::{fixture, rstest};
+    use std::convert::TryFrom;
 
     use crate::model::user::tests::UserIdFixtures;
 
@@ -81,12 +82,12 @@ pub(crate) mod tests {
 
     #[fixture]
     fn route0_without_op() -> RouteInfo {
-        RouteInfo::route0(0)
+        RouteInfo::empty_route0(0)
     }
 
     #[fixture]
     fn route0_op2() -> RouteInfo {
-        RouteInfo::route0(2)
+        RouteInfo::empty_route0(2)
     }
 
     #[rstest]
@@ -102,22 +103,47 @@ pub(crate) mod tests {
     }
 
     pub trait RouteInfoFixtures {
-        fn route0(op_num: usize) -> RouteInfo {
+        fn empty_route0(op_num: usize) -> RouteInfo {
             RouteInfo {
                 id: RouteId::new(),
                 name: "route0".into(),
                 owner_id: UserId::doncic(),
                 op_num,
+                ..Default::default()
             }
         }
 
-        fn route1(op_num: usize) -> RouteInfo {
+        fn filled_route0(
+            asc_gain: i32,
+            desc_gain: i32,
+            total_dist: f64,
+            op_num: usize,
+        ) -> RouteInfo {
             RouteInfo {
-                id: RouteId::new(),
-                name: "route1".into(),
-                owner_id: UserId::doncic(),
-                op_num,
+                ascent_elevation_gain: Elevation::try_from(asc_gain).unwrap(),
+                descent_elevation_gain: Elevation::try_from(desc_gain).unwrap(),
+                total_distance: Distance::try_from(total_dist).unwrap(),
+                ..Self::empty_route0(op_num)
             }
+        }
+
+        fn empty_route1(op_num: usize) -> RouteInfo {
+            RouteInfo {
+                name: "route1".into(),
+                ..Self::empty_route0(op_num)
+            }
+        }
+
+        fn yokohama_to_chiba() -> RouteInfo {
+            RouteInfo::filled_route0(10, 0, 46779.709825324135, 2)
+        }
+
+        fn yokohama_to_chiba_via_tokyo() -> RouteInfo {
+            RouteInfo::filled_route0(10, 0, 58759.973932514884, 3)
+        }
+
+        fn yokohama_to_tokyo() -> RouteInfo {
+            RouteInfo::filled_route0(3, 0, 26936.42633640023, 3)
         }
     }
 

--- a/api/domain/src/model/route/search_query.rs
+++ b/api/domain/src/model/route/search_query.rs
@@ -2,9 +2,15 @@ use serde::{Deserialize, Serialize};
 
 use crate::model::user::UserId;
 
+use super::RouteId;
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "fixtures"), derive(PartialEq))]
 pub struct RouteSearchQuery {
+    #[serde(skip_deserializing)]
+    pub ids: Option<Vec<RouteId>>,
+    #[serde(skip_deserializing)]
+    pub caller_id: Option<UserId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub owner_id: Option<UserId>,
     #[serde(default)]

--- a/api/domain/src/model/route/search_query.rs
+++ b/api/domain/src/model/route/search_query.rs
@@ -31,8 +31,10 @@ pub(crate) mod tests {
     use super::*;
 
     pub trait RouteSearchQueryFixtures {
-        fn search_guest() -> RouteSearchQuery {
+        fn search_guest(ids: Option<Vec<RouteId>>, caller_id: Option<UserId>) -> RouteSearchQuery {
             RouteSearchQuery {
+                ids,
+                caller_id,
                 owner_id: Some(UserId::doncic()),
                 ..Default::default()
             }

--- a/api/domain/src/model/route/search_query.rs
+++ b/api/domain/src/model/route/search_query.rs
@@ -16,6 +16,8 @@ pub struct RouteSearchQuery {
     #[serde(default)]
     pub page_offset: usize,
     pub page_size: Option<usize>,
+    #[serde(default)]
+    pub is_editable: bool,
 }
 
 impl RouteSearchQuery {
@@ -31,11 +33,18 @@ pub(crate) mod tests {
     use super::*;
 
     pub trait RouteSearchQueryFixtures {
-        fn search_guest(ids: Option<Vec<RouteId>>, caller_id: Option<UserId>) -> RouteSearchQuery {
+        fn doncic_query(ids: Vec<RouteId>, is_editable: bool) -> RouteSearchQuery {
             RouteSearchQuery {
-                ids,
-                caller_id,
+                ids: Some(ids),
+                caller_id: Some(UserId::doncic()),
+                ..Self::doncic_request(is_editable)
+            }
+        }
+
+        fn doncic_request(is_editable: bool) -> RouteSearchQuery {
+            RouteSearchQuery {
                 owner_id: Some(UserId::doncic()),
+                is_editable,
                 ..Default::default()
             }
         }

--- a/api/domain/src/model/route/search_query.rs
+++ b/api/domain/src/model/route/search_query.rs
@@ -1,16 +1,18 @@
 use serde::{Deserialize, Serialize};
+use validator::Validate;
 
 use crate::model::user::UserId;
 
 use super::RouteId;
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Validate)]
 #[cfg_attr(any(test, feature = "fixtures"), derive(PartialEq))]
 pub struct RouteSearchQuery {
     #[serde(skip_deserializing)]
     pub ids: Option<Vec<RouteId>>,
     #[serde(skip_deserializing)]
     pub caller_id: Option<UserId>,
+    #[validate]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub owner_id: Option<UserId>,
     #[serde(default)]

--- a/api/domain/src/model/route/types.rs
+++ b/api/domain/src/model/route/types.rs
@@ -25,6 +25,7 @@ pub type Distance = NumericValueObject<OrderedFloat<f64>, 0>;
 
 /// Value Object for BigDecimal type
 #[derive(
+    Default,
     Add,
     AddAssign,
     Sub,
@@ -39,7 +40,7 @@ pub type Distance = NumericValueObject<OrderedFloat<f64>, 0>;
     Serialize,
     Deserialize,
 )]
-pub struct NumericValueObject<T, const MAX_ABS: u32>(T);
+pub struct NumericValueObject<T: Default, const MAX_ABS: u32>(T);
 
 impl<const MAX_ABS: u32> NumericValueObject<i32, MAX_ABS> {
     pub fn value(&self) -> i32 {
@@ -53,7 +54,9 @@ impl<const MAX_ABS: u32> NumericValueObject<OrderedFloat<f64>, MAX_ABS> {
     }
 }
 
-impl<T: Copy + FromPrimitive + Bounded, const MAX_ABS: u32> NumericValueObject<T, MAX_ABS> {
+impl<T: Copy + Default + FromPrimitive + Bounded, const MAX_ABS: u32>
+    NumericValueObject<T, MAX_ABS>
+{
     pub fn max_value() -> Self {
         Self(if MAX_ABS == 0 {
             T::max_value()

--- a/api/domain/src/model/types.rs
+++ b/api/domain/src/model/types.rs
@@ -6,10 +6,11 @@ use route_bucket_utils::ApplicationError;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
-#[derive(Default, Debug, Clone, Display, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Display, Serialize, Deserialize, PartialEq, Eq, Validate)]
 #[display(fmt = "{}", id)]
 #[serde(transparent)]
 pub struct NanoId<T, const LEN: usize> {
+    #[validate(length(min = "LEN", max = "LEN"))]
     id: String,
     #[serde(skip)]
     _phantom: PhantomData<T>,

--- a/api/domain/src/repository.rs
+++ b/api/domain/src/repository.rs
@@ -2,14 +2,16 @@ use async_trait::async_trait;
 use futures::future::BoxFuture;
 use route_bucket_utils::ApplicationResult;
 
+pub use permission::{CallPermissionRepository, PermissionRepository};
 pub use route::{CallRouteRepository, RouteRepository};
 pub use user::{CallUserRepository, UserRepository};
 
 #[cfg(feature = "mocking")]
-pub use route::MockRouteRepository;
-#[cfg(feature = "mocking")]
-pub use user::MockUserRepository;
+pub use self::{
+    permission::MockPermissionRepository, route::MockRouteRepository, user::MockUserRepository,
+};
 
+pub(crate) mod permission;
 pub(crate) mod route;
 pub(crate) mod user;
 

--- a/api/domain/src/repository/permission.rs
+++ b/api/domain/src/repository/permission.rs
@@ -18,6 +18,12 @@ pub trait PermissionRepository: Repository {
         conn: &<Self as Repository>::Connection,
     ) -> ApplicationResult<PermissionType>;
 
+    async fn find_by_user_id(
+        &self,
+        user_id: &UserId,
+        conn: &<Self as Repository>::Connection,
+    ) -> ApplicationResult<Vec<Permission>>;
+
     async fn authorize_user(
         &self,
         route_info: &RouteInfo,
@@ -77,6 +83,8 @@ mockall::mock! {
     #[async_trait]
     impl PermissionRepository for PermissionRepository {
         async fn find_type(&self, route_info: &RouteInfo, user_id: Option<UserId>, conn: &super::MockConnection) -> ApplicationResult<PermissionType>;
+
+        async fn find_by_user_id(&self, user_id: &UserId, conn: &super::MockConnection) -> ApplicationResult<Vec<Permission>>;
 
         async fn authorize_user(&self, route_info: &RouteInfo, user_id: Option<UserId>, target_type: PermissionType, conn: &super::MockConnection) -> ApplicationResult<()>;
 

--- a/api/domain/src/repository/permission.rs
+++ b/api/domain/src/repository/permission.rs
@@ -1,0 +1,61 @@
+use async_trait::async_trait;
+use route_bucket_utils::ApplicationResult;
+
+use crate::model::{
+    permission::{Permission, PermissionType},
+    route::{RouteId, RouteInfo},
+    user::UserId,
+};
+
+use super::Repository;
+
+#[async_trait]
+pub trait PermissionRepository: Repository {
+    async fn authorize_user(
+        &self,
+        route_info: &RouteInfo,
+        user_id: &UserId,
+        target_type: PermissionType,
+        conn: &<Self as Repository>::Connection,
+    ) -> ApplicationResult<()>;
+
+    async fn insert_or_update(
+        &self,
+        permission: &Permission,
+        conn: &<Self as Repository>::Connection,
+    ) -> ApplicationResult<()>;
+
+    async fn delete(
+        &self,
+        route_id: &RouteId,
+        user_id: &UserId,
+        conn: &<Self as Repository>::Connection,
+    ) -> ApplicationResult<()>;
+}
+
+pub trait CallPermissionRepository {
+    type PermissionRepository: PermissionRepository;
+
+    fn permission_repository(&self) -> &Self::PermissionRepository;
+}
+
+#[cfg(feature = "mocking")]
+mockall::mock! {
+    pub PermissionRepository {}
+
+    #[async_trait]
+    impl Repository for PermissionRepository {
+        type Connection = super::MockConnection;
+
+        async fn get_connection(&self) -> ApplicationResult<super::MockConnection>;
+    }
+
+    #[async_trait]
+    impl PermissionRepository for PermissionRepository {
+        async fn authorize_user(&self, route_info: &RouteInfo, user_id: &UserId, target_type: PermissionType, conn: &super::MockConnection) -> ApplicationResult<()>;
+
+        async fn insert_or_update(&self, permission: &Permission, conn: &super::MockConnection) -> ApplicationResult<()>;
+
+        async fn delete(&self, route_id: &RouteId, user_id: &UserId, conn: &super::MockConnection) -> ApplicationResult<()>;
+    }
+}

--- a/api/domain/src/repository/permission.rs
+++ b/api/domain/src/repository/permission.rs
@@ -21,6 +21,7 @@ pub trait PermissionRepository: Repository {
     async fn find_by_user_id(
         &self,
         user_id: &UserId,
+        target_type: PermissionType,
         conn: &<Self as Repository>::Connection,
     ) -> ApplicationResult<Vec<Permission>>;
 
@@ -84,7 +85,7 @@ mockall::mock! {
     impl PermissionRepository for PermissionRepository {
         async fn find_type(&self, route_info: &RouteInfo, user_id: Option<UserId>, conn: &super::MockConnection) -> ApplicationResult<PermissionType>;
 
-        async fn find_by_user_id(&self, user_id: &UserId, conn: &super::MockConnection) -> ApplicationResult<Vec<Permission>>;
+        async fn find_by_user_id(&self, user_id: &UserId, target_type: PermissionType, conn: &super::MockConnection) -> ApplicationResult<Vec<Permission>>;
 
         async fn authorize_user(&self, route_info: &RouteInfo, user_id: Option<UserId>, target_type: PermissionType, conn: &super::MockConnection) -> ApplicationResult<()>;
 

--- a/api/infrastructure/src/dto.rs
+++ b/api/infrastructure/src/dto.rs
@@ -1,4 +1,5 @@
 pub mod operation;
+pub mod permission;
 pub mod route;
 pub mod search_query;
 pub mod segment;

--- a/api/infrastructure/src/dto/permission.rs
+++ b/api/infrastructure/src/dto/permission.rs
@@ -1,0 +1,47 @@
+use std::str::FromStr;
+
+use getset::Getters;
+use route_bucket_domain::model::{
+    permission::{Permission, PermissionType},
+    route::RouteId,
+    user::UserId,
+};
+use route_bucket_utils::{ApplicationError, ApplicationResult};
+
+/// ルートのdto構造体
+#[derive(sqlx::FromRow, Getters)]
+#[get = "pub"]
+pub(crate) struct PermissionDto {
+    pub(crate) route_id: String,
+    pub(crate) user_id: String,
+    pub(crate) permission_type: String,
+}
+
+impl PermissionDto {
+    pub fn into_model(self) -> ApplicationResult<Permission> {
+        let Self {
+            user_id,
+            route_id,
+            permission_type,
+        } = self;
+        Ok(Permission::from((
+            RouteId::from_string(route_id),
+            UserId::from(user_id),
+            PermissionType::from_str(&permission_type).map_err(|e| {
+                ApplicationError::DataBaseError(format!(
+                    "Failed to parse permission.permission_type ({:?})",
+                    e
+                ))
+            })?,
+        )))
+    }
+
+    pub fn from_model(permission: &Permission) -> ApplicationResult<Self> {
+        let (route_id, user_id, permission_type) = permission.clone().into();
+        Ok(Self {
+            route_id: route_id.to_string(),
+            user_id: user_id.to_string(),
+            permission_type: permission_type.to_string(),
+        })
+    }
+}

--- a/api/infrastructure/src/dto/route.rs
+++ b/api/infrastructure/src/dto/route.rs
@@ -19,6 +19,7 @@ pub struct RouteDto {
     ascent_elevation_gain: u32,
     descent_elevation_gain: u32,
     total_distance: f64,
+    is_public: bool,
     created_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
 }
@@ -33,6 +34,7 @@ impl RouteDto {
             ascent_elevation_gain,
             descent_elevation_gain,
             total_distance,
+            is_public,
             created_at,
             updated_at,
         } = self;
@@ -44,6 +46,7 @@ impl RouteDto {
             Elevation::try_from(ascent_elevation_gain as i32)?,
             Elevation::try_from(descent_elevation_gain as i32)?,
             Distance::try_from(total_distance)?,
+            is_public,
             created_at,
             updated_at,
         )))
@@ -58,6 +61,7 @@ impl RouteDto {
             ascent_elevation_gain: route_info.ascent_elevation_gain().value() as u32,
             descent_elevation_gain: route_info.descent_elevation_gain().value() as u32,
             total_distance: route_info.total_distance().value(),
+            is_public: *route_info.is_public(),
             created_at: *route_info.created_at(),
             updated_at: *route_info.updated_at(),
         })

--- a/api/infrastructure/src/dto/route.rs
+++ b/api/infrastructure/src/dto/route.rs
@@ -1,6 +1,9 @@
+use std::convert::TryFrom;
+
+use chrono::{DateTime, Utc};
 use getset::Getters;
 use route_bucket_domain::model::{
-    route::{RouteId, RouteInfo},
+    route::{Distance, Elevation, RouteId, RouteInfo},
     user::UserId,
 };
 use route_bucket_utils::ApplicationResult;
@@ -13,6 +16,11 @@ pub struct RouteDto {
     name: String,
     owner_id: String,
     operation_pos: u32,
+    ascent_elevation_gain: u32,
+    descent_elevation_gain: u32,
+    total_distance: f64,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
 }
 
 impl RouteDto {
@@ -22,12 +30,22 @@ impl RouteDto {
             name,
             owner_id,
             operation_pos,
+            ascent_elevation_gain,
+            descent_elevation_gain,
+            total_distance,
+            created_at,
+            updated_at,
         } = self;
-        Ok(RouteInfo::new(
+        Ok(RouteInfo::with_details(
             RouteId::from_string(id),
             &name,
             UserId::from(owner_id),
             operation_pos as usize,
+            Elevation::try_from(ascent_elevation_gain as i32)?,
+            Elevation::try_from(descent_elevation_gain as i32)?,
+            Distance::try_from(total_distance)?,
+            created_at,
+            updated_at,
         ))
     }
 
@@ -37,6 +55,11 @@ impl RouteDto {
             name: route_info.name().clone(),
             owner_id: route_info.owner_id().to_string(),
             operation_pos: *route_info.op_num() as u32,
+            ascent_elevation_gain: route_info.ascent_elevation_gain().value() as u32,
+            descent_elevation_gain: route_info.descent_elevation_gain().value() as u32,
+            total_distance: route_info.total_distance().value(),
+            created_at: route_info.created_at().clone(),
+            updated_at: route_info.updated_at().clone(),
         })
     }
 }

--- a/api/infrastructure/src/dto/route.rs
+++ b/api/infrastructure/src/dto/route.rs
@@ -36,9 +36,9 @@ impl RouteDto {
             created_at,
             updated_at,
         } = self;
-        Ok(RouteInfo::with_details(
+        Ok(RouteInfo::from((
             RouteId::from_string(id),
-            &name,
+            name,
             UserId::from(owner_id),
             operation_pos as usize,
             Elevation::try_from(ascent_elevation_gain as i32)?,
@@ -46,7 +46,7 @@ impl RouteDto {
             Distance::try_from(total_distance)?,
             created_at,
             updated_at,
-        ))
+        )))
     }
 
     pub fn from_model(route_info: &RouteInfo) -> ApplicationResult<RouteDto> {
@@ -58,8 +58,8 @@ impl RouteDto {
             ascent_elevation_gain: route_info.ascent_elevation_gain().value() as u32,
             descent_elevation_gain: route_info.descent_elevation_gain().value() as u32,
             total_distance: route_info.total_distance().value(),
-            created_at: route_info.created_at().clone(),
-            updated_at: route_info.updated_at().clone(),
+            created_at: *route_info.created_at(),
+            updated_at: *route_info.updated_at(),
         })
     }
 }

--- a/api/infrastructure/src/dto/search_query.rs
+++ b/api/infrastructure/src/dto/search_query.rs
@@ -100,10 +100,10 @@ impl From<RouteSearchQuery> for SearchQuery {
             ..Default::default()
         };
 
-        let mut visibility_conditions = if route_search_query.is_editable {
-            Vec::new()
-        } else {
-            vec![WhereCondition::Eq("is_public", "true".into())]
+        let mut visibility_conditions = Vec::new();
+
+        if !route_search_query.is_editable {
+            visibility_conditions.push(WhereCondition::Eq("is_public", "true".into()))
         };
 
         if let Some(ids) = route_search_query.ids {

--- a/api/infrastructure/src/dto/search_query.rs
+++ b/api/infrastructure/src/dto/search_query.rs
@@ -100,7 +100,11 @@ impl From<RouteSearchQuery> for SearchQuery {
             ..Default::default()
         };
 
-        let mut visibility_conditions = vec![WhereCondition::Eq("is_public", "true".into())];
+        let mut visibility_conditions = if route_search_query.is_editable {
+            Vec::new()
+        } else {
+            vec![WhereCondition::Eq("is_public", "true".into())]
+        };
 
         if let Some(ids) = route_search_query.ids {
             visibility_conditions.push(WhereCondition::In(

--- a/api/infrastructure/src/dto/search_query.rs
+++ b/api/infrastructure/src/dto/search_query.rs
@@ -1,19 +1,39 @@
-use std::collections::HashMap;
-
 use itertools::Itertools;
 use route_bucket_domain::model::route::RouteSearchQuery;
 
 #[derive(Clone, Debug)]
 enum WhereCondition {
-    Eq(String),
+    Eq(&'static str, String),
+    In(&'static str, Vec<String>),
+    And(Vec<WhereCondition>),
+    Or(Vec<WhereCondition>),
 }
 
 impl WhereCondition {
-    fn to_query(&self, field_name: &'static str) -> String {
+    fn to_query(&self) -> String {
         match self {
-            Self::Eq(value) => {
-                format!("{} = \"{}\"", field_name, value)
+            Self::Eq(field_name, value) => {
+                format!("{} = {}", field_name, value)
             }
+            Self::In(field_name, values) => {
+                if values.is_empty() {
+                    format!("false")
+                } else {
+                    format!("{} IN ({})", field_name, values.join(","))
+                }
+            }
+            Self::And(values) | Self::Or(values) => match values.len() {
+                0 => String::new(),
+                1 => values[0].to_query(),
+                _ => {
+                    let sep = if matches!(self, Self::And(_)) {
+                        " AND "
+                    } else {
+                        " OR "
+                    };
+                    format!("({})", values.into_iter().map(Self::to_query).join(sep))
+                }
+            },
         }
     }
 }
@@ -37,7 +57,7 @@ impl OrderBy {
 #[derive(Clone, Debug, Default)]
 pub(crate) struct SearchQuery {
     table_name: &'static str,
-    where_conditions: HashMap<&'static str, WhereCondition>,
+    where_condition: Option<WhereCondition>,
     order_by: Option<OrderBy>,
     limit: Option<usize>,
     offset: Option<usize>,
@@ -51,14 +71,8 @@ impl SearchQuery {
             self.table_name
         );
 
-        if !self.where_conditions.is_empty() {
-            query += &format!(
-                "WHERE {} ",
-                self.where_conditions
-                    .iter()
-                    .map(|(field, cond)| cond.to_query(field))
-                    .join(", "),
-            );
+        if let Some(cond) = self.where_condition.clone() {
+            query += &format!("WHERE {} ", cond.to_query());
         }
 
         if !is_for_counting {
@@ -86,11 +100,26 @@ impl From<RouteSearchQuery> for SearchQuery {
             ..Default::default()
         };
 
-        if let Some(owner_id) = route_search_query.owner_id {
-            search_query
-                .where_conditions
-                .insert("owner_id", WhereCondition::Eq(owner_id.to_string()));
+        let mut visibility_conditions = vec![WhereCondition::Eq("is_public", "true".into())];
+
+        if let Some(ids) = route_search_query.ids {
+            visibility_conditions.push(WhereCondition::In(
+                "id",
+                ids.into_iter().map(|id| format!("'{}'", id)).collect(),
+            ));
         }
+
+        if let Some(caller_id) = route_search_query.caller_id {
+            visibility_conditions.push(WhereCondition::Eq("owner_id", format!("'{}'", caller_id)));
+        }
+
+        let mut conditions = vec![WhereCondition::Or(visibility_conditions)];
+
+        if let Some(owner_id) = route_search_query.owner_id {
+            conditions.push(WhereCondition::Eq("owner_id", format!("'{}'", owner_id)));
+        }
+
+        search_query.where_condition = Some(WhereCondition::And(conditions));
 
         // TODO: ここを指定できるようにする
         search_query.order_by = Some(OrderBy {

--- a/api/infrastructure/src/dto/search_query.rs
+++ b/api/infrastructure/src/dto/search_query.rs
@@ -17,7 +17,7 @@ impl WhereCondition {
             }
             Self::In(field_name, values) => {
                 if values.is_empty() {
-                    format!("false")
+                    "false".to_string()
                 } else {
                     format!("{} IN ({})", field_name, values.join(","))
                 }
@@ -31,7 +31,7 @@ impl WhereCondition {
                     } else {
                         " OR "
                     };
-                    format!("({})", values.into_iter().map(Self::to_query).join(sep))
+                    format!("({})", values.iter().map(Self::to_query).join(sep))
                 }
             },
         }

--- a/api/infrastructure/src/dto/search_query.rs
+++ b/api/infrastructure/src/dto/search_query.rs
@@ -61,16 +61,18 @@ impl SearchQuery {
             );
         }
 
-        if let Some(order_by) = &self.order_by {
-            query += &format!("ORDER BY {} ", order_by.to_query());
-        }
+        if !is_for_counting {
+            if let Some(order_by) = &self.order_by {
+                query += &format!("ORDER BY {} ", order_by.to_query());
+            }
 
-        if let Some(limit) = self.limit {
-            query += &format!("LIMIT {} ", limit);
-        }
+            if let Some(limit) = self.limit {
+                query += &format!("LIMIT {} ", limit);
+            }
 
-        if let Some(offset) = self.offset {
-            query += &format!("OFFSET {} ", offset);
+            if let Some(offset) = self.offset {
+                query += &format!("OFFSET {} ", offset);
+            }
         }
 
         query

--- a/api/infrastructure/src/lib.rs
+++ b/api/infrastructure/src/lib.rs
@@ -2,7 +2,10 @@ pub use external::firebase::FirebaseAuthApi;
 pub use external::osrm::OsrmApi;
 pub use external::reserved_uids_reader::ReservedUidsReader;
 pub use external::srtm::SrtmReader;
-pub use repository::{init_repositories, route::RouteRepositoryMySql, user::UserRepositoryMySql};
+pub use repository::{
+    init_repositories, permission::PermissionRepositoryMySql, route::RouteRepositoryMySql,
+    user::UserRepositoryMySql,
+};
 
 mod dto;
 mod external;

--- a/api/infrastructure/src/repository.rs
+++ b/api/infrastructure/src/repository.rs
@@ -38,7 +38,13 @@ pub async fn init_repositories() -> (
 }
 
 fn gen_err_mapper(msg: &'static str) -> impl FnOnce(sqlx::Error) -> ApplicationError {
-    move |err| ApplicationError::DataBaseError(format!("{} ({:?})", msg, err))
+    move |err| {
+        let err_str = format!("{} ({:?})", msg, err);
+        match err {
+            sqlx::Error::RowNotFound => ApplicationError::ResourceNotFound(err_str),
+            _ => ApplicationError::DataBaseError(err_str),
+        }
+    }
 }
 
 #[derive(Deref)]

--- a/api/infrastructure/src/repository.rs
+++ b/api/infrastructure/src/repository.rs
@@ -9,13 +9,19 @@ use sqlx::pool::PoolConnection;
 use sqlx::{MySql, TransactionManager};
 use tokio::sync::Mutex;
 
+use self::permission::PermissionRepositoryMySql;
 use self::route::RouteRepositoryMySql;
 use self::user::UserRepositoryMySql;
 
+pub mod permission;
 pub mod route;
 pub mod user;
 
-pub async fn init_repositories() -> (RouteRepositoryMySql, UserRepositoryMySql) {
+pub async fn init_repositories() -> (
+    RouteRepositoryMySql,
+    UserRepositoryMySql,
+    PermissionRepositoryMySql,
+) {
     let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL NOT FOUND");
     let pool = Arc::new(
         MySqlPoolOptions::new()
@@ -26,7 +32,8 @@ pub async fn init_repositories() -> (RouteRepositoryMySql, UserRepositoryMySql) 
     );
     (
         RouteRepositoryMySql(pool.clone()),
-        UserRepositoryMySql(pool),
+        UserRepositoryMySql(pool.clone()),
+        PermissionRepositoryMySql(pool),
     )
 }
 

--- a/api/infrastructure/src/repository/permission.rs
+++ b/api/infrastructure/src/repository/permission.rs
@@ -1,0 +1,127 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use route_bucket_domain::{
+    model::{
+        permission::{Permission, PermissionType},
+        route::{RouteId, RouteInfo},
+        user::UserId,
+    },
+    repository::{PermissionRepository, Repository},
+};
+use route_bucket_utils::{ApplicationError, ApplicationResult};
+use sqlx::MySqlPool;
+use tokio::sync::Mutex;
+
+use crate::dto::permission::PermissionDto;
+
+use super::{gen_err_mapper, RepositoryConnectionMySql};
+
+pub struct PermissionRepositoryMySql(pub(super) Arc<MySqlPool>);
+
+#[async_trait]
+impl Repository for PermissionRepositoryMySql {
+    type Connection = RepositoryConnectionMySql;
+
+    async fn get_connection(&self) -> ApplicationResult<Self::Connection> {
+        self.0
+            .acquire()
+            .await
+            .map(Mutex::new)
+            .map(RepositoryConnectionMySql)
+            .map_err(gen_err_mapper("failed to get connection"))
+    }
+}
+
+#[async_trait]
+impl PermissionRepository for PermissionRepositoryMySql {
+    async fn authorize_user(
+        &self,
+        route_info: &RouteInfo,
+        user_id: &UserId,
+        target_type: PermissionType,
+        conn: &<Self as Repository>::Connection,
+    ) -> ApplicationResult<()> {
+        if *user_id == *route_info.owner_id() {
+            return Ok(());
+        }
+
+        let mut conn = conn.lock().await;
+
+        let auth_err_closure = || {
+            ApplicationError::AuthorizationError(format!(
+                "User {} doesn't have {} permission on Route {}",
+                user_id,
+                target_type,
+                route_info.id()
+            ))
+        };
+
+        sqlx::query_as::<_, PermissionDto>(
+            r"
+            SELECT * FROM permissions WHERE route_id = ?, user_id = ?
+            ",
+        )
+        .bind(route_info.id().to_string())
+        .bind(user_id.to_string())
+        .fetch_one(&mut *conn)
+        .await
+        .map_err(|sqlx_err| match sqlx_err {
+            sqlx::Error::RowNotFound => auth_err_closure(),
+            other => gen_err_mapper("failed to find permission")(other),
+        })
+        .and_then(|dto| {
+            let permission = dto.into_model()?;
+            (target_type <= *permission.permission_type())
+                .then(|| ())
+                .ok_or_else(auth_err_closure)
+        })
+    }
+
+    async fn insert_or_update(
+        &self,
+        permission: &Permission,
+        conn: &<Self as Repository>::Connection,
+    ) -> ApplicationResult<()> {
+        let mut conn = conn.lock().await;
+        let dto = PermissionDto::from_model(permission)?;
+
+        sqlx::query(
+            r"
+            INSERT INTO permissions VALUES (?, ?, ?)
+            ON DUPLICATE KEY UPDATE `permission_type` = ?
+            ",
+        )
+        .bind(dto.route_id())
+        .bind(dto.user_id())
+        .bind(dto.permission_type())
+        .bind(dto.permission_type())
+        .execute(&mut *conn)
+        .await
+        .map_err(gen_err_mapper("failed to insert or update Permission"))?;
+
+        Ok(())
+    }
+
+    async fn delete(
+        &self,
+        route_id: &RouteId,
+        user_id: &UserId,
+        conn: &<Self as Repository>::Connection,
+    ) -> ApplicationResult<()> {
+        let mut conn = conn.lock().await;
+
+        sqlx::query(
+            r"
+            DELETE FROM permissions WHERE route_id = ?, user_id = ?
+            ",
+        )
+        .bind(route_id.to_string())
+        .bind(user_id.to_string())
+        .execute(&mut *conn)
+        .await
+        .map_err(gen_err_mapper("failed to delete Permission"))?;
+
+        Ok(())
+    }
+}

--- a/api/infrastructure/src/repository/permission.rs
+++ b/api/infrastructure/src/repository/permission.rs
@@ -49,7 +49,7 @@ impl PermissionRepository for PermissionRepositoryMySql {
 
         let sqlx_result = sqlx::query_as::<_, PermissionDto>(
             r"
-            SELECT * FROM permissions WHERE route_id = ?, user_id = ?
+            SELECT * FROM permissions WHERE `route_id` = ? AND `user_id` = ?
             ",
         )
         .bind(route_info.id().to_string())
@@ -102,7 +102,7 @@ impl PermissionRepository for PermissionRepositoryMySql {
 
         sqlx::query(
             r"
-            DELETE FROM permissions WHERE route_id = ?, user_id = ?
+            DELETE FROM permissions WHERE `route_id` = ? AND `user_id` = ?
             ",
         )
         .bind(route_id.to_string())

--- a/api/infrastructure/src/repository/permission.rs
+++ b/api/infrastructure/src/repository/permission.rs
@@ -62,7 +62,13 @@ impl PermissionRepository for PermissionRepositoryMySql {
                 let permission = dto.into_model()?;
                 Ok(*permission.permission_type())
             }
-            Err(sqlx::Error::RowNotFound) => Ok(PermissionType::None),
+            Err(sqlx::Error::RowNotFound) => {
+                if *route_info.is_public() {
+                    Ok(PermissionType::Viewer)
+                } else {
+                    Ok(PermissionType::None)
+                }
+            }
             Err(other_sqlx_err) => Err(gen_err_mapper("failed to find permission")(other_sqlx_err)),
         }
     }

--- a/api/infrastructure/src/repository/route.rs
+++ b/api/infrastructure/src/repository/route.rs
@@ -327,9 +327,9 @@ impl RouteRepository for RouteRepositoryMySql {
             r"
             INSERT INTO routes (
                 `id`, `name`, `owner_id`, `operation_pos`, `ascent_elevation_gain`, 
-                `descent_elevation_gain`, `total_distance`       
+                `descent_elevation_gain`, `total_distance`, `is_public`
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             ",
         )
         .bind(dto.id())
@@ -339,6 +339,7 @@ impl RouteRepository for RouteRepositoryMySql {
         .bind(dto.ascent_elevation_gain())
         .bind(dto.descent_elevation_gain())
         .bind(dto.total_distance())
+        .bind(dto.is_public())
         .execute(&mut *conn)
         .await
         .map_err(gen_err_mapper("failed to insert RouteInfo"))?;

--- a/api/infrastructure/src/repository/route.rs
+++ b/api/infrastructure/src/repository/route.rs
@@ -325,14 +325,20 @@ impl RouteRepository for RouteRepositoryMySql {
 
         sqlx::query(
             r"
-            INSERT INTO routes (`id`, `name`, `owner_id`, `operation_pos`)
-            VALUES (?, ?, ?, ?)
+            INSERT INTO routes (
+                `id`, `name`, `owner_id`, `operation_pos`, `ascent_elevation_gain`, 
+                `descent_elevation_gain`, `total_distance`       
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
             ",
         )
         .bind(dto.id())
         .bind(dto.name())
         .bind(dto.owner_id())
         .bind(dto.operation_pos())
+        .bind(dto.ascent_elevation_gain())
+        .bind(dto.descent_elevation_gain())
+        .bind(dto.total_distance())
         .execute(&mut *conn)
         .await
         .map_err(gen_err_mapper("failed to insert RouteInfo"))?;
@@ -350,13 +356,18 @@ impl RouteRepository for RouteRepositoryMySql {
         sqlx::query(
             r"
             UPDATE routes
-            SET name = ?, owner_id = ?, operation_pos = ?
+            SET 
+                name = ?, owner_id = ?, operation_pos = ?, ascent_elevation_gain = ?,
+                descent_elevation_gain = ?, total_distance = ?
             WHERE id = ?
             ",
         )
         .bind(dto.name())
         .bind(dto.owner_id())
         .bind(dto.operation_pos())
+        .bind(dto.ascent_elevation_gain())
+        .bind(dto.descent_elevation_gain())
+        .bind(dto.total_distance())
         .bind(dto.id())
         .execute(&mut *conn)
         .await

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -1,15 +1,18 @@
 use route_bucket_domain::external::{
     CallElevationApi, CallReservedUserIdCheckerApi, CallRouteInterpolationApi, CallUserAuthApi,
 };
-use route_bucket_domain::repository::{CallRouteRepository, CallUserRepository};
+use route_bucket_domain::repository::{
+    CallPermissionRepository, CallRouteRepository, CallUserRepository,
+};
 use route_bucket_infrastructure::{
-    init_repositories, FirebaseAuthApi, OsrmApi, ReservedUidsReader, RouteRepositoryMySql,
-    SrtmReader, UserRepositoryMySql,
+    init_repositories, FirebaseAuthApi, OsrmApi, PermissionRepositoryMySql, ReservedUidsReader,
+    RouteRepositoryMySql, SrtmReader, UserRepositoryMySql,
 };
 
 pub struct Server {
     route_repository: RouteRepositoryMySql,
     user_repository: UserRepositoryMySql,
+    permission_repository: PermissionRepositoryMySql,
     srtm_reader: SrtmReader,
     osrm_api: OsrmApi,
     firebase_auth_api: FirebaseAuthApi,
@@ -18,10 +21,11 @@ pub struct Server {
 
 impl Server {
     pub async fn new() -> Self {
-        let (route_repository, user_repository) = init_repositories().await;
+        let (route_repository, user_repository, permission_repository) = init_repositories().await;
         Self {
             route_repository,
             user_repository,
+            permission_repository,
             srtm_reader: SrtmReader::new().unwrap(),
             osrm_api: OsrmApi::new(),
             firebase_auth_api: FirebaseAuthApi::new().await.unwrap(),
@@ -44,6 +48,14 @@ impl CallUserRepository for Server {
 
     fn user_repository(&self) -> &Self::UserRepository {
         &self.user_repository
+    }
+}
+
+impl CallPermissionRepository for Server {
+    type PermissionRepository = PermissionRepositoryMySql;
+
+    fn permission_repository(&self) -> &Self::PermissionRepository {
+        &self.permission_repository
     }
 }
 

--- a/api/usecase/src/lib.rs
+++ b/api/usecase/src/lib.rs
@@ -67,5 +67,24 @@ mod test_macros {
                 true
             })
         };
+        ($repo_exp:expr, $method_name:ident, $in_exp0:expr, $in_exp1:expr, $out_exp:expr) => {
+            expect_at_repository!($repo_exp, $method_name, $out_exp).withf(
+                move |input0, input1, _| {
+                    assert_eq!(*input0, $in_exp0);
+                    assert_eq!(*input1, $in_exp1);
+                    true
+                },
+            )
+        };
+        ($repo_exp:expr, $method_name:ident, $in_exp0:expr, $in_exp1:expr, $in_exp2:expr, $out_exp:expr) => {
+            expect_at_repository!($repo_exp, $method_name, $out_exp).withf(
+                move |input0, input1, input2, _| {
+                    assert_eq!(*input0, $in_exp0);
+                    assert_eq!(*input1, $in_exp1);
+                    assert_eq!(*input2, $in_exp2);
+                    true
+                },
+            )
+        };
     }
 }

--- a/api/usecase/src/lib.rs
+++ b/api/usecase/src/lib.rs
@@ -58,11 +58,11 @@ mod test_macros {
 
     #[macro_export]
     macro_rules! expect_at_repository {
-        ($usecase:expr, $method_name:ident, $out_exp:expr) => {
-            crate::expect_once!($usecase.repository, $method_name).return_const(Ok($out_exp))
+        ($repo_exp:expr, $method_name:ident, $out_exp:expr) => {
+            crate::expect_once!($repo_exp, $method_name).return_const(Ok($out_exp))
         };
-        ($usecase:expr, $method_name:ident, $in_exp:expr, $out_exp:expr) => {
-            expect_at_repository!($usecase, $method_name, $out_exp).withf(move |input, _| {
+        ($repo_exp:expr, $method_name:ident, $in_exp:expr, $out_exp:expr) => {
+            expect_at_repository!($repo_exp, $method_name, $out_exp).withf(move |input, _| {
                 assert_eq!(*input, $in_exp);
                 true
             })

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -447,10 +447,11 @@ mod tests {
                 },
                 user::UserIdFixtures,
             },
+            permission::Permission,
             route::{Coordinate, DrawingMode, RouteGpx, Segment},
             user::UserId,
         },
-        repository::{MockConnection, MockRouteRepository},
+        repository::{MockConnection, MockPermissionRepository, MockRouteRepository},
     };
     use rstest::rstest;
 
@@ -596,8 +597,13 @@ mod tests {
         };
 
         let mut usecase = TestRouteUseCase::new();
-        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_info_at_route_repository(route_id(), RouteInfo::empty_route0(0));
+        usecase.expect_authenticate_at_auth_api(doncic_token(), UserId::doncic());
+        usecase.expect_authorize_user_at_permission_repository(
+            RouteInfo::empty_route0(0),
+            UserId::doncic(),
+            PermissionType::Editor,
+        );
         usecase.expect_update_info_at_route_repository(RouteInfo::empty_route1(0));
 
         assert_eq!(
@@ -615,10 +621,15 @@ mod tests {
         };
 
         let mut usecase = TestRouteUseCase::new();
-        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_at_route_repository(
             route_id(),
             Route::yokohama_to_chiba_filled(false, false),
+        );
+        usecase.expect_authenticate_at_auth_api(doncic_token(), UserId::doncic());
+        usecase.expect_authorize_user_at_permission_repository(
+            RouteInfo::empty_route0(2),
+            UserId::doncic(),
+            PermissionType::Editor,
         );
         usecase.expect_correct_coordinate_at_interpolation_api(
             tokyo_before_correction(),
@@ -653,10 +664,15 @@ mod tests {
         };
 
         let mut usecase = TestRouteUseCase::new();
-        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_at_route_repository(
             route_id(),
             Route::yokohama_to_chiba_via_tokyo_filled(false, false),
+        );
+        usecase.expect_authenticate_at_auth_api(doncic_token(), UserId::doncic());
+        usecase.expect_authorize_user_at_permission_repository(
+            RouteInfo::empty_route0(3),
+            UserId::doncic(),
+            PermissionType::Editor,
         );
         usecase.expect_interpolate_empty_segments_at_interpolation_api(
             yokohama_to_chiba_before_interpolation(false),
@@ -685,10 +701,15 @@ mod tests {
         };
 
         let mut usecase = TestRouteUseCase::new();
-        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_at_route_repository(
             route_id(),
             Route::yokohama_to_chiba_filled(false, false),
+        );
+        usecase.expect_authenticate_at_auth_api(doncic_token(), UserId::doncic());
+        usecase.expect_authorize_user_at_permission_repository(
+            RouteInfo::empty_route0(2),
+            UserId::doncic(),
+            PermissionType::Editor,
         );
         usecase.expect_correct_coordinate_at_interpolation_api(
             tokyo_before_correction(),
@@ -717,8 +738,13 @@ mod tests {
     #[tokio::test]
     async fn can_clear_route() {
         let mut usecase = TestRouteUseCase::new();
-        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_info_at_route_repository(route_id(), RouteInfo::empty_route0(3));
+        usecase.expect_authenticate_at_auth_api(doncic_token(), UserId::doncic());
+        usecase.expect_authorize_user_at_permission_repository(
+            RouteInfo::empty_route0(3),
+            UserId::doncic(),
+            PermissionType::Editor,
+        );
         usecase.expect_update_at_route_repository(Route::empty());
 
         assert_eq!(
@@ -731,10 +757,15 @@ mod tests {
     #[tokio::test]
     async fn can_redo_operation() {
         let mut usecase = TestRouteUseCase::new();
-        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_at_route_repository(
             route_id(),
             Route::yokohama_to_chiba_filled(false, false),
+        );
+        usecase.expect_authenticate_at_auth_api(doncic_token(), UserId::doncic());
+        usecase.expect_authorize_user_at_permission_repository(
+            RouteInfo::empty_route0(2),
+            UserId::doncic(),
+            PermissionType::Editor,
         );
         usecase.expect_interpolate_empty_segments_at_interpolation_api(
             yokohama_to_chiba_via_tokyo_before_interpolation(),
@@ -758,10 +789,15 @@ mod tests {
     #[tokio::test]
     async fn can_undo_operation() {
         let mut usecase = TestRouteUseCase::new();
-        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
         usecase.expect_find_at_route_repository(
             route_id(),
             Route::yokohama_to_chiba_via_tokyo_filled(false, false),
+        );
+        usecase.expect_authenticate_at_auth_api(doncic_token(), UserId::doncic());
+        usecase.expect_authorize_user_at_permission_repository(
+            RouteInfo::empty_route0(3),
+            UserId::doncic(),
+            PermissionType::Editor,
         );
         usecase.expect_interpolate_empty_segments_at_interpolation_api(
             yokohama_to_chiba_before_interpolation(true),
@@ -784,13 +820,19 @@ mod tests {
     async fn can_delete() {
         let mut usecase = TestRouteUseCase::new();
         usecase.expect_find_info_at_route_repository(route_id(), RouteInfo::empty_route0(0));
-        usecase.expect_authorize_at_auth_api(UserId::doncic(), doncic_token());
+        usecase.expect_authenticate_at_auth_api(doncic_token(), UserId::doncic());
+        usecase.expect_authorize_user_at_permission_repository(
+            RouteInfo::empty_route0(0),
+            UserId::doncic(),
+            PermissionType::Editor,
+        );
         usecase.expect_delete_at_route_repository(route_id());
         assert_eq!(usecase.delete(&route_id(), &doncic_token()).await, Ok(()));
     }
 
     struct TestRouteUseCase {
-        repository: MockRouteRepository,
+        route_repository: MockRouteRepository,
+        permission_repository: MockPermissionRepository,
         interpolation_api: MockRouteInterpolationApi,
         elevation_api: MockElevationApi,
         auth_api: MockUserAuthApi,
@@ -800,7 +842,8 @@ mod tests {
     impl TestRouteUseCase {
         fn new() -> Self {
             let mut usecase = TestRouteUseCase {
-                repository: MockRouteRepository::new(),
+                route_repository: MockRouteRepository::new(),
+                permission_repository: MockPermissionRepository::new(),
                 interpolation_api: MockRouteInterpolationApi::new(),
                 elevation_api: MockElevationApi::new(),
                 auth_api: MockUserAuthApi::new(),
@@ -854,6 +897,79 @@ mod tests {
             expect_at_repository!(self.route_repository, delete, param_id, ());
         }
 
+        #[allow(dead_code)]
+        fn expect_get_connection_at_permission_repository(&mut self) {
+            expect_at_repository!(
+                self.permission_repository,
+                get_connection,
+                MockConnection {}
+            );
+        }
+
+        #[allow(dead_code)]
+        fn expect_find_type_at_permission_repository(
+            &mut self,
+            param_info: RouteInfo,
+            param_user_id: UserId,
+            return_permission_type: PermissionType,
+        ) {
+            self.expect_get_connection_at_permission_repository();
+            expect_at_repository!(
+                self.permission_repository,
+                find_type,
+                param_info,
+                param_user_id,
+                return_permission_type
+            );
+        }
+
+        fn expect_authorize_user_at_permission_repository(
+            &mut self,
+            param_info: RouteInfo,
+            param_user_id: UserId,
+            param_permission_type: PermissionType,
+        ) {
+            self.expect_get_connection_at_permission_repository();
+            expect_at_repository!(
+                self.permission_repository,
+                authorize_user,
+                param_info,
+                param_user_id,
+                param_permission_type,
+                ()
+            );
+        }
+
+        #[allow(dead_code)]
+        fn expect_insert_or_update_at_permission_repository(
+            &mut self,
+            param_permission: Permission,
+        ) {
+            self.expect_get_connection_at_permission_repository();
+            expect_at_repository!(
+                self.permission_repository,
+                insert_or_update,
+                param_permission,
+                ()
+            );
+        }
+
+        #[allow(dead_code)]
+        fn expect_delete_at_permission_repository(
+            &mut self,
+            param_route_id: RouteId,
+            param_user_id: UserId,
+        ) {
+            self.expect_get_connection_at_permission_repository();
+            expect_at_repository!(
+                self.permission_repository,
+                delete,
+                param_route_id,
+                param_user_id,
+                ()
+            );
+        }
+
         fn expect_correct_coordinate_at_interpolation_api(
             &mut self,
             param_coord: Coordinate,
@@ -896,10 +1012,6 @@ mod tests {
         fn expect_authenticate_at_auth_api(&mut self, param_token: String, return_id: UserId) {
             expect_once!(self.auth_api, authenticate, param_token, return_id);
         }
-
-        fn expect_authorize_at_auth_api(&mut self, param_id: UserId, param_token: String) {
-            expect_once!(self.auth_api, authorize, param_id, param_token, ());
-        }
     }
 
     // impls to enable trait RouteUseCase
@@ -907,7 +1019,15 @@ mod tests {
         type RouteRepository = MockRouteRepository;
 
         fn route_repository(&self) -> &Self::RouteRepository {
-            &self.repository
+            &self.route_repository
+        }
+    }
+
+    impl CallPermissionRepository for TestRouteUseCase {
+        type PermissionRepository = MockPermissionRepository;
+
+        fn permission_repository(&self) -> &Self::PermissionRepository {
+            &self.permission_repository
         }
     }
 

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -168,7 +168,7 @@ where
         conn.transaction(|conn| {
             async move {
                 let owner_id = self.user_auth_api().authenticate(user_access_token).await?;
-                let route_info = RouteInfo::new(&req.name, owner_id);
+                let route_info = RouteInfo::new(&req.name, owner_id, req.is_public);
 
                 self.route_repository()
                     .insert_info(&route_info, conn)

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -638,6 +638,7 @@ mod tests {
     async fn can_create() {
         let req = RouteCreateRequest {
             name: "route0".into(),
+            is_public: false,
         };
 
         let mut usecase = TestRouteUseCase::new();

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -95,7 +95,7 @@ where
         let conn = self.route_repository().get_connection().await?;
 
         let mut route = self.route_repository().find(route_id, &conn).await?;
-        route.attach_distance_from_start()?;
+        route.attach_distance_from_start();
         self.elevation_api().attach_elevations(&mut route)?;
 
         route.try_into()
@@ -132,7 +132,7 @@ where
         let conn = self.route_repository().get_connection().await?;
 
         let mut route = self.route_repository().find(route_id, &conn).await?;
-        route.attach_distance_from_start()?;
+        route.attach_distance_from_start();
         self.elevation_api().attach_elevations(&mut route)?;
 
         route.try_into()
@@ -217,7 +217,7 @@ where
                     .interpolate_empty_segments(&mut route)
                     .await?;
                 self.elevation_api().attach_elevations(&mut route)?;
-                route.attach_distance_from_start()?;
+                route.attach_distance_from_start();
 
                 self.route_repository().update(&route, conn).await?;
 
@@ -250,7 +250,7 @@ where
                     .interpolate_empty_segments(&mut route)
                     .await?;
                 self.elevation_api().attach_elevations(&mut route)?;
-                route.attach_distance_from_start()?;
+                route.attach_distance_from_start();
 
                 self.route_repository().update(&route, conn).await?;
 
@@ -290,7 +290,7 @@ where
                     .interpolate_empty_segments(&mut route)
                     .await?;
                 self.elevation_api().attach_elevations(&mut route)?;
-                route.attach_distance_from_start()?;
+                route.attach_distance_from_start();
 
                 self.route_repository().update(&route, conn).await?;
 
@@ -345,7 +345,7 @@ where
                     .interpolate_empty_segments(&mut route)
                     .await?;
                 self.elevation_api().attach_elevations(&mut route)?;
-                route.attach_distance_from_start()?;
+                route.attach_distance_from_start();
 
                 self.route_repository().update(&route, conn).await?;
 
@@ -375,7 +375,7 @@ where
                     .interpolate_empty_segments(&mut route)
                     .await?;
                 self.elevation_api().attach_elevations(&mut route)?;
-                route.attach_distance_from_start()?;
+                route.attach_distance_from_start();
 
                 self.route_repository().update(&route, conn).await?;
 

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -147,7 +147,7 @@ where
         conn.transaction(|conn| {
             async move {
                 let owner_id = self.user_auth_api().authenticate(user_access_token).await?;
-                let route_info = RouteInfo::new(RouteId::new(), &req.name, owner_id, 0);
+                let route_info = RouteInfo::new(&req.name, owner_id);
 
                 self.route_repository()
                     .insert_info(&route_info, conn)

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -459,7 +459,7 @@ where
 
         let perm_conn = self.permission_repository().get_connection().await?;
         self.permission_repository()
-            .authorize_user(&route_info, &user_id, PermissionType::Editor, &perm_conn)
+            .authorize_user(&route_info, &user_id, PermissionType::Owner, &perm_conn)
             .await?;
         self.permission_repository()
             .insert_or_update(
@@ -485,7 +485,7 @@ where
 
         let perm_conn = self.permission_repository().get_connection().await?;
         self.permission_repository()
-            .authorize_user(&route_info, &user_id, PermissionType::Editor, &perm_conn)
+            .authorize_user(&route_info, &user_id, PermissionType::Owner, &perm_conn)
             .await?;
         self.permission_repository()
             .delete(route_info.id(), &req.user_id, &perm_conn)
@@ -904,7 +904,7 @@ mod tests {
         usecase.expect_authorize_user_at_permission_repository(
             RouteInfo::empty_route0(0),
             UserId::doncic(),
-            PermissionType::Editor,
+            PermissionType::Owner,
         );
         usecase.expect_insert_or_update_at_permission_repository(
             Permission::porzingis_viewer_permission(),
@@ -932,7 +932,7 @@ mod tests {
         usecase.expect_authorize_user_at_permission_repository(
             info.clone(),
             UserId::doncic(),
-            PermissionType::Editor,
+            PermissionType::Owner,
         );
         usecase.expect_delete_at_permission_repository(id.clone(), UserId::porzingis());
         assert_eq!(

--- a/api/usecase/src/route.rs
+++ b/api/usecase/src/route.rs
@@ -805,13 +805,13 @@ mod tests {
                 elevation_api: MockElevationApi::new(),
                 auth_api: MockUserAuthApi::new(),
             };
-            expect_at_repository!(usecase, get_connection, MockConnection {});
+            expect_at_repository!(usecase.route_repository, get_connection, MockConnection {});
 
             usecase
         }
 
         fn expect_find_at_route_repository(&mut self, param_id: RouteId, return_route: Route) {
-            expect_at_repository!(self, find, param_id, return_route);
+            expect_at_repository!(self.route_repository, find, param_id, return_route);
         }
 
         fn expect_find_info_at_route_repository(
@@ -819,7 +819,7 @@ mod tests {
             param_id: RouteId,
             return_info: RouteInfo,
         ) {
-            expect_at_repository!(self, find_info, param_id, return_info);
+            expect_at_repository!(self.route_repository, find_info, param_id, return_info);
         }
 
         fn expect_search_infos_at_route_repository(
@@ -827,7 +827,7 @@ mod tests {
             query: RouteSearchQuery,
             return_infos: Vec<RouteInfo>,
         ) {
-            expect_at_repository!(self, search_infos, query, return_infos);
+            expect_at_repository!(self.route_repository, search_infos, query, return_infos);
         }
 
         fn expect_count_infos_at_route_repository(
@@ -835,23 +835,23 @@ mod tests {
             query: RouteSearchQuery,
             return_count: usize,
         ) {
-            expect_at_repository!(self, count_infos, query, return_count);
+            expect_at_repository!(self.route_repository, count_infos, query, return_count);
         }
 
         fn expect_insert_info_at_route_repository(&mut self, param_info: RouteInfo) {
-            expect_at_repository!(self, insert_info, param_info, ());
+            expect_at_repository!(self.route_repository, insert_info, param_info, ());
         }
 
         fn expect_update_at_route_repository(&mut self, param_route: Route) {
-            expect_at_repository!(self, update, param_route, ());
+            expect_at_repository!(self.route_repository, update, param_route, ());
         }
 
         fn expect_update_info_at_route_repository(&mut self, param_info: RouteInfo) {
-            expect_at_repository!(self, update_info, param_info, ());
+            expect_at_repository!(self.route_repository, update_info, param_info, ());
         }
 
         fn expect_delete_at_route_repository(&mut self, param_id: RouteId) {
-            expect_at_repository!(self, delete, param_id, ());
+            expect_at_repository!(self.route_repository, delete, param_id, ());
         }
 
         fn expect_correct_coordinate_at_interpolation_api(

--- a/api/usecase/src/route/requests.rs
+++ b/api/usecase/src/route/requests.rs
@@ -1,10 +1,10 @@
-use derive_more::From;
+use derive_more::{From, Into};
 use serde::Deserialize;
 use validator::{Validate, ValidationError};
 
 use route_bucket_domain::model::{
     permission::PermissionType,
-    route::{Coordinate, DrawingMode},
+    route::{Coordinate, DrawingMode, RouteId},
     user::UserId,
 };
 
@@ -13,6 +13,13 @@ pub struct RouteCreateRequest {
     #[validate(length(min = 1, max = 50))]
     pub(super) name: String,
     pub(super) is_public: bool,
+}
+
+#[derive(From, Into, Deserialize, Validate)]
+pub struct RoutePositionParams {
+    #[validate]
+    pub(super) id: RouteId,
+    pub(super) pos: usize,
 }
 
 #[derive(From, Deserialize, Validate)]

--- a/api/usecase/src/route/requests.rs
+++ b/api/usecase/src/route/requests.rs
@@ -1,5 +1,6 @@
 use derive_more::From;
 use serde::Deserialize;
+use validator::{Validate, ValidationError};
 
 use route_bucket_domain::model::{
     permission::PermissionType,
@@ -7,36 +8,53 @@ use route_bucket_domain::model::{
     user::UserId,
 };
 
-#[derive(From, Deserialize)]
+#[derive(From, Deserialize, Validate)]
 pub struct RouteCreateRequest {
+    #[validate(length(min = 1, max = 50))]
     pub(super) name: String,
     pub(super) is_public: bool,
 }
 
-#[derive(From, Deserialize)]
+#[derive(From, Deserialize, Validate)]
 pub struct NewPointRequest {
     pub(super) mode: DrawingMode,
+    // TODO: Validate coordinate range.
     pub(super) coord: Coordinate,
 }
 
-#[derive(From, Deserialize)]
+#[derive(From, Deserialize, Validate)]
 pub struct RemovePointRequest {
     pub(super) mode: DrawingMode,
 }
 
-#[derive(From, Deserialize)]
+#[derive(From, Deserialize, Validate)]
 pub struct RouteRenameRequest {
+    #[validate(length(min = 1, max = 50))]
     pub(super) name: String,
 }
 
-#[derive(From, Deserialize)]
+#[derive(From, Deserialize, Validate)]
 pub struct UpdatePermissionRequest {
+    #[validate]
     pub(super) user_id: UserId,
     #[serde(alias = "type")]
+    #[validate(custom = "Self::validate_permission_type")]
     pub(super) permission_type: PermissionType,
 }
 
-#[derive(From, Deserialize)]
+impl UpdatePermissionRequest {
+    // NOTE: validatorのrangeはnumber以外にはなぜか対応していない
+    // 参考： https://github.com/Keats/validator/issues/204
+    fn validate_permission_type(permission_type: &PermissionType) -> Result<(), ValidationError> {
+        match *permission_type {
+            PermissionType::Viewer | PermissionType::Editor => Ok(()),
+            _ => Err(ValidationError::new("Only VIEWER and EDITOR are allowed.")),
+        }
+    }
+}
+
+#[derive(From, Deserialize, Validate)]
 pub struct DeletePermissionRequest {
+    #[validate]
     pub(super) user_id: UserId,
 }

--- a/api/usecase/src/route/requests.rs
+++ b/api/usecase/src/route/requests.rs
@@ -1,7 +1,11 @@
 use derive_more::From;
 use serde::Deserialize;
 
-use route_bucket_domain::model::route::{Coordinate, DrawingMode};
+use route_bucket_domain::model::{
+    permission::PermissionType,
+    route::{Coordinate, DrawingMode},
+    user::UserId,
+};
 
 #[derive(From, Deserialize)]
 pub struct RouteCreateRequest {
@@ -22,4 +26,16 @@ pub struct RemovePointRequest {
 #[derive(From, Deserialize)]
 pub struct RouteRenameRequest {
     pub(super) name: String,
+}
+
+#[derive(From, Deserialize)]
+pub struct UpdatePermissionRequest {
+    pub(super) user_id: UserId,
+    #[serde(alias = "type")]
+    pub(super) permission_type: PermissionType,
+}
+
+#[derive(From, Deserialize)]
+pub struct DeletePermissionRequest {
+    pub(super) user_id: UserId,
 }

--- a/api/usecase/src/route/requests.rs
+++ b/api/usecase/src/route/requests.rs
@@ -10,6 +10,7 @@ use route_bucket_domain::model::{
 #[derive(From, Deserialize)]
 pub struct RouteCreateRequest {
     pub(super) name: String,
+    pub(super) is_public: bool,
 }
 
 #[derive(From, Deserialize)]

--- a/api/usecase/src/route/responses.rs
+++ b/api/usecase/src/route/responses.rs
@@ -46,8 +46,7 @@ pub struct RouteOperationResponse {
 impl TryFrom<Route> for RouteGetResponse {
     type Error = ApplicationError;
 
-    fn try_from(mut route: Route) -> Result<Self, Self::Error> {
-        route.reflect_update_on_seg_list_to_info()?;
+    fn try_from(route: Route) -> Result<Self, Self::Error> {
         let (info, _, seg_list) = route.into();
         Ok(RouteGetResponse {
             route_info: info,
@@ -63,8 +62,7 @@ impl TryFrom<Route> for RouteGetResponse {
 impl TryFrom<Route> for RouteOperationResponse {
     type Error = ApplicationError;
 
-    fn try_from(mut route: Route) -> Result<Self, Self::Error> {
-        route.reflect_update_on_seg_list_to_info()?;
+    fn try_from(route: Route) -> Result<Self, Self::Error> {
         let (info, _, seg_list) = route.into();
         Ok(RouteOperationResponse {
             waypoints: seg_list.gather_waypoints(),
@@ -89,11 +87,8 @@ mod tests {
 
     fn empty_route_get_resp() -> RouteGetResponse {
         RouteGetResponse {
-            route_info: RouteInfo::route0(0),
+            route_info: RouteInfo::empty_route0(0),
             waypoints: Vec::new(),
-            ascent_elevation_gain: Elevation::zero(),
-            descent_elevation_gain: Elevation::zero(),
-            total_distance: Distance::zero(),
             segments: Vec::new(),
             bounding_box: None,
         }
@@ -102,11 +97,8 @@ mod tests {
     fn full_route_get_resp() -> RouteGetResponse {
         let dist = 26936.42633640023;
         RouteGetResponse {
-            route_info: RouteInfo::route0(3),
+            route_info: RouteInfo::filled_route0(10, 0, 58759.973932514884, 3),
             waypoints: Coordinate::yokohama_to_chiba_via_tokyo_coords(false, None),
-            ascent_elevation_gain: 10.try_into().unwrap(),
-            descent_elevation_gain: 0.try_into().unwrap(),
-            total_distance: 58759.973932514884.try_into().unwrap(),
             segments: vec![
                 Segment::yokohama_to_tokyo(true, Some(0.), false, DrawingMode::Freehand),
                 Segment::tokyo_to_chiba(true, Some(dist), false, DrawingMode::Freehand),

--- a/api/usecase/src/user.rs
+++ b/api/usecase/src/user.rs
@@ -317,25 +317,25 @@ mod tests {
                 auth_api: MockUserAuthApi::new(),
                 uid_check_api: MockReservedUserIdCheckerApi::new(),
             };
-            expect_at_repository!(usecase, get_connection, MockConnection {});
+            expect_at_repository!(usecase.repository, get_connection, MockConnection {});
 
             usecase
         }
 
         fn expect_find_at_user_repository(&mut self, param_id: UserId, return_user: User) {
-            expect_at_repository!(self, find, param_id, return_user);
+            expect_at_repository!(self.repository, find, param_id, return_user);
         }
 
         fn expect_insert_at_user_repository(&mut self, param_user: User) {
-            expect_at_repository!(self, insert, param_user, ());
+            expect_at_repository!(self.repository, insert, param_user, ());
         }
 
         fn expect_update_at_user_repository(&mut self, param_user: User) {
-            expect_at_repository!(self, update, param_user, ());
+            expect_at_repository!(self.repository, update, param_user, ());
         }
 
         fn expect_delete_at_user_repository(&mut self, param_id: UserId) {
-            expect_at_repository!(self, delete, param_id, ());
+            expect_at_repository!(self.repository, delete, param_id, ());
         }
 
         fn expect_create_account_at_auth_api(

--- a/api/usecase/src/user.rs
+++ b/api/usecase/src/user.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use async_trait::async_trait;
 use futures::FutureExt;
 use route_bucket_domain::{
@@ -48,7 +46,7 @@ where
     }
 
     async fn create(&self, req: UserCreateRequest) -> ApplicationResult<UserCreateResponse> {
-        let (user, email, password) = req.try_into()?;
+        let (user, email, password) = req.into();
 
         let conn = self.user_repository().get_connection().await?;
         conn.transaction(|conn| {

--- a/api/usecase/src/user/requests.rs
+++ b/api/usecase/src/user/requests.rs
@@ -1,8 +1,5 @@
-use std::convert::TryFrom;
-
 use chrono::{NaiveDate, Utc};
 use derive_more::From;
-use route_bucket_utils::ApplicationError;
 use serde::Deserialize;
 use validator::Validate;
 
@@ -37,12 +34,9 @@ impl Validate for UserCreateRequest {
     }
 }
 
-impl TryFrom<UserCreateRequest> for (User, Email, String) {
-    type Error = ApplicationError;
-
-    fn try_from(value: UserCreateRequest) -> Result<Self, Self::Error> {
-        value.validate()?;
-        Ok((
+impl From<UserCreateRequest> for (User, Email, String) {
+    fn from(value: UserCreateRequest) -> Self {
+        (
             User::new(
                 value.id,
                 value.name,
@@ -52,7 +46,7 @@ impl TryFrom<UserCreateRequest> for (User, Email, String) {
             ),
             value.email,
             value.password,
-        ))
+        )
     }
 }
 

--- a/api/utils/src/error.rs
+++ b/api/utils/src/error.rs
@@ -28,11 +28,8 @@ pub enum ApplicationError {
     #[display(fmt = "InvalidOperation: {}", _0)]
     InvalidOperation(&'static str),
 
-    #[display(fmt = "ResourceNotFound: {} {} not found", resource_name, id)]
-    ResourceNotFound {
-        resource_name: &'static str,
-        id: String,
-    },
+    #[display(fmt = "ResourceNotFound: {}", _0)]
+    ResourceNotFound(String),
 
     #[display(fmt = "UseCaseError: {}", _0)]
     UseCaseError(String),

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -43,7 +43,7 @@ CREATE TABLE users
     `name`      VARCHAR(50)      NOT NULL,
     `gender`    VARCHAR(6)       NOT NULL,
     `birthdate` DATE                     ,
-    `icon_url`  VARCHAR(100)             ,
+    `icon_url`  TEXT                     ,
     PRIMARY KEY (`id`)
 );
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,9 +1,12 @@
 CREATE TABLE routes
 (
-    `id`            VARCHAR(11)      NOT NULL,
-    `name`          VARCHAR(50)      NOT NULL,
-    `owner_id`      VARCHAR(40)      NOT NULL,
-    `operation_pos` INTEGER UNSIGNED NOT NULL,
+    `id`                     VARCHAR(11)      NOT NULL,
+    `name`                   VARCHAR(50)      NOT NULL,
+    `owner_id`               VARCHAR(40)      NOT NULL,
+    `operation_pos`          INTEGER UNSIGNED NOT NULL,
+    `ascent_elevation_gain`  INTEGER UNSIGNED NOT NULL,
+    `descent_elevation_gain` INTEGER UNSIGNED NOT NULL,
+    `total_distance`         DOUBLE           NOT NULL,
     `created_at`    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     `updated_at`    TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     INDEX updated_idx (`updated_at`),

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -46,3 +46,11 @@ CREATE TABLE users
     `icon_url`  VARCHAR(100)             ,
     PRIMARY KEY (`id`)
 );
+
+CREATE TABLE permissions
+(
+    `route_id`        VARCHAR(11) NOT NULL,
+    `user_id`         VARCHAR(40) NOT NULL,
+    `permission_type` VARCHAR(6)  NOT NULL,
+    PRIMARY KEY (`user_id`, `route_id`)
+);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -7,6 +7,7 @@ CREATE TABLE routes
     `ascent_elevation_gain`  INTEGER UNSIGNED NOT NULL,
     `descent_elevation_gain` INTEGER UNSIGNED NOT NULL,
     `total_distance`         DOUBLE           NOT NULL,
+    `is_public`              TINYINT(1)       NOT NULL,
     `created_at`    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     `updated_at`    TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     INDEX updated_idx (`updated_at`),


### PR DESCRIPTION
Closes #15 , closes #126 

controllerで`actix_web_validator`の`Path`や`Json`などのラッパーを用いると、中身のstructに`Validate`トレイトをderiveしてあげるだけで、リクエスト時に勝手にバリデーションを行なってくれる

唯一、`Coordinate`については、根本的に緯度経度のstructをリファクタする必要がありそうだったので保留とした -> #140 